### PR TITLE
build: publish a homebrew cask to akash-network/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,11 +92,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Publishes the Homebrew cask to akash-network/homebrew-tap. That is
-          # a different repository, so GITHUB_TOKEN cannot write to it — this
-          # must be a PAT (or app token) with contents:write on the tap.
-          # Prereleases skip the cask entirely, so an alpha releases fine
-          # without it.
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # a different repository, so GITHUB_TOKEN cannot write to it. Same
+          # secret name akash-network/node already uses to reach the tap, so
+          # an org-level secret covers both; node only needs actions:write to
+          # dispatch a workflow there, while writing the cask needs
+          # contents:write. Prereleases skip the cask, so an alpha releases
+          # fine without it.
+          GORELEASER_ACCESS_TOKEN: ${{ secrets.GORELEASER_ACCESS_TOKEN }}
         run: make release
 
       - name: Manual run (${{ inputs.mode }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,12 @@ jobs:
         if: github.event_name == 'push'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Publishes the Homebrew cask to akash-network/homebrew-tap. That is
+          # a different repository, so GITHUB_TOKEN cannot write to it — this
+          # must be a PAT (or app token) with contents:write on the tap.
+          # Prereleases skip the cask entirely, so an alpha releases fine
+          # without it.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: make release
 
       - name: Manual run (${{ inputs.mode }})

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -171,12 +171,62 @@ nfpms:
     vendor: "Akash Network"
     homepage: "https://akash.network"
     maintainer: "Akash Network <hello@akash.network>"
-    description: "Unified CLI and TUI for the Akash Network."
+    description: "Unified CLI for the Akash Network."
     license: "Apache-2.0"
     file_name_template: "akt_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - deb
       - rpm
+
+# Homebrew, published straight into akash-network/homebrew-tap as part of the
+# release. node reaches the same tap by dispatching an event to it and
+# regenerating akash.rb from a template there; goreleaser writes the cask
+# itself, so there is no dispatch, no second workflow, and no template to keep
+# in step with the archives.
+#
+# A cask rather than a formula: `brews` is deprecated and goreleaser exits
+# non-zero on it, which would break `make release-check`. No platform is lost
+# by the switch -- `binary` is a portable stanza, so the generated cask carries
+# working on_macos and on_linux blocks and `brew install` covers both, same as
+# node's akash.rb formula does.
+homebrew_casks:
+  - name: akt
+    binaries:
+      - akt
+    ids:
+      - akt
+    # The tap is a different repository, so the release job's GITHUB_TOKEN --
+    # scoped to this one -- cannot write to it. Needs a token with
+    # contents:write on akash-network/homebrew-tap, exported as
+    # HOMEBREW_TAP_TOKEN.
+    repository:
+      owner: akash-network
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Casks
+    homepage: "https://akash.network"
+    description: "Unified CLI for the Akash Network"
+    license: "Apache-2.0"
+    # `brew install akt` must keep resolving to the newest stable build, so an
+    # alpha or rc never overwrites the cask. `auto` skips the upload when the
+    # version is a prerelease, which is the gate node applies with
+    # is_prerelease.sh before notifying the tap.
+    skip_upload: auto
+    hooks:
+      post:
+        # The darwin binaries are neither signed nor notarized, so Gatekeeper
+        # quarantines them on download and the first run dies with "cannot be
+        # opened because the developer cannot be verified". Strip the attribute
+        # at install time. Remove this once the release is signed and notarized.
+        #
+        # Guarded on OS.mac?: the hook is emitted outside the on_macos block and
+        # so runs on Linux too, where /usr/bin/xattr does not exist and the
+        # install would fail on a quarantine flag that platform never sets.
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/akt"]
+          end
 
 snapshot:
   version_template: "{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -198,12 +198,12 @@ homebrew_casks:
     # The tap is a different repository, so the release job's GITHUB_TOKEN --
     # scoped to this one -- cannot write to it. Needs a token with
     # contents:write on akash-network/homebrew-tap, exported as
-    # HOMEBREW_TAP_TOKEN.
+    # GORELEASER_ACCESS_TOKEN.
     repository:
       owner: akash-network
       name: homebrew-tap
       branch: main
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      token: "{{ .Env.GORELEASER_ACCESS_TOKEN }}"
     directory: Casks
     homepage: "https://akash.network"
     description: "Unified CLI for the Akash Network"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,7 @@
 | `akash-network/provider`         | Provider binary (`provider-services`). Imports chain-sdk CLI, adds provider gateway + operator commands. | **Keeps** only provider-operator commands: `run`, `operator *`, `tools *`, `migrate`. Stops exporting user-facing CLI.                                      |
 | `ovrclk/akt` (pre-rewrite)       | MVP CLI prototype. Config system, account/network/deploy commands.                                       | Design reference. Concepts (profiles, git-like config) evolved into the context system. Replaced in place by the rewrite below.                             |
 | `cloud-j-luna/aktop`             | Community TUI for monitoring Akash consensus state, validator voting, and provider operations.           | Design reference and prior art for TUI. Its consensus/validator/provider monitoring views inform the TUI design. Functionality subsumed by `akt monitor`. |
-| **`ovrclk/akt`**                 | **New.** This repository, and the rewrite that replaced the prototype above.                             | The unified user CLI and TUI. Releases publish here; a move to `akash-network/akt` is possible later, but that repository does not exist yet.                |
+| **`akash-network/akt`**          | **New.** This repository, and the rewrite that replaced the prototype above.                             | The unified user CLI. Transferred from `ovrclk/akt`, which now redirects here; releases and the Homebrew cask publish under this name.                       |
 
 ### 1.4 The `monitor` Command
 
@@ -405,7 +405,7 @@ An unrecognized mode falls back to `dim`, so a config typo never silently disabl
 ## 4. Package Structure
 
 ```
-pkg.akt.dev/akt/                         # module path (repo: github.com/ovrclk/akt)
+pkg.akt.dev/akt/                         # module path (repo: github.com/akash-network/akt)
 ├── cmd/
 │   └── akt/                             # Binary entry point
 ├── internal/

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -32,7 +32,7 @@ GORELEASER_WORKDIR       := /go/src/$(GORELEASER_MOD_MOUNT)
 # Container image path akt would publish to. Nothing consumes this yet --
 # .goreleaser.yaml has no `dockers:` section because akt is a client binary,
 # not a node -- but this is the path to use when one is added.
-RELEASE_DOCKER_IMAGE     ?= ghcr.io/ovrclk/akt
+RELEASE_DOCKER_IMAGE     ?= ghcr.io/akash-network/akt
 
 GORELEASER_GOWORK        := $(GOWORK)
 
@@ -122,15 +122,28 @@ release-dry-run: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 
 # The real thing: builds the matrix and uploads to the GitHub release for the
 # current tag. Driven by .github/workflows/release.yml on `v*` tag pushes;
-# running it by hand needs a GITHUB_TOKEN with contents:write. The token is
-# passed by name so it never lands in the echoed command line.
+# running it by hand needs a GITHUB_TOKEN with contents:write. Tokens are
+# passed by name so they never land in the echoed command line.
+#
+# HOMEBREW_TAP_TOKEN publishes the cask to akash-network/homebrew-tap, which is
+# a separate repository that GITHUB_TOKEN cannot reach. It is defaulted to the
+# empty string rather than passed through as-is: `token: "{{ .Env.X }}"` fails
+# to render when X is absent from the environment entirely, which would abort a
+# release that was never going to touch the tap. Empty renders fine, and
+# `skip_upload: auto` means a prerelease skips the upload regardless — so an
+# alpha releases without the secret, while a stable release without it fails at
+# the cask step with an auth error rather than a template error.
 .PHONY: release
 release: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 	@if [ -z "$${GITHUB_TOKEN}" ]; then \
 		echo "GITHUB_TOKEN is required to publish a release"; \
 		exit 1; \
 	fi
-	docker run $(GORELEASER_DOCKER_ARGS) -e GITHUB_TOKEN $(GORELEASER_IMAGE) release --clean $(GORELEASER_ARGS)
+	@if [ -z "$${HOMEBREW_TAP_TOKEN}" ]; then \
+		echo "warning: HOMEBREW_TAP_TOKEN unset -- a stable release will fail at the Homebrew cask step"; \
+	fi
+	HOMEBREW_TAP_TOKEN="$${HOMEBREW_TAP_TOKEN:-}" \
+	docker run $(GORELEASER_DOCKER_ARGS) -e GITHUB_TOKEN -e HOMEBREW_TAP_TOKEN $(GORELEASER_IMAGE) release --clean $(GORELEASER_ARGS)
 
 .PHONY: bins
 bins: $(AKT)

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -125,7 +125,7 @@ release-dry-run: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 # running it by hand needs a GITHUB_TOKEN with contents:write. Tokens are
 # passed by name so they never land in the echoed command line.
 #
-# HOMEBREW_TAP_TOKEN publishes the cask to akash-network/homebrew-tap, which is
+# GORELEASER_ACCESS_TOKEN publishes the cask to akash-network/homebrew-tap, which is
 # a separate repository that GITHUB_TOKEN cannot reach. It is defaulted to the
 # empty string rather than passed through as-is: `token: "{{ .Env.X }}"` fails
 # to render when X is absent from the environment entirely, which would abort a
@@ -139,11 +139,11 @@ release: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 		echo "GITHUB_TOKEN is required to publish a release"; \
 		exit 1; \
 	fi
-	@if [ -z "$${HOMEBREW_TAP_TOKEN}" ]; then \
-		echo "warning: HOMEBREW_TAP_TOKEN unset -- a stable release will fail at the Homebrew cask step"; \
+	@if [ -z "$${GORELEASER_ACCESS_TOKEN}" ]; then \
+		echo "warning: GORELEASER_ACCESS_TOKEN unset -- a stable release will fail at the Homebrew cask step"; \
 	fi
-	HOMEBREW_TAP_TOKEN="$${HOMEBREW_TAP_TOKEN:-}" \
-	docker run $(GORELEASER_DOCKER_ARGS) -e GITHUB_TOKEN -e HOMEBREW_TAP_TOKEN $(GORELEASER_IMAGE) release --clean $(GORELEASER_ARGS)
+	GORELEASER_ACCESS_TOKEN="$${GORELEASER_ACCESS_TOKEN:-}" \
+	docker run $(GORELEASER_DOCKER_ARGS) -e GITHUB_TOKEN -e GORELEASER_ACCESS_TOKEN $(GORELEASER_IMAGE) release --clean $(GORELEASER_ARGS)
 
 .PHONY: bins
 bins: $(AKT)


### PR DESCRIPTION
Publishes a Homebrew cask straight into `akash-network/homebrew-tap` as part of the release.
