### PR TITLE
build: publish the homebrew cask on prereleases too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,10 @@ jobs:
         if: github.event_name == 'push'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Publishes the Homebrew cask to akash-network/homebrew-tap. That is
-          # a different repository, so GITHUB_TOKEN cannot write to it. Same
-          # secret name akash-network/node already uses to reach the tap, so
-          # an org-level secret covers both; node only needs actions:write to
-          # dispatch a workflow there, while writing the cask needs
-          # contents:write. Prereleases skip the cask, so an alpha releases
-          # fine without it.
+          # Writes the Homebrew cask to akash-network/homebrew-tap, which
+          # GITHUB_TOKEN cannot reach. Same secret node uses, but node only
+          # dispatches a workflow (actions:write) -- writing the cask needs
+          # contents:write.
           GORELEASER_ACCESS_TOKEN: ${{ secrets.GORELEASER_ACCESS_TOKEN }}
         run: make release
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -208,11 +208,10 @@ homebrew_casks:
     homepage: "https://akash.network"
     description: "Unified CLI for the Akash Network"
     license: "Apache-2.0"
-    # `brew install akt` must keep resolving to the newest stable build, so an
-    # alpha or rc never overwrites the cask. `auto` skips the upload when the
-    # version is a prerelease, which is the gate node applies with
-    # is_prerelease.sh before notifying the tap.
-    skip_upload: auto
+    # Publish on prereleases too -- there is no stable release yet, so `auto`
+    # would leave the tap empty. Switch to `auto` at the first stable tag, or
+    # an alpha will downgrade `brew install akt` users.
+    skip_upload: false
     hooks:
       post:
         # The darwin binaries are neither signed nor notarized, so Gatekeeper

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -125,14 +125,11 @@ release-dry-run: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 # running it by hand needs a GITHUB_TOKEN with contents:write. Tokens are
 # passed by name so they never land in the echoed command line.
 #
-# GORELEASER_ACCESS_TOKEN publishes the cask to akash-network/homebrew-tap, which is
-# a separate repository that GITHUB_TOKEN cannot reach. It is defaulted to the
-# empty string rather than passed through as-is: `token: "{{ .Env.X }}"` fails
-# to render when X is absent from the environment entirely, which would abort a
-# release that was never going to touch the tap. Empty renders fine, and
-# `skip_upload: auto` means a prerelease skips the upload regardless — so an
-# alpha releases without the secret, while a stable release without it fails at
-# the cask step with an auth error rather than a template error.
+# GORELEASER_ACCESS_TOKEN writes the cask to akash-network/homebrew-tap, which
+# GITHUB_TOKEN cannot reach. Needs contents:write, and is required for every
+# release since skip_upload is false. Defaulted to empty because
+# `{{ .Env.X }}` fails to render when X is unset at all, which would kill the
+# release before it built anything.
 .PHONY: release
 release: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 	@if [ -z "$${GITHUB_TOKEN}" ]; then \
@@ -140,7 +137,7 @@ release: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 		exit 1; \
 	fi
 	@if [ -z "$${GORELEASER_ACCESS_TOKEN}" ]; then \
-		echo "warning: GORELEASER_ACCESS_TOKEN unset -- a stable release will fail at the Homebrew cask step"; \
+		echo "warning: GORELEASER_ACCESS_TOKEN unset -- this release will fail at the Homebrew cask step"; \
 	fi
 	GORELEASER_ACCESS_TOKEN="$${GORELEASER_ACCESS_TOKEN:-}" \
 	docker run $(GORELEASER_DOCKER_ARGS) -e GITHUB_TOKEN -e GORELEASER_ACCESS_TOKEN $(GORELEASER_IMAGE) release --clean $(GORELEASER_ARGS)


### PR DESCRIPTION
`skip_upload: auto` skips the cask on prereleases, mirroring node's `is_prerelease.sh` gate. akt has no stable release yet, so that gate leaves the tap empty — there is nothing for `brew install akt` to install during the alpha series.

Sets `skip_upload: false` so every release publishes the cask.

**Consequence:** `GORELEASER_ACCESS_TOKEN` is now required for *every* release, not just stable ones. It needs `contents:write` on `akash-network/homebrew-tap` (node only uses it to dispatch a workflow, which needs `actions:write`).

**Follow-up:** switch back to `auto` at the first stable tag, or an alpha will overwrite the cask and downgrade anyone on `brew install akt`.