### PR TITLE
fix(console): make --tail and the service filter actually filter

### DIFF
--- a/internal/cli/console/gateway.go
+++ b/internal/cli/console/gateway.go
@@ -211,20 +211,65 @@ func logsCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 				return fmt.Errorf("stream lease logs: %w", err)
 			}
 
+			// Neither filter survives the round trip, so both are applied
+			// here as well and the flags do what they claim:
+			//
+			//   - tail: the provider client takes the parameter and drops it
+			//     (`_ int64` in its LeaseLogs signature), so nothing is sent.
+			//   - service: the client does send ?services=, and the provider
+			//     returns every service anyway.
+			//
+			// Buffering only happens for a bounded one-shot read; --follow
+			// streams as before, since "last N lines of an endless stream"
+			// has no meaning and buffering it would hang.
+			buffered := !follow && tail > 0
+			var tailBuf []string
+
+			emit := func(msg providerLogMsg) {
+				if !matchesService(msg.Name, service) {
+					return
+				}
+
+				line := fmt.Sprintf("[%s] %s", msg.Name, msg.Message)
+				if buffered {
+					tailBuf = append(tailBuf, line)
+					if int64(len(tailBuf)) > tail {
+						tailBuf = tailBuf[len(tailBuf)-int(tail):]
+					}
+
+					return
+				}
+
+				fmt.Fprintln(cmd.OutOrStdout(), line)
+			}
+
+			flush := func() {
+				for _, line := range tailBuf {
+					fmt.Fprintln(cmd.OutOrStdout(), line)
+				}
+			}
+
 			for {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
 				case msg, ok := <-logs.Stream:
 					if !ok {
+						flush()
 						return nil
 					}
-					fmt.Fprintf(cmd.OutOrStdout(), "[%s] %s\n", msg.Name, msg.Message)
+					emit(providerLogMsg{Name: msg.Name, Message: msg.Message})
 				case reason, ok := <-logs.OnClose:
 					if !ok {
+						flush()
 						return nil
 					}
-					return streamCloseErr("log", reason, follow)
+					if err := streamCloseErr("log", reason, follow); err != nil {
+						return err
+					}
+					flush()
+
+					return nil
 				}
 			}
 		},
@@ -588,4 +633,26 @@ func screeningAttrs(attrs attrv1.Attributes) []console.Attribute {
 	}
 
 	return out
+}
+
+// providerLogMsg is the shape the log stream yields, narrowed to the fields
+// the CLI prints so the filtering helpers can be tested without a provider.
+type providerLogMsg struct {
+	Name    string
+	Message string
+}
+
+// matchesService reports whether a log line from pod `name` belongs to
+// `service`. An empty service matches everything.
+//
+// The provider returns pod names ("web-5cfc6c7b4b-4cl7z"), not service names,
+// so an exact comparison would drop every line. Kubernetes builds those names
+// as <service>-<replicaset>-<pod>, hence the prefix match on "<service>-";
+// the bare equality covers a pod named exactly for its service.
+func matchesService(name, service string) bool {
+	if service == "" {
+		return true
+	}
+
+	return name == service || strings.HasPrefix(name, service+"-")
 }

--- a/internal/cli/console/gateway_test.go
+++ b/internal/cli/console/gateway_test.go
@@ -392,3 +392,32 @@ func TestStreamCloseErr(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesService(t *testing.T) {
+	tests := []struct {
+		name    string
+		pod     string
+		service string
+		want    bool
+	}{
+		// No filter requested: everything passes.
+		{"empty filter", "web-5cfc6c7b4b-4cl7z", "", true},
+		// The provider reports pod names, so the service name has to match
+		// through the replicaset/pod suffix Kubernetes appends.
+		{"pod of the service", "web-5cfc6c7b4b-4cl7z", "web", true},
+		{"pod named exactly", "web", "web", true},
+		// The bug this guards: asking for one service used to return them all.
+		{"pod of another service", "cache-666dd889cf-zpbn5", "web", false},
+		// A prefix that is not a name boundary must not match, or `web` would
+		// silently include `webhook`.
+		{"prefix but different service", "webhook-abc-123", "web", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchesService(tc.pod, tc.service); got != tc.want {
+				t.Fatalf("matchesService(%q, %q) = %v, want %v", tc.pod, tc.service, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`akt console logs <dseq> web --tail 3` returned every line of every service.

Both filters are dropped before they reach the provider:

- **`--tail`** — `LeaseLogs` in `pkg.akt.dev/go` takes the count as `_ int64` and never sends it
- **service** — the client *does* send `?services=`, and the provider returns all services anyway

Applied client-side so the flags do what they document. Tail buffers only for a bounded one-shot read; with `--follow`, "last N lines of an endless stream" is meaningless and buffering would hang.

The service match is a prefix rather than an equality — the provider reports pod names (`web-5cfc6c7b4b-4cl7z`), so comparing to `web` directly would drop every line. The `-` boundary matters, or `web` would swallow `webhook`.

## Verified against a live provider

| | before | after |
|---|---|---|
| `--tail 3` (of 443 lines) | 443 | 3 |
| `--tail 10` | 443 | 10 |
| nonexistent service | 443 | 0 |
| `control-db --tail 5` | 443 | 5 |
| no filters | 443 | 443 |

Plus unit tests on the matcher, including the `web` / `webhook` boundary.

Upstream follow-ups (not fixed here): `--tail` should be sent by `pkg.akt.dev/go`, and the provider should honour `?services=`.