### PR TITLE
fix(console): stop losing the manifest and name the SDL mistake

### DIFF
--- a/internal/cli/console/deployment.go
+++ b/internal/cli/console/deployment.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -149,12 +150,22 @@ func deploymentCreateCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 
 			// Cache the manifest so `lease create` can default to it.
 			note := ""
+			// Emitted only when the manifest could not be cached. `lease
+			// create` needs the manifest Console rendered from the SDL, and it
+			// is returned exactly once, here -- telling the user to pass
+			// --manifest without handing them the file leaves a deployment
+			// that can be leased but never gets a workload, quietly burning
+			// escrow.
+			uncachedManifest := ""
+
 			switch {
 			case rc == nil:
-				note = "manifest not cached (no active context); pass --manifest to `lease create`"
+				note = "manifest not cached (no active context): save the manifest field below and pass it to `lease create --manifest`"
+				uncachedManifest = result.Manifest
 			case result.Manifest != "":
 				if err := console.SaveManifest(rc.Root, rc.Name, result.DSeq.String(), result.Manifest); err != nil {
-					note = fmt.Sprintf("manifest not cached: %v", err)
+					note = fmt.Sprintf("manifest not cached (%v): save the manifest field below and pass it to `lease create --manifest`", err)
+					uncachedManifest = result.Manifest
 				}
 			}
 
@@ -164,11 +175,12 @@ func deploymentCreateCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			}
 
 			return printJSON(cmd, struct {
-				DSeq   string `json:"dseq"`
-				TxHash string `json:"txHash,omitempty"`
-				State  string `json:"state"`
-				Note   string `json:"note,omitempty"`
-			}{result.DSeq.String(), txHash, "open", note})
+				DSeq     string `json:"dseq"`
+				TxHash   string `json:"txHash,omitempty"`
+				State    string `json:"state"`
+				Note     string `json:"note,omitempty"`
+				Manifest string `json:"manifest,omitempty"`
+			}{result.DSeq.String(), txHash, "open", note, uncachedManifest})
 		},
 	}
 
@@ -416,11 +428,10 @@ func leaseCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 			var manifest string
 			switch {
 			case manifestFile != "":
-				data, err := os.ReadFile(manifestFile)
+				manifest, err = manifestFromFile(manifestFile)
 				if err != nil {
-					return fmt.Errorf("read manifest file: %w", err)
+					return err
 				}
-				manifest = string(data)
 
 			case rc != nil:
 				manifest, err = console.LoadManifest(rc.Root, rc.Name, dseq)
@@ -457,4 +468,26 @@ func leaseCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd.AddCommand(create)
 
 	return cmd
+}
+
+// manifestFromFile reads a --manifest file, rejecting anything that is not
+// JSON.
+//
+// The file wanted here is the manifest Console renders from the SDL, not the
+// SDL itself. Passing the SDL is the obvious mistake -- same file, same
+// directory -- and Console replies "invalid character '-' in numeric literal",
+// which is its JSON parser hitting the leading `---` of the YAML. Checking
+// locally names the actual cause and costs no API call.
+func manifestFromFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read manifest file: %w", err)
+	}
+
+	if !json.Valid(data) {
+		return "", fmt.Errorf("manifest file %s is not JSON: --manifest takes the manifest Console renders "+
+			"(reported by `akt console deployment create`, cached per context), not the SDL", path)
+	}
+
+	return string(data), nil
 }

--- a/internal/cli/console/deployment_test.go
+++ b/internal/cli/console/deployment_test.go
@@ -150,3 +150,52 @@ func TestDeploymentListZeroFlagValues(t *testing.T) {
 		t.Errorf("limit=0 must be omitted so the server default applies, got query %v", gotQuery)
 	}
 }
+
+func TestManifestFromFile(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, content string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+
+		return p
+	}
+
+	t.Run("accepts a rendered manifest", func(t *testing.T) {
+		p := write("manifest.json", `[{"name":"dcloud","services":[]}]`)
+
+		got, err := manifestFromFile(p)
+		if err != nil {
+			t.Fatalf("expected the JSON manifest to be accepted, got %v", err)
+		}
+		if got == "" {
+			t.Fatal("expected the file contents back")
+		}
+	})
+
+	// The regression: passing the SDL got as far as Console, which replied
+	// "invalid character '-' in numeric literal" -- its JSON parser hitting
+	// the leading `---`. Nothing about that names the real mistake.
+	t.Run("rejects an SDL with a message that names the cause", func(t *testing.T) {
+		p := write("deploy.yaml", "---\nversion: \"2.0\"\nservices:\n  web:\n    image: nginx\n")
+
+		_, err := manifestFromFile(p)
+		if err == nil {
+			t.Fatal("expected an SDL file to be rejected")
+		}
+		for _, want := range []string{"not JSON", "not the SDL"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error should mention %q, got: %v", want, err)
+			}
+		}
+	})
+
+	t.Run("reports a missing file", func(t *testing.T) {
+		if _, err := manifestFromFile(filepath.Join(dir, "absent.json")); err == nil {
+			t.Fatal("expected a missing file to error")
+		}
+	})
+}


### PR DESCRIPTION
Two ways to end up with a lease that never gets a workload, both silent. Found while deploying a live multi-service workload to test `console events`.

## 1. `deployment create` without a context threw the manifest away

It printed `manifest not cached (no active context); pass --manifest to lease create` — but Console returns that manifest **exactly once, at create**, so there was nothing left to pass.

Real consequence, hit during testing: the deployment leased fine, then sat with an **active lease and no workload**, burning escrow, with `console status` answering 404.

Now the manifest is included in the result whenever it could not be cached, so the instruction is actually followable.

## 2. `lease create --manifest` posted whatever bytes it got

Passing the SDL is the obvious mistake — same file, same directory. Console replies:

```
422: invalid character '-' in numeric literal
```

That's its JSON parser hitting the leading `---` of the YAML. Nothing in it names the cause. Now checked locally:

```
manifest file deploy.yaml is not JSON: --manifest takes the manifest Console
renders (reported by `akt console deployment create`, cached per context), not the SDL
```

Fails before the API call rather than after.

## Verified

- Reproduced the original 422 against the live API, then confirmed the new message replaces it
- Unit tests: rendered manifest accepted, SDL rejected with a message naming the cause, missing file errors