### PR TITLE
fix(console): create wallet settings when none exist yet

### DIFF
--- a/internal/cli/console/wallet.go
+++ b/internal/cli/console/wallet.go
@@ -1,10 +1,12 @@
 package console
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
 )
 
@@ -139,6 +141,17 @@ func walletSettingsCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			}
 
 			settings, err := cl.GetWalletSettings(cmd.Context())
+			// An account that has never configured auto-reload has no
+			// settings record, which the API reports as 404. That is the
+			// normal state, not a failure -- report the defaults rather than
+			// exiting non-zero.
+			if errors.Is(err, console.ErrNotFound) {
+				return printJSON(cmd, struct {
+					AutoReloadEnabled bool   `json:"autoReloadEnabled"`
+					Configured        bool   `json:"configured"`
+					Note              string `json:"note"`
+				}{false, false, "no wallet settings configured; enable auto-reload with `akt console wallet settings true`"})
+			}
 			if err != nil {
 				return fmt.Errorf("get wallet settings: %w", err)
 			}

--- a/internal/console/wallet.go
+++ b/internal/console/wallet.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -64,14 +65,25 @@ func (c *Client) GetWalletSettings(ctx context.Context) (*WalletSettings, error)
 // UpdateWalletSettings enables or disables wallet auto-reload and returns the
 // stored settings.
 //
-// Wire: PUT /v1/wallet-settings, body {"data":{"autoReloadEnabled":...}},
-// data-enveloped response.
+// Wire: PUT /v1/wallet-settings, body {"data":{"autoReloadEnabled":...}};
+// on 404, POST the same body to create the record. Data-enveloped response.
+//
+// An account that has never configured auto-reload has no settings record at
+// all, and PUT reports that as 404 — so the update would fail on exactly the
+// accounts that have never set it, which is most of them. The API exposes
+// POST for creation; falling back to it mirrors SetDeploymentAutoTopUp.
 func (c *Client) UpdateWalletSettings(ctx context.Context, autoReloadEnabled bool) (*WalletSettings, error) {
 	body := envelope(map[string]any{"autoReloadEnabled": autoReloadEnabled})
 
 	var out WalletSettings
+
 	err := c.doData(ctx, http.MethodPut, "/v1/wallet-settings", body, &out)
+	if errors.Is(err, ErrNotFound) {
+		err = c.doData(ctx, http.MethodPost, "/v1/wallet-settings", body, &out)
+	}
+
 	c.record("update-wallet-settings", "", err)
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/console/wallet_test.go
+++ b/internal/console/wallet_test.go
@@ -156,3 +156,53 @@ func TestGetUsageHistoryValidatesDateFormat(t *testing.T) {
 		t.Fatal("expected invalid date format to be rejected client-side")
 	}
 }
+
+// TestUpdateWalletSettingsCreatesWhenAbsent covers the account state that is
+// most common: auto-reload has never been configured, so there is no settings
+// record and PUT answers 404. Without the POST fallback the update fails on
+// exactly the accounts that need it.
+func TestUpdateWalletSettingsCreatesWhenAbsent(t *testing.T) {
+	var methods []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"NotFound","message":"no wallet settings"}`))
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"autoReloadEnabled":true}}`))
+	}))
+	defer srv.Close()
+
+	c := console.New(srv.URL, "key")
+
+	got, err := c.UpdateWalletSettings(context.Background(), true)
+	require.NoError(t, err)
+	assert.True(t, got.AutoReloadEnabled)
+	assert.Equal(t, []string{http.MethodPut, http.MethodPost}, methods,
+		"a 404 from PUT must fall back to POST to create the record")
+}
+
+// TestUpdateWalletSettingsUsesPutWhenPresent guards the other direction: an
+// account that already has settings must not be sent a redundant create.
+func TestUpdateWalletSettingsUsesPutWhenPresent(t *testing.T) {
+	var methods []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"autoReloadEnabled":false}}`))
+	}))
+	defer srv.Close()
+
+	c := console.New(srv.URL, "key")
+
+	_, err := c.UpdateWalletSettings(context.Background(), false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{http.MethodPut}, methods, "an existing record needs only the PUT")
+}


### PR DESCRIPTION
An account that has never configured auto-reload has no settings record, and the API reports that as 404 on **both** read and write:

```
$ akt console wallet settings
get wallet settings: console: resource not found (HTTP 404): GET /v1/wallet-settings
```

The path is correct — `/v1/wallet-settings` GET is in the vendored OpenAPI spec. There simply is no record.

Two consequences:

- **Read** surfaced the normal unconfigured state as a hard error
- **Update** only ever sent `PUT`, so enabling auto-reload would fail on exactly the accounts that had never set it — which is most of them

`SetDeploymentAutoTopUp` already solves this for the per-deployment equivalent (`PATCH`, falling back to `POST` on 404). This applies the same shape: `PUT`, falling back to `POST`, which the spec exposes as *Create wallet settings*.

Read now reports the unconfigured default instead of failing:

```json
{
  "autoReloadEnabled": false,
  "configured": false,
  "note": "no wallet settings configured; enable auto-reload with `akt console wallet settings true`"
}
```

## Verification

- Read path confirmed against the live Console API — exits 0 with the payload above
- Unit tests cover both directions: 404 on PUT falls back to POST, and an existing record uses PUT alone with no redundant create

The write path is **not** exercised against the live API on purpose — calling it enables auto-reload, which authorizes automatic credit purchases against a real payment method.