### PR TITLE
fix(mcp): serve the console rail without a chain context

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -447,6 +447,13 @@ func requiresContext(cmd *cobra.Command) bool {
 	// environment; capability gating reports a missing key instead.
 	case strings.HasPrefix(path, "akt console"):
 		return false
+	// The MCP server resolves a Console credential the same way, and serves
+	// the Console tools off it alone. Requiring a context here would refuse a
+	// server to anyone holding only an API key, which is exactly the managed
+	// setup that has no wallet to configure. It reports for itself when
+	// neither rail is available.
+	case strings.HasPrefix(path, "akt mcp"):
+		return false
 	}
 
 	return true

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -48,25 +49,16 @@ func New(ctx context.Context, cctx sdkclient.Context, enableWrites bool, console
 
 	s := &Server{mcp: srv}
 
-	if enableWrites {
-		cl, err := client.NewClient(ctx, cctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create chain client: %w", err)
-		}
-		s.registerQueryTools(cl)
-		s.registerWriteTools(cl)
-	} else {
-		cl, err := client.NewLightClient(cctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create chain client: %w", err)
-		}
-		s.registerQueryTools(cl)
-	}
+	// A chain client is not a prerequisite when the Console rail is
+	// available: a managed context reaches deployments, wallet, providers and
+	// pricing over the Console API and never touches a node, so refusing to
+	// start without a wallet and an RPC endpoint would deny that user a
+	// server they can fully use. The failure is only fatal when it leaves the
+	// server with nothing at all.
+	chainErr := s.registerChainTools(ctx, cctx, enableWrites)
 
-	// The Console rail is additive: a managed context reaches deployments,
-	// wallet and providers through the Console API instead of a chain node, so
-	// an assistant with only a Console key still has tools. Registered only
-	// when a key resolved -- otherwise every call would fail on auth.
+	// The Console rail is additive, and registered only when a key resolved --
+	// otherwise every call would fail on auth.
 	if consoleClient != nil {
 		s.registerConsoleQueryTools(consoleClient)
 
@@ -75,7 +67,46 @@ func New(ctx context.Context, cctx sdkclient.Context, enableWrites bool, console
 		}
 	}
 
+	if chainErr != nil && consoleClient == nil {
+		return nil, fmt.Errorf("no tools available: chain client unavailable (%w) and no Console API key configured", chainErr)
+	}
+
 	return s, nil
+}
+
+// registerChainTools registers the chain-backed tools, returning the error
+// that prevented it rather than failing the server. A context with no RPC
+// endpoint -- which a console-api context is allowed to be -- simply has no
+// chain tools.
+func (s *Server) registerChainTools(ctx context.Context, cctx sdkclient.Context, enableWrites bool) error {
+	// Checked before building a client, because the constructors accept an
+	// empty context happily and hand back something that fails on every call.
+	// Registering those tools would advertise a chain rail that cannot work,
+	// and would mask the case where no rail is available at all.
+	if cctx.NodeURI == "" {
+		return errors.New("no chain RPC endpoint configured for the active context")
+	}
+
+	if enableWrites {
+		cl, err := client.NewClient(ctx, cctx)
+		if err != nil {
+			return err
+		}
+
+		s.registerQueryTools(cl)
+		s.registerWriteTools(cl)
+
+		return nil
+	}
+
+	cl, err := client.NewLightClient(cctx)
+	if err != nil {
+		return err
+	}
+
+	s.registerQueryTools(cl)
+
+	return nil
 }
 
 // registerConsoleQueryTools registers the read-only Console API tools.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,6 +1,14 @@
 package mcp
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+
+	aktconsole "pkg.akt.dev/akt/internal/console"
+)
 
 // mustBool reads an annotation pointer, failing when the hint was never set.
 //
@@ -67,5 +75,35 @@ func TestQueryAndWriteAnnotationsDiffer(t *testing.T) {
 	}
 	if *q.DestructiveHint == *w.DestructiveHint {
 		t.Error("read and write tools must not advertise the same destructiveHint")
+	}
+}
+
+// TestNewWithoutChainOrConsoleFails covers the case where neither rail is
+// usable. The chain client constructors accept an empty context and return
+// something that fails on every call, so without an explicit endpoint check
+// the server would start and advertise 19 chain tools that cannot work --
+// and the "nothing available" error could never fire.
+func TestNewWithoutChainOrConsoleFails(t *testing.T) {
+	_, err := New(context.Background(), sdkclient.Context{}, false, nil)
+	if err == nil {
+		t.Fatal("expected an error when there is no chain endpoint and no Console key")
+	}
+
+	for _, want := range []string{"no tools available", "Console API key"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestNewWithConsoleOnlySucceeds is the point of the change: a managed setup
+// has an API key and no wallet or RPC endpoint, and must still get a server.
+func TestNewWithConsoleOnlySucceeds(t *testing.T) {
+	s, err := New(context.Background(), sdkclient.Context{}, false, aktconsole.New("", "key"))
+	if err != nil {
+		t.Fatalf("a Console key alone must be enough to start: %v", err)
+	}
+	if s == nil {
+		t.Fatal("expected a server")
 	}
 }


### PR DESCRIPTION
> **Stacked on #17** — base is `chalabi/mcp-spec-console`, not `main`. The Console MCP tools land there; this is meaningless without them. Retarget to `main` once #17 merges.

`akt mcp` refused to start without a configured context. A managed setup — an API key and no wallet or RPC endpoint, which is exactly what `console-api` contexts are for — could not run the server at all, even though every Console tool would have worked.

Exempts `mcp` from the context requirement the way the `console` group already is, and treats a missing chain rail as absent rather than fatal. The server only fails when **neither** rail is available.

## The endpoint check matters

The chain constructors accept an empty context happily and return a client that fails on every call. My first cut relied on that returning an error — it doesn't. Running it showed the server starting with **no context and no key**, advertising 19 unusable chain tools, with the "nothing available" error unreachable:

```
tools with NO context and NO key: 19
```

So the endpoint is checked before a client is built.

## Verified by running the server

```
no context, no key    -> errors: "no tools available: chain client unavailable ... and no Console API key configured"
no context, with key  ->  8 tools (8 console,  0 chain)
console-only context  ->  8 tools (8 console,  0 chain)   ← RPC: (none)
mainnet context + key -> 27 tools (8 console, 19 chain)
```

Unit tests cover both ends, and `TestNewWithoutChainOrConsoleFails` **fails** without the endpoint check — confirmed by reverting it.