### PR TITLE
fix(cli): correct the commands and capabilities the help text names

### DIFF
--- a/internal/cli/context/commands.go
+++ b/internal/cli/context/commands.go
@@ -271,7 +271,7 @@ func editCmd(mgr func() *aktctx.Manager) *cobra.Command {
 
 			forkNetwork, _ := cmd.Flags().GetBool("fork-network")
 			if forkNetwork && cmd.Flags().Changed("network") {
-				return fmt.Errorf("cannot use --fork-network with --network; use akt network create to fork manually")
+				return fmt.Errorf("cannot use --fork-network with --network; use akt context network create to fork manually")
 			}
 
 			changed := map[string]string{}

--- a/internal/cli/keys/commands.go
+++ b/internal/cli/keys/commands.go
@@ -1,4 +1,4 @@
-// Package keys implements the `akt keys` CLI commands for managing
+// Package keys implements the `akt context keys` CLI commands for managing
 // cryptographic keys within the context's keyring.
 package keys
 
@@ -290,7 +290,7 @@ func listCmd(getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 			}
 
 			if len(records) == 0 {
-				fmt.Println("No keys found. Add one with: akt keys add <name>")
+				fmt.Println("No keys found. Add one with: akt context keys add <name>")
 				return nil
 			}
 

--- a/internal/cli/network/commands.go
+++ b/internal/cli/network/commands.go
@@ -167,7 +167,7 @@ func listCmd(mgr func() *aktctx.Manager) *cobra.Command {
 			nets := m.ListNetworks()
 
 			if len(nets) == 0 {
-				fmt.Println("No networks configured. Create one with: akt network create <name> --template mainnet")
+				fmt.Println("No networks configured. Create one with: akt context network create <name> --template mainnet")
 				return nil
 			}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -99,8 +99,8 @@ func NewRootCmd(bi BuildInfo) *cobra.Command {
 
 	root := &cobra.Command{
 		Use:   "akt",
-		Short: "Akash Network CLI and TUI",
-		Long:  "akt is the unified command-line interface and terminal user interface for the Akash Network.",
+		Short: "Akash Network CLI",
+		Long:  "akt is the unified command-line interface for the Akash Network.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// 1. Seed the SDK client.Context with encoding config so that
 			//    downstream PersistentPreRunE hooks (tx/query) always find
@@ -286,7 +286,7 @@ func NewRootCmd(bi BuildInfo) *cobra.Command {
 	root.PersistentFlags().String("home", "", "Home directory for config, contexts, and keyrings (default: $AKT_HOME or ~/.config/akt)")
 	root.PersistentFlags().String("context", "", "Active context name (overrides current-context in config)")
 	root.PersistentFlags().StringP("output", "o", "pretty", "Output format: pretty, json, yaml")
-	root.PersistentFlags().BoolP("interactive", "i", false, "Force interactive (TUI) mode even if disabled in config")
+	root.PersistentFlags().BoolP("interactive", "i", false, "Launch the TUI. Currently disabled while UX feedback is collected; set AKT_EXPERIMENTAL_TUI=1 to opt in")
 	root.PersistentFlags().CountP("verbose", "v", "Increase output verbosity (-v verbose, -vv debug)")
 	root.PersistentFlags().BoolP("quiet", "q", false, "Suppress all output except errors")
 

--- a/internal/output/pretty/network.go
+++ b/internal/output/pretty/network.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RenderNetworkShow renders a network definition as a styled string.
-// Used by both CLI "akt network show" and TUI network detail views.
+// Used by both CLI "akt context network show" and TUI network detail views.
 func RenderNetworkShow(net aktctx.Network, usedBy []string) string {
 	var buf strings.Builder
 
@@ -47,7 +47,7 @@ func RenderNetworkShow(net aktctx.Network, usedBy []string) string {
 }
 
 // RenderNetworkList renders a list of networks as a styled table string.
-// Used by both CLI "akt network list" and TUI network list views.
+// Used by both CLI "akt context network list" and TUI network list views.
 func RenderNetworkList(nets []aktctx.Network, getUsedBy func(name string) []string) string {
 	var buf strings.Builder
 


### PR DESCRIPTION
`akt context keys list` on an empty keyring tells the user to run a command that does not exist:

```
$ akt context keys list
No keys found. Add one with: akt keys add <name>

$ akt keys add mykey
unknown command "keys" for "akt"
```

Key management only exists under `akt context keys`. This is the first thing a new user with no keys sees, and it sends them straight into a dead end. `akt context network list` and the `--fork-network` conflict error pointed at `akt network create` the same way.

## Audit of the rest

I extracted every `akt …` suggestion from user-facing strings and checked each against the real command tree. Two more claims no longer hold:

- The root command described akt as a **"command-line interface and terminal user interface"** — advertising a TUI that is disabled and was removed from the docs. It is the very first line of `akt --help`.
- `-i` promised to **"Force interactive (TUI) mode even if disabled in config"**, then refused with "the TUI is currently disabled". It now says so plainly and names `AKT_EXPERIMENTAL_TUI`, the escape hatch that actually works.

## Verified

Each corrected command was run verbatim to confirm it does what the message claims:

```
$ akt context keys add testkey       -> name: testkey, address: akash1vkww…
$ akt context network create testnet --template mainnet   -> network created
$ AKT_EXPERIMENTAL_TUI=1 akt         -> reaches bubbletea (opt-in works)
```

The 85 invocations in cobra `Example` blocks were audited the same way — all resolve.

No behavior changes: strings only, plus stale package and renderer comments naming the same wrong paths.