### PR TITLE
build: make a failed release retryable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -264,6 +264,11 @@ release:
   # `github: {owner: ..., name: ...}` here if it ever needs to be forced.
   prerelease: auto
   mode: replace
+  # mode: replace swaps the release notes, not the uploaded files. Without
+  # this, re-running a release that failed partway -- which is exactly when a
+  # retry is wanted -- dies with 422 already_exists on the first asset and
+  # never reaches the steps that failed.
+  replace_existing_artifacts: true
   draft: false
   name_template: "akt {{ .Version }}"
 


### PR DESCRIPTION
Re-running a release that failed partway dies on the first asset and never reaches the step that actually failed:

```
422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists}]
```

That is exactly when a retry is wanted. The `v0.0.1-a4` run published all 8 assets and then failed writing the Homebrew cask; the re-run couldn't get back to the cask step to confirm the token fix, because it died re-uploading artifacts that were already there.

`mode: replace` — which we already set — swaps the release *notes*, not the uploaded files. `replace_existing_artifacts` is the one that clears them first.