### PR TITLE
build: skip the homebrew cask on prereleases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -208,10 +208,11 @@ homebrew_casks:
     homepage: "https://akash.network"
     description: "Unified CLI for the Akash Network"
     license: "Apache-2.0"
-    # Publish on prereleases too -- there is no stable release yet, so `auto`
-    # would leave the tap empty. Switch to `auto` at the first stable tag, or
-    # an alpha will downgrade `brew install akt` users.
-    skip_upload: false
+    # Skip prereleases: `brew install akt` must keep resolving to the newest
+    # stable build. Publishing alphas was only correct while there was no
+    # stable release to overwrite -- now there is, and an alpha reaching the
+    # tap would downgrade everyone on it.
+    skip_upload: auto
     hooks:
       post:
         # The darwin binaries are neither signed nor notarized, so Gatekeeper


### PR DESCRIPTION
Publishing alphas to the tap was only correct while there was no stable release to overwrite. With `v0.0.1` being cut, an alpha reaching the tap would downgrade everyone on `brew install akt` to a prerelease.

`skip_upload: auto` skips the cask when the version is a prerelease — the same gate `node` applies via `is_prerelease.sh`.

Must land before the stable tag, since the release builds from the tagged commit.