### PR TITLE
build: publish a homebrew formula instead of a cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -180,19 +180,22 @@ nfpms:
 
 # Homebrew, published straight into akash-network/homebrew-tap as part of the
 # release. node reaches the same tap by dispatching an event to it and
-# regenerating akash.rb from a template there; goreleaser writes the cask
+# regenerating akash.rb from a template there; goreleaser writes the formula
 # itself, so there is no dispatch, no second workflow, and no template to keep
 # in step with the archives.
 #
-# A cask rather than a formula: `brews` is deprecated and goreleaser exits
-# non-zero on it, which would break `make release-check`. No platform is lost
-# by the switch -- `binary` is a portable stanza, so the generated cask carries
-# working on_macos and on_linux blocks and `brew install` covers both, same as
-# node's akash.rb formula does.
-homebrew_casks:
+# A formula at the tap root, alongside akash.rb and akash-provider-services.rb,
+# rather than a cask under Casks/. Two reasons beyond matching the siblings:
+# Homebrew refuses to install a cask from an untrusted third-party tap until
+# the user runs `brew trust`, which a formula does not require, and akt is a
+# plain CLI binary rather than a macOS application bundle.
+#
+# `brews` is deprecated in favour of `homebrew_casks` and goreleaser will drop
+# it eventually; when that happens this has to move to a formula generated some
+# other way, not to a cask, or the trust prompt comes back. See release-check
+# in make/releasing.mk, which tolerates the deprecation warning.
+brews:
   - name: akt
-    binaries:
-      - akt
     ids:
       - akt
     # The tap is a different repository, so the release job's GITHUB_TOKEN --
@@ -204,28 +207,17 @@ homebrew_casks:
       name: homebrew-tap
       branch: main
       token: "{{ .Env.GORELEASER_ACCESS_TOKEN }}"
-    directory: Casks
+    # Repository root, where akash.rb and akash-provider-services.rb live.
+    directory: .
     homepage: "https://akash.network"
     description: "Unified CLI for the Akash Network"
     license: "Apache-2.0"
-    # Publish on prereleases too -- there is no stable release yet, so `auto`
-    # would leave the tap empty. Switch to `auto` at the first stable tag, or
-    # an alpha will downgrade `brew install akt` users.
-    skip_upload: false
-    hooks:
-      post:
-        # The darwin binaries are neither signed nor notarized, so Gatekeeper
-        # quarantines them on download and the first run dies with "cannot be
-        # opened because the developer cannot be verified". Strip the attribute
-        # at install time. Remove this once the release is signed and notarized.
-        #
-        # Guarded on OS.mac?: the hook is emitted outside the on_macos block and
-        # so runs on Linux too, where /usr/bin/xattr does not exist and the
-        # install would fail on a quarantine flag that platform never sets.
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/akt"]
-          end
+    # Skip prereleases: `brew install akt` must keep resolving to the newest
+    # stable build, and an alpha reaching the tap would downgrade everyone on
+    # it. Same gate node applies with is_prerelease.sh.
+    skip_upload: auto
+    test: |
+      system "#{bin}/akt", "version"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}"

--- a/make/releasing.mk
+++ b/make/releasing.mk
@@ -90,9 +90,24 @@ GORELEASER := docker run $(GORELEASER_DOCKER_ARGS) $(GORELEASER_IMAGE)
 release-libs:
 
 # Validate .goreleaser.yaml. Cheap, needs no build.
+#
+# `goreleaser check` exits non-zero on a deprecated property even when the
+# config is otherwise valid, and akt uses one deliberately: `brews`, to publish
+# a Homebrew formula rather than a cask (see .goreleaser.yaml for why). Failing
+# the gate on that would mean either dropping the gate or shipping a cask, so
+# the deprecation-only outcome is tolerated -- and only that one. Any other
+# error still fails, and the warning is printed so the eventual removal of
+# `brews` is not a surprise.
 .PHONY: release-check
 release-check: $(GORELEASER_DOCKER_CONFIG)/config.json
-	$(GORELEASER) check $(GORELEASER_ARGS)
+	@out=$$($(GORELEASER) check $(GORELEASER_ARGS) 2>&1); status=$$?; \
+	echo "$$out"; \
+	if [ $$status -eq 0 ]; then exit 0; fi; \
+	if echo "$$out" | grep -q 'configuration is valid, but uses deprecated properties'; then \
+		echo "release-check: passing on deprecation warnings only"; \
+		exit 0; \
+	fi; \
+	exit $$status
 
 # Full cross-compile with a synthetic version, no tag and no publishing.
 # Artifacts land in .cache/goreleaser.
@@ -111,11 +126,12 @@ release-dry-run: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 # running it by hand needs a GITHUB_TOKEN with contents:write. Tokens are
 # passed by name so they never land in the echoed command line.
 #
-# GORELEASER_ACCESS_TOKEN writes the cask to akash-network/homebrew-tap, which
-# GITHUB_TOKEN cannot reach. Needs contents:write, and is required for every
-# release since skip_upload is false. Defaulted to empty because
-# `{{ .Env.X }}` fails to render when X is unset at all, which would kill the
-# release before it built anything.
+# GORELEASER_ACCESS_TOKEN writes the Homebrew formula to
+# akash-network/homebrew-tap, which GITHUB_TOKEN cannot reach. Needs
+# contents:write. Only stable releases touch the tap (skip_upload: auto), so a
+# prerelease succeeds without it. Defaulted to empty because `{{ .Env.X }}`
+# fails to render when X is unset at all, which would kill the release before
+# it built anything.
 .PHONY: release
 release: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 	@if [ -z "$${GITHUB_TOKEN}" ]; then \
@@ -123,7 +139,7 @@ release: release-libs $(GORELEASER_DOCKER_CONFIG)/config.json
 		exit 1; \
 	fi
 	@if [ -z "$${GORELEASER_ACCESS_TOKEN}" ]; then \
-		echo "warning: GORELEASER_ACCESS_TOKEN unset -- this release will fail at the Homebrew cask step"; \
+		echo "warning: GORELEASER_ACCESS_TOKEN unset -- a stable release will fail at the Homebrew formula step"; \
 	fi
 	GORELEASER_ACCESS_TOKEN="$${GORELEASER_ACCESS_TOKEN:-}" \
 	docker run $(GORELEASER_DOCKER_ARGS) -e GITHUB_TOKEN -e GORELEASER_ACCESS_TOKEN $(GORELEASER_IMAGE) release --clean $(GORELEASER_ARGS)


### PR DESCRIPTION
`akt` landed in the tap as `Casks/akt.rb`, while its siblings — `akash.rb` and `akash-provider-services.rb` — are formulae at the repository root. `akt` is a plain CLI binary, not a macOS application bundle, so it belongs with them.

The cask also costs users a step. Homebrew refuses to install a cask from an untrusted third-party tap:

```
Error: Refusing to load cask akash-network/tap/akt from untrusted tap akash-network/tap.
Run `brew trust --cask akash-network/tap/akt` to trust it.
```

A formula needs no such step, so the install is back to two commands:

```bash
brew tap akash-network/tap
brew install akt
```

## Why it was a cask, and why that was wrong

`brews` is deprecated and `goreleaser check` exits non-zero on it, which would have failed `make release-check`. I took the cask to keep that gate green. That was the wrong trade.

`brews` still works — a snapshot build generates a valid formula (`class Akt < Formula`, `ruby -c` clean, both platforms). Only `check` objects, and its own message says *"configuration is valid, but uses deprecated properties"*.

So `release-check` now tolerates a deprecation-only result and nothing else:

- deprecated `brews` → passes, warning printed
- unknown field (`bogus_field_that_does_not_exist`) → **still fails**, verified

## Follow-up

`brews` will eventually be removed from goreleaser. When it is, this has to move to a formula generated another way — not back to a cask, or the trust prompt returns. That's noted in the config where someone will actually read it.

## Needs doing alongside the merge

`Casks/akt.rb` must be deleted from the tap, or Homebrew sees both a cask and a formula named `akt`. I don't have write access there (`push=false`).