### PR TITLE
build: retract v0.0.1 and the deleted prerelease tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,16 @@ module pkg.akt.dev/akt
 
 go 1.26.1
 
+// v0.0.1 resolves to an unrelated commit. It was tagged in March under the
+// ovrclk namespace, and proxy.golang.org and sum.golang.org recorded it then;
+// both are append-only, so retagging the repository cannot change what a
+// `go get` returns. The prerelease tags were deleted from the repository but
+// are likewise still served by the proxy.
+retract (
+	v0.0.1
+	[v0.0.1-a0, v0.0.1-a5]
+)
+
 require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.2


### PR DESCRIPTION
`v0.0.1` resolves to an unrelated commit. It was tagged in March under the ovrclk namespace, and the module proxy recorded it then:

```json
{"Version":"v0.0.1","Time":"2026-03-24T02:04:25Z",
 "Origin":{"Hash":"8d2d4ed855a24011978d92e7fa479eca124943df","Ref":"refs/tags/v0.0.1"}}
```

with the hash logged in the checksum database:

```
pkg.akt.dev/akt v0.0.1 h1:p2gTS3BbsANppOs2gA9JH9QXy7yAinUwCiKZbOBN3Xo=
```

Both are append-only, so retagging the repository cannot change what `go get` returns. Users on the proxy silently receive the March tree; users on `GOPROXY=direct` get a checksum mismatch against the log. Deleting the tag on GitHub changes neither.

Retracting is the supported way to withdraw a published version. The prerelease tags were deleted from the repository but the proxy still serves them, so they are retracted in the same range.

**This must merge before the next tag** — a retraction only takes effect for anyone resolving a later version.

Next release is `v0.0.2`.