### PR TITLE
fix(cli): resolve the context's default account to an address

### DIFF
--- a/internal/client/context.go
+++ b/internal/client/context.go
@@ -42,8 +42,27 @@ func BuildClientContext(
 		WithKeyringDir(aktctx.KeyringDir(rc.Root, rc.Keyring))
 
 	// Set default account if configured.
+	//
+	// WithFrom records the name only; FromName and FromAddress stay empty
+	// until something resolves the name against the keyring. Tx commands do
+	// that themselves, queries never do -- so every query that falls back to
+	// the default account saw no address and reported "no default account
+	// set" on a context that had one configured and displayed. Resolve it
+	// here so both paths agree.
+	//
+	// A name that is not in the keyring is left as the bare From value rather
+	// than failing: the context is built for every command, including the
+	// keys and context commands someone would use to fix it.
 	if rc.DefaultAccount != "" {
 		cctx = cctx.WithFrom(rc.DefaultAccount)
+
+		if kr != nil {
+			if rec, err := kr.Key(rc.DefaultAccount); err == nil {
+				if addr, err := rec.GetAddress(); err == nil {
+					cctx = cctx.WithFromName(rc.DefaultAccount).WithFromAddress(addr)
+				}
+			}
+		}
 	}
 
 	// Set broadcast mode.


### PR DESCRIPTION
`WithFrom` records the account *name*; `FromName` and `FromAddress` stay empty until something resolves that name against the keyring. Tx commands do it themselves. Queries never did, so every query falling back to the default account saw no address.

## Two consequences

**1. The error tells you to do something you already did.**

```
$ akt context keys list
NAME  TYPE   ADDRESS                                       PUBKEY
k1    local  akash1ahy35r3wvyp5vescy2743k6g43g5mhertn8g45  032b49d4...

$ akt context show
  Default Account:  k1

$ akt q deployment 12345
deployment filter: no default account set; provide owner address or configure default-account
```

**2. The quiet one — `akt q deployment` returned other people's deployments.**

Documented as listing the deployments owned by the default account. An empty owner means no filter, so it listed the network instead:

```
no-arg query, on an account that owns nothing:
  before:  100 deployments
  after:     0 deployments
```

## Fix

Resolve the name through the keyring where the context is built, setting `FromName`/`FromAddress` alongside `From`. That repairs every query taking an optional owner — deployment, order, bid, lease, escrow — and both symptoms above.

A name absent from the keyring is left as the bare `From` value rather than failing, since this context is built for *every* command, including the `keys` and `context` commands someone would use to correct it.

## Verified

A/B against `main` on an identical home:

```
                 main                                    this branch
bare dseq   "no default account set"                rpc NotFound (reaches the chain)
no-arg      100 deployments (not the user's)        0 deployments (correct)
```

Full suite and lint clean.

## Related

Unblocks #27, which documents `<dseq>` as a supported form for these commands. That's accurate once this lands.