### PR TITLE
fix(mcp): make the chain tools actually work

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- **MCP provider tools reached authenticated gateway endpoints anonymously**: provider status, lease status, service status, and manifest submission now use the shared provider gateway client, which attaches the resolved wallet's JWT. The MCP inventory documentation now matches the capability-driven 27 read / 33 total maximum.
+
+- **`console_wallet_balance` returned µACT while describing Console credits**: the MCP result now exposes `available_usd`, `in_deployments_usd`, and `total_usd`, derived from the Console balance helpers, so a `$17.94` balance cannot be mistaken for `17,940,000` dollars.
+
 - **`akt q staking params`/`pool` could panic on a sparse response**: proto3 omits zero-valued fields, so an unset `LegacyDec`/`Int` unmarshals with a nil inner `big.Int` and any arithmetic on it panics — `FormatPercentDec` and `FormatDecAsAKT` did exactly that. Two independent reviewers hit it. Formatting now goes through `DecOrZero`/`IntOrZero`, so an omitted field renders as `0` instead of crashing the command. 3 regression tests.
 
 - **A failed config write reported success**: `SaveConfig` deferred `f.Close()` on the file it had just created, discarding the flush error — a full disk or I/O failure while writing `config.yaml` returned nil. The store's YAML export had the same bug (a truncated export reported success). Both now close explicitly and return the error.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -219,6 +219,14 @@ Each context has an `auth-method` that determines how transactions are signed an
 
 A context uses **one** auth method. Users who need both can create separate contexts (e.g., `prod` with keyring auth and `console` with console-api auth), potentially sharing the same network definition.
 
+The MCP adapter follows the same boundary. Chain-backed provider gateway tools
+must construct clients through `internal/provider.NewGatewayClient`, using the
+resolved account and keyring to attach a wallet-signed JWT. An MCP handler may
+select a provider URL, but it may not create an unauthenticated provider REST
+client of its own. Console MCP tools likewise translate Console wire values
+into the semantic units promised by their schemas before returning them to a
+client.
+
 #### 3.1.5 Console Provider Gateway Access
 
 A `console-api` context has no wallet, yet the operations users reach for most after a deployment goes live — container logs, cluster events, live lease status, an interactive shell — are served by the **provider's** gateway, not by the Console API. `akt` reaches those gateways directly from a managed context, with no wallet and no local signing key involved (`internal/cli/console/gateway.go`):

--- a/SPEC.md
+++ b/SPEC.md
@@ -1633,19 +1633,26 @@ akt events --module market --output json
 
 #### `akt mcp`
 
-Start an MCP (Model Context Protocol) server over stdio transport for AI assistant integration. The server exposes Akash Network tools that AI assistants can invoke to query chain state, check provider status, and (with explicit permission) perform mutating operations.
+Start an MCP (Model Context Protocol) server over stdio transport. The server exposes Akash Network tools that compatible clients can invoke to query chain state, check provider status, and (with explicit permission) perform mutating operations.
 
-Configuration is resolved from the active akt context (network, keyring, default account). No additional environment variables are required beyond a configured context.
+Configuration is resolved from the active akt context (network, keyring, default account). Console tools are registered when a Console API key resolves through `--console-api-key`, `AKT_CONSOLE_API_KEY`, or the active context credential.
 
-| Flag               | Type | Default | Description                                                                       |
-| ------------------ | ---- | ------- | --------------------------------------------------------------------------------- |
-| `--enable-writes`  | bool | `false` | Enable write tools (on-chain transactions and provider mutations). Without this flag, only read-only query tools are available. |
+| Flag                | Type   | Default | Description                                                                       |
+| ------------------- | ------ | ------- | --------------------------------------------------------------------------------- |
+| `--console-api-key` | string | `""`    | Console API key for this process; overrides environment and context credentials.  |
+| `--enable-writes`   | bool   | `false` | Enable write tools (on-chain transactions and provider mutations). Without this flag, only read-only query tools are available. |
 
 **Permission model:**
 
-By default, only read-only query tools are registered. This prevents AI agents from sending unapproved transactions or performing mutating operations. The `--enable-writes` flag must be explicitly passed to enable write tools. This flag covers both on-chain transactions (which require keyring signing) and mutating provider REST API calls (e.g., submitting manifests).
+By default, only read-only query tools are registered. This prevents an MCP client from sending unapproved transactions or performing mutating operations. The `--enable-writes` flag must be explicitly passed to enable write tools. This flag covers both on-chain transactions (which require keyring signing), Console mutations, and mutating provider REST API calls (e.g., submitting manifests).
 
-**Read-only tools (always available, 21 tools):**
+The inventory is capability-driven. A chain RPC registers 19 read tools; a
+Console credential registers eight. With both configured, `tools/list`
+returns 27 read-only tools. `--enable-writes` adds four chain/provider writes
+and two Console writes, for 33 tools total. A server with only one rail exposes
+only that rail's subset.
+
+**Read-only tools (up to 27 tools):**
 
 | Tool Name                      | Description                                                                |
 | ------------------------------ | -------------------------------------------------------------------------- |
@@ -1668,8 +1675,16 @@ By default, only read-only query tools are registered. This prevents AI agents f
 | `akash_service_status`         | Service status within a lease                                              |
 | `akash_list_audited_providers` | List audited provider attributes                                           |
 | `akash_list_certificates`      | List on-chain certificates                                                 |
+| `console_list_deployments`     | List deployments belonging to the configured Console account              |
+| `console_get_deployment`       | Get one Console-managed deployment                                         |
+| `console_list_bids`            | List bids for a Console-managed deployment                                 |
+| `console_wallet_balance`       | Available, in-deployment, and total Console credits in USD                  |
+| `console_usage_history`        | Get Console spend history                                                  |
+| `console_list_providers`       | List providers in the Console catalog                                      |
+| `console_get_provider`         | Get one provider from the Console catalog                                  |
+| `console_gpu_prices`           | List current Console GPU pricing                                           |
 
-**Write tools (only with `--enable-writes`, 4 tools):**
+**Write tools (only with `--enable-writes`, up to 6 tools):**
 
 | Tool Name                      | Description                                                                |
 | ------------------------------ | -------------------------------------------------------------------------- |
@@ -1677,17 +1692,21 @@ By default, only read-only query tools are registered. This prevents AI agents f
 | `akash_create_lease`           | Create a lease from a bid (on-chain transaction)                           |
 | `akash_close_lease`            | Close an active lease (on-chain transaction)                               |
 | `akash_submit_manifest`        | Submit manifest to provider (provider REST mutation)                       |
+| `console_close_deployment`     | Close a Console-managed deployment                                         |
+| `console_deposit`              | Add USD credit to a Console-managed deployment                             |
 
-**Transport:** stdio (JSON-RPC over stdin/stdout). Designed for use with MCP-compatible AI assistants (e.g., Claude Desktop).
+**Transport:** stdio (JSON-RPC over stdin/stdout). Designed for use with any MCP-compatible client.
 
-**Client implementation:** Uses `v1beta3.LightClient` from chain-sdk for read-only mode, `v1beta3.Client` for write mode.
+**Client implementation:** Uses `v1beta3.LightClient` from chain-sdk for read-only mode, `v1beta3.Client` for write mode, and the shared authenticated provider gateway client for provider REST tools. A `provider_url` selects the endpoint; it does not disable authentication. Keyring contexts attach a wallet-signed JWT, and missing signing identity is reported before the request.
+
+**Money units:** `console_wallet_balance` returns explicit `available_usd`, `in_deployments_usd`, and `total_usd` numbers. Console's integer µACT wire values must not leak through this semantic interface.
 
 **Default account handling:** Tools that accept an `owner` parameter (e.g., `akash_list_deployments`, `akash_list_leases`) default to the context's `default-account` when the parameter is omitted. If no `default-account` is configured (e.g., a monitoring-only context), the `owner` parameter is **required** — the tool returns an error explaining that the owner must be specified explicitly when no default account is available.
 
 **Examples:**
 
 ```bash
-# Read-only mode (default, safe for AI agents)
+# Read-only mode (default)
 akt mcp
 
 # With write tools enabled (explicit user consent)
@@ -4958,7 +4977,7 @@ Cobra provides this feature via `Command.SuggestionsMinimumDistance` and `Comman
 | 2.9  | Store status command    | Display store info, sync state, record counts                                                                                  | Accurate reporting of store contents                                      |
 | 2.10 | Events command          | Live blockchain event streaming                                                                                                | `akt events` shows real-time events                                       |
 | 2.11 | Console API client      | `auth-method: console-api` support, API key resolved flag > env > per-context stored credential (§7.1), deployment CRUD via Console managed wallet API, `akt console` command group (§2.9) | Create, update, close deployments; list bids; create leases via Console API with the API key resolved per §7.1 |
-| 2.12 | MCP server              | `akt mcp` command with stdio JSON-RPC transport, 21 read-only tools, 4 write tools gated behind `--enable-writes`              | Read-only tools query chain state; write tools send transactions. Config resolved from active context. |
+| 2.12 | MCP server              | `akt mcp` command with stdio JSON-RPC transport, up to 27 read-only tools and 6 write tools gated behind `--enable-writes`     | Read-only tools query the configured chain and/or Console rail; write tools are opt-in. Provider calls authenticate through the shared gateway client. |
 
 ### Phase 3: TUI Mode
 

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os/exec"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -65,6 +66,76 @@ func mcpToolsList(t *testing.T, home string, extra ...string) []map[string]any {
 	t.Fatalf("no tools/list response\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
 
 	return nil
+}
+
+func TestMCPToolInventory(t *testing.T) {
+	// Tool registration only needs the presence of a key; tools/list does not
+	// call the Console API. This keeps the full two-rail inventory hermetic.
+	t.Setenv("AKT_CONSOLE_API_KEY", "test-key")
+
+	home := t.TempDir()
+	initHome(t, home)
+	mustRunAkt(t, home, "context", "network", "create", "net", "--chain-id", "akashnet-2", "--rpc", unreachableNode)
+	mustRunAkt(t, home, "context", "create", "ctx", "--network", "net", "--set-current")
+
+	readNames := []string{
+		"akash_account_balance",
+		"akash_block_height",
+		"akash_get_bid",
+		"akash_get_deployment",
+		"akash_get_group",
+		"akash_get_lease",
+		"akash_get_order",
+		"akash_get_provider",
+		"akash_lease_status",
+		"akash_list_audited_providers",
+		"akash_list_bids",
+		"akash_list_certificates",
+		"akash_list_deployments",
+		"akash_list_leases",
+		"akash_list_orders",
+		"akash_list_providers",
+		"akash_node_status",
+		"akash_provider_status",
+		"akash_service_status",
+		"console_get_deployment",
+		"console_get_provider",
+		"console_gpu_prices",
+		"console_list_bids",
+		"console_list_deployments",
+		"console_list_providers",
+		"console_usage_history",
+		"console_wallet_balance",
+	}
+	writes := []string{
+		"akash_close_deployment",
+		"akash_close_lease",
+		"akash_create_lease",
+		"akash_submit_manifest",
+		"console_close_deployment",
+		"console_deposit",
+	}
+
+	assertToolNames(t, mcpToolsList(t, home), readNames)
+	assertToolNames(t, mcpToolsList(t, home, "--enable-writes"), append(readNames, writes...))
+}
+
+func assertToolNames(t *testing.T, tools []map[string]any, want []string) {
+	t.Helper()
+
+	want = append([]string(nil), want...)
+	got := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		got = append(got, name)
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("tool inventory mismatch\ngot (%d):\n%s\nwant (%d):\n%s",
+			len(got), strings.Join(got, "\n"), len(want), strings.Join(want, "\n"))
+	}
 }
 
 func annotation(tool map[string]any, key string) (bool, bool) {

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -155,3 +155,103 @@ func TestMCPWriteToolsRequireOptIn(t *testing.T) {
 		t.Error("--enable-writes registered no tools marked as mutating")
 	}
 }
+
+// mcpCallTool performs the initialize handshake and one tools/call, returning
+// the call's result plus whatever the server wrote to stderr. Both matter: a
+// handler that dereferences a missing dependency takes the process down, and
+// that only shows up on stderr.
+func mcpCallTool(t *testing.T, home, tool string) (result map[string]any, stderr string) {
+	t.Helper()
+
+	call, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+		"params": map[string]any{"name": tool, "arguments": map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("marshal call: %v", err)
+	}
+
+	cmd := exec.Command(aktBinary(t), "--home", home, "mcp")
+	cmd.Stdin = strings.NewReader(strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"1"}}}`,
+		string(call),
+	}, "\n") + "\n")
+
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start akt mcp: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("akt mcp did not exit; stderr:\n%s", errb.String())
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		var resp struct {
+			ID     int            `json:"id"`
+			Result map[string]any `json:"result"`
+		}
+		if json.Unmarshal([]byte(line), &resp) == nil && resp.ID == 2 {
+			return resp.Result, errb.String()
+		}
+	}
+
+	return nil, errb.String()
+}
+
+// TestMCPChainToolReachesTheNode calls a chain-backed tool, which is the only
+// way to catch a server that lists its tools correctly and then cannot run
+// them.
+//
+// The command builds its client context from the cobra command, which carries
+// a node URI but no RPC client — the tx and query trees each construct one in
+// their own PersistentPreRunE, and mcp has neither. Every chain tool therefore
+// failed: the query tools reported being offline, and the node tools
+// dereferenced the missing client and killed the process. Listing the tools
+// and calling a Console tool both pass in that state, which is how it shipped.
+//
+// The node here is unreachable on purpose, so the call must fail — but it has
+// to fail as a transport error, having reached the point of dialling.
+func TestMCPChainToolReachesTheNode(t *testing.T) {
+	home := t.TempDir()
+	initHome(t, home)
+	mustRunAkt(t, home, "context", "network", "create", "net", "--chain-id", "akashnet-2", "--rpc", unreachableNode)
+	mustRunAkt(t, home, "context", "create", "ctx", "--network", "net", "--set-current")
+
+	// A node tool: these are the ones that panicked rather than erroring.
+	result, stderr := mcpCallTool(t, home, "akash_block_height")
+
+	if strings.Contains(stderr, "panic:") {
+		t.Fatalf("calling a chain tool panicked:\n%s", stderr)
+	}
+
+	if result == nil {
+		t.Fatalf("no response to tools/call; the server likely died\nstderr:\n%s", stderr)
+	}
+
+	text := ""
+	if content, ok := result["content"].([]any); ok && len(content) > 0 {
+		if first, ok := content[0].(map[string]any); ok {
+			text, _ = first["text"].(string)
+		}
+	}
+
+	// "offline mode" is what the client reports when it was handed no RPC
+	// client at all -- the bug -- as distinct from failing to reach the node.
+	if strings.Contains(text, "no RPC client") || strings.Contains(text, "offline mode") {
+		t.Fatalf("the chain tool was given no RPC client: %s", text)
+	}
+
+	if !strings.Contains(text, "connection refused") && !strings.Contains(text, "dial") {
+		t.Fatalf("expected a transport error from the unreachable node, got: %s", text)
+	}
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
+	aclient "pkg.akt.dev/go/node/client"
+
 	"pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
 	aktmcp "pkg.akt.dev/akt/internal/mcp"
@@ -51,6 +53,21 @@ close lease, and submit manifest.`,
 			// same value the flag would have.
 			if enableWrites && cctx.SignModeStr == "" {
 				cctx = cctx.WithSignModeStr(flags.SignModeDirect)
+			}
+
+			// Attach an RPC client. The tx and query trees build one in their
+			// own PersistentPreRunE; this command has neither, so the context
+			// arrives with a node URI and no client. Every chain tool then
+			// fails -- the query tools with "no RPC client is defined in
+			// offline mode", and the node tools by dereferencing the missing
+			// client, which takes the whole server down.
+			if cctx.Client == nil && cctx.NodeURI != "" {
+				rpcClient, err := aclient.NewClient(ctx, cctx.NodeURI)
+				if err != nil {
+					return fmt.Errorf("connect to %s: %w", cctx.NodeURI, err)
+				}
+
+				cctx = cctx.WithClient(rpcClient)
 			}
 
 			srv, err := aktmcp.New(ctx, cctx, enableWrites, consoleClientFor(cmd, mgrFn))

--- a/internal/mcp/tools/console/tools.go
+++ b/internal/mcp/tools/console/tools.go
@@ -122,7 +122,7 @@ func HandleListBids(cl *console.Client) mcpserver.ToolHandlerFunc {
 func ToolWalletBalance() mcp.Tool {
 	return mcp.NewTool(
 		"console_wallet_balance",
-		mcp.WithDescription("Get the balance of the Console-managed wallet: available credits, total, and any amount held in escrow by open deployments."),
+		mcp.WithDescription("Get the Console-managed wallet's available, in-deployment, and total balances in USD."),
 	)
 }
 
@@ -134,7 +134,15 @@ func HandleWalletBalance(cl *console.Client) mcpserver.ToolHandlerFunc {
 			return marshal.ErrResultf("failed to get wallet balance: %v", err), nil
 		}
 
-		return marshal.ToTextResult(resp)
+		return marshal.ToTextResult(struct {
+			AvailableUSD     float64 `json:"available_usd"`
+			InDeploymentsUSD float64 `json:"in_deployments_usd"`
+			TotalUSD         float64 `json:"total_usd"`
+		}{
+			AvailableUSD:     resp.BalanceUSD(),
+			InDeploymentsUSD: resp.DeploymentsUSD(),
+			TotalUSD:         resp.TotalUSD(),
+		})
 	}
 }
 

--- a/internal/mcp/tools/console/tools.go
+++ b/internal/mcp/tools/console/tools.go
@@ -155,9 +155,33 @@ func ToolUsageHistory() mcp.Tool {
 // HandleUsageHistory returns the handler for console_usage_history.
 func HandleUsageHistory(cl *console.Client) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// The address is resolved server-side from the API key, so it is not
-		// exposed as a tool argument.
-		resp, err := cl.GetUsageHistory(ctx, "",
+		// The endpoint needs the managed wallet's on-chain address; it is not
+		// derived from the API key, and sending an empty one is rejected. Look
+		// it up the same way `akt console usage` does rather than making the
+		// caller supply an address they have no way to know.
+		user, err := cl.GetUser(ctx)
+		if err != nil {
+			return marshal.ErrResultf("get user: %v", err), nil
+		}
+
+		wallets, err := cl.ListWallets(ctx, user.ID)
+		if err != nil {
+			return marshal.ErrResultf("list wallets: %v", err), nil
+		}
+
+		address := ""
+		for _, w := range wallets {
+			if w.Address != "" {
+				address = w.Address
+				break
+			}
+		}
+
+		if address == "" {
+			return marshal.ErrResult("no managed wallet with an on-chain address was found"), nil
+		}
+
+		resp, err := cl.GetUsageHistory(ctx, address,
 			marshal.OptionalString(req, "start_date"),
 			marshal.OptionalString(req, "end_date"),
 		)

--- a/internal/mcp/tools/console/tools_test.go
+++ b/internal/mcp/tools/console/tools_test.go
@@ -1,0 +1,59 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	aktconsole "pkg.akt.dev/akt/internal/console"
+)
+
+func TestWalletBalanceReturnsExplicitUSDFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"balance":17937977,"deployments":39437176,"total":57375153}}`))
+	}))
+	defer srv.Close()
+
+	result, err := HandleWalletBalance(aktconsole.New(srv.URL, "test-key"))(
+		context.Background(),
+		mcp.CallToolRequest{},
+	)
+	if err != nil {
+		t.Fatalf("handler returned an error: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handler returned an MCP error: %#v", result)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("content items = %d, want 1", len(result.Content))
+	}
+
+	content, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content type = %T, want mcp.TextContent", result.Content[0])
+	}
+
+	var got map[string]float64
+	if err := json.Unmarshal([]byte(content.Text), &got); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, content.Text)
+	}
+
+	want := map[string]float64{
+		"available_usd":      17.937977,
+		"in_deployments_usd": 39.437176,
+		"total_usd":          57.375153,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("result fields = %#v, want exactly %#v", got, want)
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Errorf("%s = %v, want %v", key, got[key], value)
+		}
+	}
+}

--- a/internal/mcp/tools/provider/tools.go
+++ b/internal/mcp/tools/provider/tools.go
@@ -3,11 +3,10 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	manifest "pkg.akt.dev/go/manifest/v2beta3"
 	v1beta3 "pkg.akt.dev/go/node/client/v1beta3"
@@ -16,6 +15,7 @@ import (
 	rest "pkg.akt.dev/go/provider/client"
 
 	"pkg.akt.dev/akt/internal/mcp/marshal"
+	aktprovider "pkg.akt.dev/akt/internal/provider"
 )
 
 // --- On-chain provider query tools ---
@@ -91,7 +91,7 @@ func HandleProviderStatus(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			return marshal.ErrResultf("%v", err), nil
 		}
 
-		rcl, err := rest.NewClient(ctx, sdk.AccAddress{}, rest.WithProviderURL(providerURL))
+		rcl, err := gatewayClient(ctx, cl, providerURL)
 		if err != nil {
 			return marshal.ErrResultf("failed to create provider client: %v", err), nil
 		}
@@ -151,7 +151,7 @@ func HandleLeaseStatus(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			return marshal.ErrResultf("%v", err), nil
 		}
 
-		rcl, err := rest.NewClient(ctx, cl.ClientContext().GetFromAddress(), rest.WithProviderURL(providerURL))
+		rcl, err := gatewayClient(ctx, cl, providerURL)
 		if err != nil {
 			return marshal.ErrResultf("failed to create provider client: %v", err), nil
 		}
@@ -226,7 +226,7 @@ func HandleServiceStatus(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			return marshal.ErrResultf("%v", err), nil
 		}
 
-		rcl, err := rest.NewClient(ctx, cl.ClientContext().GetFromAddress(), rest.WithProviderURL(providerURL))
+		rcl, err := gatewayClient(ctx, cl, providerURL)
 		if err != nil {
 			return marshal.ErrResultf("failed to create provider client: %v", err), nil
 		}
@@ -290,7 +290,7 @@ func HandleSubmitManifest(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			return marshal.ErrResultf("invalid manifest JSON: %v", err), nil
 		}
 
-		rcl, err := rest.NewClient(ctx, cl.ClientContext().GetFromAddress(), rest.WithProviderURL(providerURL))
+		rcl, err := gatewayClient(ctx, cl, providerURL)
 		if err != nil {
 			return marshal.ErrResultf("failed to create provider client: %v", err), nil
 		}
@@ -301,4 +301,17 @@ func HandleSubmitManifest(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 
 		return marshal.ToTextResult(map[string]string{"status": "manifest submitted successfully"})
 	}
+}
+
+func gatewayClient(ctx context.Context, cl v1beta3.LightClient, providerURL string) (rest.Client, error) {
+	cctx := cl.ClientContext()
+	addr := cctx.GetFromAddress()
+	if addr.Empty() {
+		return nil, fmt.Errorf("provider gateway authentication requires a configured default account")
+	}
+	if cctx.Keyring == nil {
+		return nil, fmt.Errorf("provider gateway authentication requires a keyring")
+	}
+
+	return aktprovider.NewGatewayClient(ctx, cctx, addr, providerURL, "jwt", cctx.Keyring)
 }

--- a/internal/mcp/tools/provider/tools_test.go
+++ b/internal/mcp/tools/provider/tools_test.go
@@ -1,0 +1,179 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	v1beta3 "pkg.akt.dev/go/node/client/v1beta3"
+
+	aktcodec "pkg.akt.dev/akt/internal/codec"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
+)
+
+type contextLightClient struct {
+	cctx sdkclient.Context
+}
+
+func (cl contextLightClient) Query() v1beta3.QueryClient { return nil }
+func (cl contextLightClient) Node() v1beta3.NodeClient   { return nil }
+func (cl contextLightClient) ClientContext() sdkclient.Context {
+	return cl.cctx
+}
+func (contextLightClient) PrintMessage(interface{}) error { return nil }
+func (contextLightClient) PrintJSON(interface{}) error    { return nil }
+
+func TestProviderGatewayHandlersAuthenticate(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "Bearer ") {
+			http.Error(w, "missing bearer token", http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cl := newSignedLightClient(t)
+	tests := []struct {
+		name    string
+		handler mcpserver.ToolHandlerFunc
+		args    map[string]any
+	}{
+		{
+			name:    "provider status",
+			handler: HandleProviderStatus(cl),
+			args:    map[string]any{"provider_url": srv.URL},
+		},
+		{
+			name:    "lease status",
+			handler: HandleLeaseStatus(cl),
+			args: map[string]any{
+				"provider_url": srv.URL,
+				"dseq":         float64(1),
+				"gseq":         float64(1),
+				"oseq":         float64(1),
+			},
+		},
+		{
+			name:    "service status",
+			handler: HandleServiceStatus(cl),
+			args: map[string]any{
+				"provider_url": srv.URL,
+				"dseq":         float64(1),
+				"gseq":         float64(1),
+				"oseq":         float64(1),
+				"service":      "web",
+			},
+		},
+		{
+			name:    "submit manifest",
+			handler: HandleSubmitManifest(cl),
+			args: map[string]any{
+				"provider_url":  srv.URL,
+				"dseq":          float64(1),
+				"manifest_json": `[]`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.handler(context.Background(), mcp.CallToolRequest{
+				Params: mcp.CallToolParams{Arguments: tt.args},
+			})
+			if err != nil {
+				t.Fatalf("handler returned an error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("handler returned no result")
+			}
+			if result.IsError {
+				t.Fatalf("handler returned an MCP error: %s", resultText(result))
+			}
+		})
+	}
+
+	if requests != len(tests) {
+		t.Fatalf("gateway requests = %d, want %d", requests, len(tests))
+	}
+}
+
+func TestGatewayClientRequiresSigningIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		cl   v1beta3.LightClient
+		want string
+	}{
+		{
+			name: "default account",
+			cl:   contextLightClient{},
+			want: "default account",
+		},
+		{
+			name: "keyring",
+			cl: func() v1beta3.LightClient {
+				signed := newSignedLightClient(t).(contextLightClient)
+				signed.cctx = signed.cctx.WithKeyring(nil)
+				return signed
+			}(),
+			want: "keyring",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := gatewayClient(context.Background(), tt.cl, "https://provider.example.com")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want one containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func newSignedLightClient(t *testing.T) v1beta3.LightClient {
+	t.Helper()
+
+	kr := aktkeyring.NewInMemory(aktcodec.MakeEncodingConfig().Codec)
+	record, _, err := kr.NewMnemonic(
+		"testkey",
+		sdkkeyring.English,
+		"m/44'/118'/0'/0/0",
+		"",
+		aktkeyring.DefaultAlgo(),
+	)
+	if err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+
+	addr, err := record.GetAddress()
+	if err != nil {
+		t.Fatalf("get key address: %v", err)
+	}
+
+	return contextLightClient{cctx: sdkclient.Context{}.
+		WithKeyring(kr).
+		WithFromName(record.Name).
+		WithFromAddress(addr)}
+}
+
+func resultText(result *mcp.CallToolResult) string {
+	if len(result.Content) == 0 {
+		return ""
+	}
+	if content, ok := result.Content[0].(mcp.TextContent); ok {
+		return content.Text
+	}
+	return fmt.Sprint(result.Content[0])
+}


### PR DESCRIPTION
Every chain-backed tool in the MCP server was broken. Found by calling all 27 read-only tools rather than only listing them:

```
before:  4 ok, 21 error, 2 panic
after:  18 ok,  9 error, 0 panic
```

(The 9 remaining are test-argument artefacts — `account_balance` and `get_deployment` derive an owner from a configured key, and the `*_status` tools want a gateway URL. Each was checked individually.)

## 1. No RPC client was ever attached

The command builds its context from `GetClientContextFromCmd`, which carries a node URI but no client. The `tx` and `query` trees each construct one in their own `PersistentPreRunE`; `mcp` has neither.

Result: query tools answered `no RPC client is defined in offline mode`, and the two node tools dereferenced the missing client and **panicked, killing the server** — one `tools/call` ended the session.

Fixed by building the client from the node URI before handing the context over, the same way `internal/tui/app.go` already does.

## 2. `console_usage_history` sent an empty address

I wrote that tool assuming Console derives the address from the API key. It doesn't — the endpoint rejects the request, so the tool failed on every call while `akt console usage` worked, because the CLI looks the wallet address up first. Now it does the same.

## 3. The test gap that let this ship

The existing MCP tests list tools and call a *Console* tool. Neither touches the chain client, so a server advertising 19 unusable chain tools passes both.

Added a test that calls a node tool against an unreachable endpoint and requires a **transport** error: reaching the dial proves a client was attached, `offline mode` proves one wasn't, and a panic proves the handler dereferenced it.

Verified it fails without the fix:

```
--- FAIL: TestMCPChainToolReachesTheNode
    mcp_test.go:234: calling a chain tool panicked
```

Verified against mainnet with the fix: `akash_block_height` → `27952075`, `akash_node_status`, `akash_list_providers`, `console_wallet_balance` all return real data.