### PR TITLE
fix: stop answering a different question than the one asked

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -12,7 +12,9 @@
   flag validates its command-specific enum before configuration or network
   work. Bare certificate lists now follow the same owner-scoping contract as
   deployments and market resources: they use the context default account or
-  refuse locally instead of querying every certificate on the network.
+  refuse locally instead of querying every certificate on the network. The
+  localnet query and deployment lifecycle coverage now supplies its validator
+  address explicitly so CI exercises that scoped contract.
 
 - **`akt q staking params`/`pool` could panic on a sparse response**: proto3 omits zero-valued fields, so an unset `LegacyDec`/`Int` unmarshals with a nil inner `big.Int` and any arithmetic on it panics — `FormatPercentDec` and `FormatDecAsAKT` did exactly that. Two independent reviewers hit it. Formatting now goes through `DecOrZero`/`IntOrZero`, so an omitted field renders as `0` instead of crashing the command. 3 regression tests.
 

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 
+- **CLI groups and output flags could accept the wrong input at exit 0**:
+  unknown tokens under completion, IBC, and upgrade groups printed help as a
+  successful command, while leaf-local `--output` strings bypassed the root
+  enum and mapped misspellings such as `josn` to pretty output. Group
+  validation is now applied to the assembled command tree, and every output
+  flag validates its command-specific enum before configuration or network
+  work. Bare certificate lists now follow the same owner-scoping contract as
+  deployments and market resources: they use the context default account or
+  refuse locally instead of querying every certificate on the network.
+
 - **`akt q staking params`/`pool` could panic on a sparse response**: proto3 omits zero-valued fields, so an unset `LegacyDec`/`Int` unmarshals with a nil inner `big.Int` and any arithmetic on it panics — `FormatPercentDec` and `FormatDecAsAKT` did exactly that. Two independent reviewers hit it. Formatting now goes through `DecOrZero`/`IntOrZero`, so an omitted field renders as `0` instead of crashing the command. 3 regression tests.
 
 - **A failed config write reported success**: `SaveConfig` deferred `f.Close()` on the file it had just created, discarding the flush error — a full disk or I/O failure while writing `config.yaml` returned nil. The store's YAML export had the same bug (a truncated export reported success). Both now close explicitly and return the error.

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- **Independent command-tree contract tests used the same package helper**:
+  the input-validation walker now has a domain-specific name so the scoping
+  and executable-help branches compile and run together after merge.
+
 - **CLI groups and output flags could accept the wrong input at exit 0**:
   unknown tokens under completion, IBC, and upgrade groups printed help as a
   successful command, while leaf-local `--output` strings bypassed the root

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -498,6 +498,10 @@ The `chain-sdk` CLI package (`pkg.akt.dev/go/cli`) will be deprecated and eventu
 > current. See the status note at the end of this section.
 
 - **Cobra** handles command parsing, flag management, help generation, and shell completion for CLI mode. It is the standard in the Go and Cosmos SDK ecosystem.
+- **Boundary validation** is applied uniformly to the assembled Cobra tree:
+  pure command groups reject unknown positional tokens instead of treating
+  them as a successful help request, and enum-valued flags reject values not
+  advertised by that command before any configuration or transport work.
 - **Bubbletea v2** (Elm Architecture: Model-Update-View) handles the interactive TUI. Its functional design isolates state management and rendering.
 - **Lipgloss v2** provides CSS-like styling for terminal output in both modes -- table formatting in CLI, full layout composition in TUI.
 - **Bubbles v2** provides battle-tested components: table, viewport, text input, spinner, help, key bindings, list, progress bar, paginator.
@@ -555,6 +559,9 @@ Query commands use a registry-based formatter system (`internal/output/pretty/`)
 | `yaml` | Machine-readable YAML (no colors) |
 
 **Dispatch flow:** Every query command calls `pretty.PrintQueryResult(cmd, cctx, msg)`. This function reads `--output`: if `json` or `yaml`, it delegates to `clientCtx.PrintProto()` with the appropriate Cosmos SDK output format; if `pretty` (the default), it looks up a registered `PrettyFormatter` for the message's protobuf type. If a formatter exists, it renders pretty output; otherwise, it falls back to JSON output. This means new protobuf types automatically get JSON output until a formatter is registered -- no regressions.
+
+The output flag is an enum at the parsing boundary. A misspelling such as
+`-o josn` is a usage error; it must never fall through to pretty output.
 
 **Formatting conventions:**
 - **List results**: Tabwriter-aligned tables with lipgloss-styled headers. State columns are color-coded (green=active/open, yellow=warning states, red=closed/lost, gray=invalid). Key identifiers (DSEQ, moniker) are bolded.

--- a/SPEC.md
+++ b/SPEC.md
@@ -379,6 +379,16 @@ Implementation note: `tx` and `query` commands are clean-copied from `akash-netw
 
 **Help text requirement**: Every command and subcommand must populate cobra's `Example` field with at least one usage example. The example should demonstrate the most common use case with realistic argument values. Commands with multiple modes of operation (e.g., list vs get, interactive vs scripted) should include one example per mode. This ensures that `akt <command> --help` is self-contained -- users should never need to consult external documentation for basic usage.
 
+**Input validation requirement**: A command group prints its help and exits 0
+only when it is invoked without an action. Any non-flag token that does not
+name a child command is an unknown-command error and exits non-zero, including
+for vendored Cosmos SDK and IBC groups. Flags with a documented set of values
+validate that set during argument parsing, before configuration or network
+work begins. In particular, the standard `--output` values are `pretty`,
+`json`, and `yaml`; workflow commands additionally accept `jsonl`, while
+SDK-compatible key and RPC commands that advertise `text|json` accept exactly
+those values.
+
 ### 2.0 Root Command Behavior (`akt` with no subcommand)
 
 When `akt` is invoked with no subcommand, the following flow determines what happens:
@@ -2120,6 +2130,12 @@ State keywords are only recognized as the sole/first component of the filter arg
 | `gseq`           | 0 in list context (no filter); 1 when needed for a unique get                |
 | `oseq`           | 0 in list context (no filter); 1 when needed for a unique get                |
 | Trailing address | Empty — no filter on the trailing identity component                         |
+
+Every owner-scoped list, including `query cert`, must resolve an omitted
+leading address from the active context before sending a request. If the
+context has no default account, the command refuses locally and explains that
+an owner address or `default-account` is required. An empty owner is never sent
+to the chain query service because it means network-wide scope.
 
 #### 3.8.5 Per-Command Filter Scope
 

--- a/e2e/localnet_test.go
+++ b/e2e/localnet_test.go
@@ -358,7 +358,6 @@ func TestLocalnetQueries(t *testing.T) {
 		{"query", "deployment", "params"},
 		{"query", "market", "params"},
 		{"query", "provider", "list"},
-		{"query", "cert", "list"},
 		{"query", "audit", "list"},
 		{"query", "bme", "params"},
 		{"query", "oracle", "params"},
@@ -372,6 +371,7 @@ func TestLocalnetQueries(t *testing.T) {
 		queries = append(queries,
 			[]string{"query", "bank", "balances", addr},
 			[]string{"query", "auth", "account", addr},
+			[]string{"query", "cert", "list", addr},
 			[]string{"query", "deployment", addr},
 			[]string{"query", "market", "order", addr},
 			[]string{"query", "market", "bid", addr},
@@ -426,7 +426,7 @@ func TestLocalnetDeploymentLifecycle(t *testing.T) {
 		mustRunAkt(t, home, "tx", "cert", "publish", "client", "--from", "validator", "--fees", "5000uakt", "--yes")
 
 		if !pollUntil(45*time.Second, func() bool {
-			return strings.Contains(stripANSI(mustRunAkt(t, home, "query", "cert", "list")), "valid")
+			return strings.Contains(stripANSI(mustRunAkt(t, home, "query", "cert", "list", addr)), "valid")
 		}) {
 			t.Fatal("published certificate never became valid on chain")
 		}

--- a/internal/cli/chain/audit_query.go
+++ b/internal/cli/chain/audit_query.go
@@ -30,6 +30,7 @@ func GetQueryAuditCmd() *cobra.Command {
 func GetAuditProvidersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "list",
+		Args:              cobra.NoArgs,
 		Short:             "Query for all providers",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/chain/audit_tx.go
+++ b/internal/cli/chain/audit_tx.go
@@ -35,6 +35,7 @@ func GetTxAuditCmd() *cobra.Command {
 func GetTxAuditAttributesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "attr",
+		RunE:  ValidateCmd,
 		Short: "Manage provider attributes",
 	}
 

--- a/internal/cli/chain/auth_query.go
+++ b/internal/cli/chain/auth_query.go
@@ -160,6 +160,7 @@ func GetQueryAuthAccountAddressByIDCmd() *cobra.Command {
 func GetQueryAuthAccountsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "accounts",
+		Args:              cobra.NoArgs,
 		Short:             "Query all the accounts",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -190,6 +191,7 @@ func GetQueryAuthAccountsCmd() *cobra.Command {
 func GetQueryAuthModuleAccountsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "module-accounts",
+		Args:              cobra.NoArgs,
 		Short:             "Query all module accounts",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/chain/bank_query.go
+++ b/internal/cli/chain/bank_query.go
@@ -161,6 +161,7 @@ func GetQueryBankSpendableBalancesCmd() *cobra.Command {
 func GetQueryBankDenomsMetadataCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "denom-metadata",
+		Args:  cobra.NoArgs,
 		Short: "Query the client metadata for coin denominations",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Query the client metadata for all the registered coin denominations

--- a/internal/cli/chain/bme_query.go
+++ b/internal/cli/chain/bme_query.go
@@ -32,6 +32,7 @@ func GetQueryBMECmd() *cobra.Command {
 func GetBMEParamsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "params",
+		Args:              cobra.NoArgs,
 		Short:             "Query the current BME module parameters",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -58,6 +59,7 @@ func GetBMEParamsCmd() *cobra.Command {
 func GetBMEVaultStateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "vault-state",
+		Args:              cobra.NoArgs,
 		Short:             "Query the current BME vault state",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -84,6 +86,7 @@ func GetBMEVaultStateCmd() *cobra.Command {
 func GetBMEStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "status",
+		Args:              cobra.NoArgs,
 		Short:             "Query status of mint operations",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/chain/cert_query.go
+++ b/internal/cli/chain/cert_query.go
@@ -48,6 +48,7 @@ akt query cert list revoked`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			cl := MustLightClientFromContext(ctx)
+			defaultOwner := cl.ClientContext().GetFromAddress().String()
 
 			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -80,6 +81,13 @@ akt query cert list revoked`,
 				}
 
 				params.Filter.State = args[1]
+			}
+
+			if params.Filter.Owner == "" {
+				if defaultOwner == "" {
+					return requireOwnerScope("certificate filter")
+				}
+				params.Filter.Owner = defaultOwner
 			}
 
 			// FEEDBACK(2026-07): the --owner flag read is disabled for the

--- a/internal/cli/chain/deployment_query.go
+++ b/internal/cli/chain/deployment_query.go
@@ -71,7 +71,10 @@ state rather than printing it.`,
 			}
 
 			// Default owner fallback when no arg and no --owner flag.
-			if dfilters.Owner == "" && defaultOwner != "" {
+			if dfilters.Owner == "" {
+				if defaultOwner == "" {
+					return requireOwnerScope("deployment filter")
+				}
 				dfilters.Owner = defaultOwner
 			}
 

--- a/internal/cli/chain/deployment_query.go
+++ b/internal/cli/chain/deployment_query.go
@@ -219,6 +219,7 @@ func GetQueryDeploymentGroupCmd() *cobra.Command {
 func GetQueryDeploymentParamsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "params",
+		Args:              cobra.NoArgs,
 		Short:             "Query the current deployment parameters",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/chain/deployment_tx.go
+++ b/internal/cli/chain/deployment_tx.go
@@ -320,6 +320,7 @@ func addDeploymentOwnerTxFlags(cmd *cobra.Command) {
 func GetTxDeploymentGroupCmds() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "group",
+		RunE:  ValidateCmd,
 		Short: "Modify a Deployment's specific Group",
 	}
 

--- a/internal/cli/chain/evidence_tx.go
+++ b/internal/cli/chain/evidence_tx.go
@@ -38,6 +38,7 @@ func GetTxEvidenceCmd(childCmds []*cobra.Command) *cobra.Command {
 func SubmitEvidenceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "submit",
+		RunE:  ValidateCmd,
 		Short: "Submit arbitrary evidence of misbehavior",
 	}
 

--- a/internal/cli/chain/flags/flags.go
+++ b/internal/cli/chain/flags/flags.go
@@ -12,6 +12,8 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	cmcli "github.com/cometbft/cometbft/libs/cli"
+
+	"pkg.akt.dev/akt/internal/output"
 )
 
 const (
@@ -349,14 +351,14 @@ func AddQueryFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().String(FlagGRPC, "", "the gRPC endpoint to use for this chain")
 	cmd.Flags().Bool(FlagGRPCInsecure, false, "allow gRPC over insecure channels, if not TLS the server must use TLS")
 	cmd.Flags().Int64(FlagHeight, 0, "Use a specific height to query state at (this can error if the node is pruning state)")
-	cmd.Flags().StringP(FlagOutput, "o", OutputPretty, "Output format (pretty|json|yaml)")
+	cmd.Flags().VarP(output.NewFormatFlag(OutputPretty), FlagOutput, "o", "Output format (pretty|json|yaml)")
 }
 
 // AddTxFlagsToCmd adds common flags to a module tx command.
 func AddTxFlagsToCmd(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringP(FlagOutput, "o", OutputPretty, "Output format (pretty|json|yaml)")
+	f.VarP(output.NewFormatFlag(OutputPretty), FlagOutput, "o", "Output format (pretty|json|yaml)")
 	f.String(FlagFrom, "", "Name or address of private key with which to sign")
 	f.Uint64P(FlagAccountNumber, "a", 0, "The account number of the signing account (offline mode only)")
 	f.Uint64P(FlagSequence, "s", 0, "The sequence number of the signing account (offline mode only)")

--- a/internal/cli/chain/gov_query.go
+++ b/internal/cli/chain/gov_query.go
@@ -93,6 +93,7 @@ $ %s query gov proposal 1
 func GetQueryGovProposalsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "proposals",
+		Args:  cobra.NoArgs,
 		Short: "Query proposals with optional filters",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Query for a all paginated proposals that match optional filters:

--- a/internal/cli/chain/keys.go
+++ b/internal/cli/chain/keys.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cflags "pkg.akt.dev/akt/internal/cli/chain/flags"
+	"pkg.akt.dev/akt/internal/output"
 )
 
 // KeysCmds registers a sub-tree of commands to interact with
@@ -52,7 +53,7 @@ The pass backend requires GnuPG: https://gnupg.org/
 		MigrateCommand(),
 	)
 
-	cmd.PersistentFlags().String(cflags.FlagOutput, "text", "Output format (text|json)")
+	cmd.PersistentFlags().Var(output.NewEnumFlag("text", "text", "json"), cflags.FlagOutput, "Output format (text|json)")
 	cflags.AddKeyringFlags(cmd.PersistentFlags())
 
 	cmd.PersistentFlags().Bool(cflags.FlagOffline, true, "")

--- a/internal/cli/chain/keys.go
+++ b/internal/cli/chain/keys.go
@@ -11,6 +11,7 @@ import (
 func KeysCmds() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "keys",
+		RunE:  ValidateCmd,
 		Short: "Manage your application's keys",
 		Long: `Keyring management commands. These keys may be in any format supported by the
 CometBFT crypto library and can be used by light-clients, full nodes, or any other application

--- a/internal/cli/chain/market_query.go
+++ b/internal/cli/chain/market_query.go
@@ -184,7 +184,11 @@ than printing it.`,
 
 			defaultOwner := cl.ClientContext().GetFromAddress().String()
 			byProvider, _ := cmd.Flags().GetString("by")
-			isByProvider := byProvider == "provider"
+
+			isByProvider, err := parseByPerspective(byProvider)
+			if err != nil {
+				return err
+			}
 
 			if len(args) > 0 {
 				af, err := cflags.BidFiltersFromArg(args[0], defaultOwner, isByProvider)
@@ -317,7 +321,11 @@ rather than printing it.`,
 
 			defaultOwner := cl.ClientContext().GetFromAddress().String()
 			byProvider, _ := cmd.Flags().GetString("by")
-			isByProvider := byProvider == "provider"
+
+			isByProvider, err := parseByPerspective(byProvider)
+			if err != nil {
+				return err
+			}
 
 			if len(args) > 0 {
 				af, err := cflags.LeaseFiltersFromArg(args[0], defaultOwner, isByProvider)
@@ -421,6 +429,7 @@ rather than printing it.`,
 func GetQueryMarketParamsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "params",
+		Args:              cobra.NoArgs,
 		Short:             "Query the current market parameters",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/chain/market_query.go
+++ b/internal/cli/chain/market_query.go
@@ -98,7 +98,10 @@ rather than printing it.`,
 			}
 
 			// Default owner fallback when no arg and no --owner flag.
-			if ofilters.Owner == "" && defaultOwner != "" {
+			if ofilters.Owner == "" {
+				if defaultOwner == "" {
+					return requireOwnerScope("order filter")
+				}
 				ofilters.Owner = defaultOwner
 			}
 
@@ -222,7 +225,14 @@ than printing it.`,
 			}
 
 			// Default owner fallback when no arg and no --owner flag (owner mode only).
-			if !isByProvider && bfilters.Owner == "" && defaultOwner != "" {
+			if isByProvider {
+				if bfilters.Provider == "" {
+					return requireProviderScope("bid filter")
+				}
+			} else if bfilters.Owner == "" {
+				if defaultOwner == "" {
+					return requireOwnerScope("bid filter")
+				}
 				bfilters.Owner = defaultOwner
 			}
 
@@ -348,7 +358,14 @@ rather than printing it.`,
 			}
 
 			// Default owner fallback when no arg and no --owner flag (owner mode only).
-			if !isByProvider && lfilters.Owner == "" && defaultOwner != "" {
+			if isByProvider {
+				if lfilters.Provider == "" {
+					return requireProviderScope("lease filter")
+				}
+			} else if lfilters.Owner == "" {
+				if defaultOwner == "" {
+					return requireOwnerScope("lease filter")
+				}
 				lfilters.Owner = defaultOwner
 			}
 

--- a/internal/cli/chain/oracle_query.go
+++ b/internal/cli/chain/oracle_query.go
@@ -34,6 +34,7 @@ func GetQueryOracleCmd() *cobra.Command {
 func GetOraclePricesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "prices",
+		Args:              cobra.NoArgs,
 		Aliases:           []string{"p"},
 		Short:             "Query price history for denoms",
 		PersistentPreRunE: QueryPersistentPreRunE,
@@ -133,6 +134,7 @@ func GetOracleAggregatedPriceCmd() *cobra.Command {
 func GetQueryOracleParamsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "params",
+		Args:              cobra.NoArgs,
 		Short:             "Query the current oracle parameters",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/chain/provider_query.go
+++ b/internal/cli/chain/provider_query.go
@@ -31,6 +31,7 @@ func GetQueryProviderCmds() *cobra.Command {
 func GetQueryProvidersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "list",
+		Args:              cobra.NoArgs,
 		Short:             "Query for all providers",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/chain/query.go
+++ b/internal/cli/chain/query.go
@@ -46,6 +46,7 @@ func QueryCmd() *cobra.Command {
 		Use:     "query",
 		Aliases: []string{"q"},
 		Short:   "Querying subcommands",
+		RunE:    ValidateCmd,
 		// Capability gating: chain queries require a chain RPC endpoint.
 		Annotations: map[string]string{capability.AnnotationKey: string(capability.ChainQuery)},
 	}

--- a/internal/cli/chain/query_scope.go
+++ b/internal/cli/chain/query_scope.go
@@ -16,6 +16,21 @@ func requireOwnerScope(resource string) error {
 	return fmt.Errorf("%s: no default account set; provide an owner address or configure default-account", resource)
 }
 
+// parseByPerspective reads --by, which selects whether the leading address is
+// an owner or a provider. It used to be compared against "provider" and
+// nothing else, so every other value -- including "Provider" -- fell through
+// to owner mode and answered a different question than the one asked.
+func parseByPerspective(v string) (bool, error) {
+	switch v {
+	case "owner":
+		return false, nil
+	case "provider":
+		return true, nil
+	default:
+		return false, fmt.Errorf("--by must be %q or %q, got %q", "owner", "provider", v)
+	}
+}
+
 // requireProviderScope refuses a --by provider list query with no provider.
 // SPEC §3.8.4 marks the leading address required in provider mode; nothing
 // enforced it, so the empty filter listed the whole network.

--- a/internal/cli/chain/query_scope.go
+++ b/internal/cli/chain/query_scope.go
@@ -1,0 +1,24 @@
+package cli
+
+import "fmt"
+
+// requireOwnerScope refuses an owner-mode list query that has no owner to
+// filter on. SPEC §3.8 defines a bare listing as "all matching resources for
+// the context's default account", so with no account configured there is
+// nothing to scope to. The query layer treats an empty owner as "no filter"
+// rather than "no results", so sending it anyway returns every matching
+// resource on the network under a heading the caller reads as their own.
+//
+// A context legitimately has no default account -- console-api contexts never
+// set one, and the monitoring context in SPEC §5 omits it deliberately -- so
+// this is a normal state to hit, not a misconfiguration.
+func requireOwnerScope(resource string) error {
+	return fmt.Errorf("%s: no default account set; provide an owner address or configure default-account", resource)
+}
+
+// requireProviderScope refuses a --by provider list query with no provider.
+// SPEC §3.8.4 marks the leading address required in provider mode; nothing
+// enforced it, so the empty filter listed the whole network.
+func requireProviderScope(resource string) error {
+	return fmt.Errorf("%s: --by provider requires a provider address; provide one as the first argument", resource)
+}

--- a/internal/cli/chain/query_scope_test.go
+++ b/internal/cli/chain/query_scope_test.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	cv1beta3 "pkg.akt.dev/go/node/client/v1beta3"
+	dvbeta "pkg.akt.dev/go/node/deployment/v1beta4"
+	mvbeta "pkg.akt.dev/go/node/market/v1beta5"
+)
+
+// capturingDeploymentQuery records the request the command actually sent, so a
+// test can assert on the filter rather than only on the returned error.
+type capturingDeploymentQuery struct {
+	dvbeta.QueryClient
+
+	lastList  *dvbeta.QueryDeploymentsRequest
+	listCalls int
+}
+
+func (s *capturingDeploymentQuery) Deployments(_ context.Context, req *dvbeta.QueryDeploymentsRequest, _ ...grpc.CallOption) (*dvbeta.QueryDeploymentsResponse, error) {
+	s.listCalls++
+	s.lastList = req
+
+	return &dvbeta.QueryDeploymentsResponse{}, nil
+}
+
+// capturingMarketQuery does the same for the order/bid/lease list paths.
+type capturingMarketQuery struct {
+	mvbeta.QueryClient
+
+	orders *mvbeta.QueryOrdersRequest
+	bids   *mvbeta.QueryBidsRequest
+	leases *mvbeta.QueryLeasesRequest
+
+	listCalls int
+}
+
+func (s *capturingMarketQuery) Orders(_ context.Context, req *mvbeta.QueryOrdersRequest, _ ...grpc.CallOption) (*mvbeta.QueryOrdersResponse, error) {
+	s.listCalls++
+	s.orders = req
+
+	return &mvbeta.QueryOrdersResponse{}, nil
+}
+
+func (s *capturingMarketQuery) Bids(_ context.Context, req *mvbeta.QueryBidsRequest, _ ...grpc.CallOption) (*mvbeta.QueryBidsResponse, error) {
+	s.listCalls++
+	s.bids = req
+
+	return &mvbeta.QueryBidsResponse{}, nil
+}
+
+func (s *capturingMarketQuery) Leases(_ context.Context, req *mvbeta.QueryLeasesRequest, _ ...grpc.CallOption) (*mvbeta.QueryLeasesResponse, error) {
+	s.listCalls++
+	s.leases = req
+
+	return &mvbeta.QueryLeasesResponse{}, nil
+}
+
+// execQueryCmdFrom is execQueryCmd with a default account configured. Passing
+// an empty from leaves the context accountless, which is the state a
+// console-api context is always in.
+func execQueryCmdFrom(t *testing.T, cmd *cobra.Command, q cv1beta3.QueryClient, from string, args ...string) (string, error) {
+	t.Helper()
+
+	var queryOut bytes.Buffer
+
+	cctx := sdkclient.Context{
+		Codec:  codec.NewProtoCodec(codectypes.NewInterfaceRegistry()),
+		Output: &queryOut,
+	}
+
+	if from != "" {
+		addr, err := sdk.AccAddressFromBech32(from)
+		require.NoError(t, err)
+
+		cctx = cctx.WithFromAddress(addr)
+	}
+
+	cl := &stubLightClient{q: q, cctx: cctx}
+
+	var cobraOut bytes.Buffer
+
+	cmd.SetOut(&cobraOut)
+	cmd.SetErr(&cobraOut)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs(append(args, "--output", "json"))
+
+	ctx := context.WithValue(context.Background(), ClientContextKey, &sdkclient.Context{})
+	ctx = context.WithValue(ctx, ContextTypeQueryClient, cl)
+	cmd.SetContext(ctx)
+
+	err := cmd.Execute()
+
+	return queryOut.String(), err
+}
+
+// TestQueryListWithoutOwnerIsRefused pins the core regression: on a context
+// with no default account, a bare owner-mode list must fail rather than drop
+// the owner filter. An empty owner is not "no results" to the query layer, it
+// is "no filter", so the unscoped request came back with every deployment on
+// the network presented as the caller's own.
+//
+// listCalls is the assertion that matters -- the request must never leave.
+func TestQueryListWithoutOwnerIsRefused(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  func() *cobra.Command
+	}{
+		{"deployment", GetQueryDeploymentCmds},
+		{"order", GetQueryMarketOrderCmd},
+		{"bid", GetQueryMarketBidCmd},
+		{"lease", GetQueryMarketLeaseCmd},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dep := &capturingDeploymentQuery{}
+			mkt := &capturingMarketQuery{}
+
+			out, err := execQueryCmdFrom(t, tc.cmd(), &stubQueryClient{dep: dep, mkt: mkt}, "")
+			require.Error(t, err, "a bare list with no default account must not answer")
+			require.Contains(t, err.Error(), "no default account set")
+			require.Zero(t, dep.listCalls, "no unscoped deployment query may be sent")
+			require.Zero(t, mkt.listCalls, "no unscoped market query may be sent")
+			require.Empty(t, out)
+		})
+	}
+}
+
+// TestQueryListByProviderWithoutProviderIsRefused: SPEC §3.8.4 makes the
+// leading address required in --by provider mode. Nothing enforced it, so
+// `--by provider` with no address listed the whole network.
+func TestQueryListByProviderWithoutProviderIsRefused(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  func() *cobra.Command
+	}{
+		{"bid", GetQueryMarketBidCmd},
+		{"lease", GetQueryMarketLeaseCmd},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mkt := &capturingMarketQuery{}
+
+			out, err := execQueryCmdFrom(t, tc.cmd(), &stubQueryClient{mkt: mkt}, "", "--by", "provider")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "--by provider requires a provider address")
+			require.Zero(t, mkt.listCalls, "no unscoped market query may be sent")
+			require.Empty(t, out)
+		})
+	}
+}
+
+// TestQueryListWithDefaultOwnerScopes is the other half: when the context does
+// have an account, the bare list still works and the filter carries it. Without
+// this the fix above could pass by refusing everything.
+func TestQueryListWithDefaultOwnerScopes(t *testing.T) {
+	t.Run("deployment", func(t *testing.T) {
+		dep := &capturingDeploymentQuery{}
+
+		_, err := execQueryCmdFrom(t, GetQueryDeploymentCmds(), &stubQueryClient{dep: dep}, stateTestOwner)
+		require.NoError(t, err)
+		require.Equal(t, 1, dep.listCalls)
+		require.Equal(t, stateTestOwner, dep.lastList.Filters.Owner, "the list must be scoped to the default account")
+	})
+
+	t.Run("order", func(t *testing.T) {
+		mkt := &capturingMarketQuery{}
+
+		_, err := execQueryCmdFrom(t, GetQueryMarketOrderCmd(), &stubQueryClient{mkt: mkt}, stateTestOwner)
+		require.NoError(t, err)
+		require.Equal(t, stateTestOwner, mkt.orders.Filters.Owner)
+	})
+
+	t.Run("bid", func(t *testing.T) {
+		mkt := &capturingMarketQuery{}
+
+		_, err := execQueryCmdFrom(t, GetQueryMarketBidCmd(), &stubQueryClient{mkt: mkt}, stateTestOwner)
+		require.NoError(t, err)
+		require.Equal(t, stateTestOwner, mkt.bids.Filters.Owner)
+	})
+
+	t.Run("lease", func(t *testing.T) {
+		mkt := &capturingMarketQuery{}
+
+		_, err := execQueryCmdFrom(t, GetQueryMarketLeaseCmd(), &stubQueryClient{mkt: mkt}, stateTestOwner)
+		require.NoError(t, err)
+		require.Equal(t, stateTestOwner, mkt.leases.Filters.Owner)
+	})
+}
+
+// TestQueryListByProviderWithProviderScopes: provider mode still works when the
+// address is supplied, and scopes to it.
+func TestQueryListByProviderWithProviderScopes(t *testing.T) {
+	t.Run("bid", func(t *testing.T) {
+		mkt := &capturingMarketQuery{}
+
+		_, err := execQueryCmdFrom(t, GetQueryMarketBidCmd(), &stubQueryClient{mkt: mkt}, "", "--by", "provider", stateTestProvider)
+		require.NoError(t, err)
+		require.Equal(t, stateTestProvider, mkt.bids.Filters.Provider)
+	})
+
+	t.Run("lease", func(t *testing.T) {
+		mkt := &capturingMarketQuery{}
+
+		_, err := execQueryCmdFrom(t, GetQueryMarketLeaseCmd(), &stubQueryClient{mkt: mkt}, "", "--by", "provider", stateTestProvider)
+		require.NoError(t, err)
+		require.Equal(t, stateTestProvider, mkt.leases.Filters.Provider)
+	})
+}

--- a/internal/cli/chain/query_scope_test.go
+++ b/internal/cli/chain/query_scope_test.go
@@ -14,6 +14,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	certv1 "pkg.akt.dev/go/node/cert/v1"
 	cv1beta3 "pkg.akt.dev/go/node/client/v1beta3"
 	dvbeta "pkg.akt.dev/go/node/deployment/v1beta4"
 	mvbeta "pkg.akt.dev/go/node/market/v1beta5"
@@ -45,6 +46,27 @@ type capturingMarketQuery struct {
 
 	listCalls int
 }
+
+type capturingCertQuery struct {
+	certv1.QueryClient
+
+	last      *certv1.QueryCertificatesRequest
+	listCalls int
+}
+
+func (s *capturingCertQuery) Certificates(_ context.Context, req *certv1.QueryCertificatesRequest, _ ...grpc.CallOption) (*certv1.QueryCertificatesResponse, error) {
+	s.listCalls++
+	s.last = req
+
+	return &certv1.QueryCertificatesResponse{}, nil
+}
+
+type certQueryClient struct {
+	*stubQueryClient
+	cert certv1.QueryClient
+}
+
+func (s *certQueryClient) Certs() certv1.QueryClient { return s.cert }
 
 func (s *capturingMarketQuery) Orders(_ context.Context, req *mvbeta.QueryOrdersRequest, _ ...grpc.CallOption) (*mvbeta.QueryOrdersResponse, error) {
 	s.listCalls++
@@ -200,6 +222,27 @@ func TestQueryListWithDefaultOwnerScopes(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, stateTestOwner, mkt.leases.Filters.Owner)
 	})
+
+	t.Run("certificate", func(t *testing.T) {
+		cert := &capturingCertQuery{}
+		query := &certQueryClient{stubQueryClient: &stubQueryClient{}, cert: cert}
+
+		_, err := execQueryCmdFrom(t, GetQueryCertCertificatesCmd(), query, stateTestOwner)
+		require.NoError(t, err)
+		require.Equal(t, 1, cert.listCalls)
+		require.Equal(t, stateTestOwner, cert.last.Filter.Owner)
+	})
+}
+
+func TestCertificateListWithoutOwnerIsRefused(t *testing.T) {
+	cert := &capturingCertQuery{}
+	query := &certQueryClient{stubQueryClient: &stubQueryClient{}, cert: cert}
+
+	out, err := execQueryCmdFrom(t, GetQueryCertCertificatesCmd(), query, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no default account set")
+	require.Zero(t, cert.listCalls, "no unscoped certificate query may be sent")
+	require.Empty(t, out)
 }
 
 // TestQueryListByProviderWithProviderScopes: provider mode still works when the

--- a/internal/cli/chain/rpc.go
+++ b/internal/cli/chain/rpc.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"github.com/cosmos/cosmos-sdk/types/query"
+
+	"pkg.akt.dev/akt/internal/output"
 )
 
 // GetValidatorSetCmd returns the validator set for a given height
@@ -49,7 +51,7 @@ func GetValidatorSetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().String(flags.FlagNode, "tcp://localhost:26657", "<host>:<port> to CometBFT RPC interface for this chain")
-	cmd.Flags().StringP(flags.FlagOutput, "o", "text", "Output format (text|json)")
+	cmd.Flags().VarP(output.NewEnumFlag("text", "text", "json"), flags.FlagOutput, "o", "Output format (text|json)")
 	cmd.Flags().Int(flags.FlagPage, query.DefaultPage, "Query a specific page of paginated results")
 	cmd.Flags().Int(flags.FlagLimit, 100, "Query number of results returned per page")
 

--- a/internal/cli/chain/server_util.go
+++ b/internal/cli/chain/server_util.go
@@ -35,6 +35,7 @@ import (
 func ServerCmds(rootCmd *cobra.Command, defaultNodeHome string, appCreator types.AppCreator, appExport types.AppExporter, addStartFlags types.ModuleInitFlags) {
 	cometCmd := &cobra.Command{
 		Use:     "comet",
+		RunE:    ValidateCmd,
 		Aliases: []string{"cometbft", "tendermint"},
 		Short:   "CometBFT subcommands",
 	}

--- a/internal/cli/chain/tx.go
+++ b/internal/cli/chain/tx.go
@@ -61,6 +61,7 @@ func TxPersistentPreRunE(cmd *cobra.Command, _ []string) error {
 func TxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tx",
+		RunE:  ValidateCmd,
 		Short: "Transactions subcommands",
 		// Capability gating: broadcasting requires a chain RPC endpoint.
 		Annotations: map[string]string{capability.AnnotationKey: string(capability.ChainTx)},

--- a/internal/cli/console/apikey.go
+++ b/internal/cli/console/apikey.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
 	aktctx "pkg.akt.dev/akt/internal/context"
@@ -12,6 +13,7 @@ import (
 func apikeyCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apikey",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Manage Console API keys",
 	}
 
@@ -132,6 +134,7 @@ var defaultJWTScope = []string{"status", "logs", "events", "shell", "send-manife
 func jwtCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "jwt",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Mint provider-scoped JWTs",
 	}
 

--- a/internal/cli/console/commands.go
+++ b/internal/cli/console/commands.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
@@ -22,6 +23,7 @@ import (
 func Commands(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "console",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Akash Console managed-wallet operations",
 		Long: "Interact with the Akash Console API: create and manage deployments through " +
 			"the Console managed wallet, inspect bids and leases, and browse the public " +

--- a/internal/cli/console/deployment.go
+++ b/internal/cli/console/deployment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
 	"pkg.akt.dev/akt/internal/console"
@@ -37,6 +38,7 @@ func parseConsoleUSD(arg string) (float64, error) {
 func deploymentCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deployment",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Manage Console deployments",
 		Long:  "Create, inspect, update, fund, and close deployments through the Console managed wallet.",
 	}
@@ -357,6 +359,7 @@ func deploymentSettingsCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 func bidCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bid",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Inspect provider bids",
 	}
 
@@ -391,6 +394,7 @@ func bidCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 func leaseCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lease",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Create leases from accepted bids",
 	}
 

--- a/internal/cli/console/marketplace.go
+++ b/internal/cli/console/marketplace.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
 	aktctx "pkg.akt.dev/akt/internal/context"
@@ -15,6 +16,7 @@ import (
 func providerCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "provider",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Browse the Console provider catalog (no API key required)",
 	}
 
@@ -137,6 +139,7 @@ func gpuCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 func templateCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "template",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Browse deployment templates (no API key required)",
 	}
 

--- a/internal/cli/console/wallet.go
+++ b/internal/cli/console/wallet.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
 	"pkg.akt.dev/akt/internal/console"
@@ -13,6 +14,7 @@ import (
 func walletCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wallet",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Managed wallet balance, settings, and cost",
 	}
 
@@ -58,11 +60,8 @@ func walletListCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			rows := make([]walletRow, 0, len(wallets))
 			for _, w := range wallets {
 				rows = append(rows, walletRow{
-					Address: w.Address,
-					// creditAmount is dollar-scale per the /v1/wallets
-					// contract (reported alongside a denom, e.g. "usdc") —
-					// unlike /v1/balances, which is µACT. No 1e6 scaling.
-					Balance:  formatUSD(w.CreditAmount),
+					Address:  w.Address,
+					Balance:  formatUSD(w.CreditUSD()),
 					Denom:    w.Denom,
 					Trialing: w.IsTrialing,
 				})

--- a/internal/cli/context/commands.go
+++ b/internal/cli/context/commands.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/spf13/cobra"
 
@@ -20,6 +21,7 @@ import (
 func Commands(mgr func() *aktctx.Manager, getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "context",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Manage contexts, networks, and keys",
 		Long:  "A context composes a network, keyring, state store, and action log into a named environment.",
 	}

--- a/internal/cli/input_contract.go
+++ b/internal/cli/input_contract.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	chaincli "pkg.akt.dev/akt/internal/cli/chain"
+	"pkg.akt.dev/akt/internal/output"
+)
+
+// enforceGroupInputValidation makes every pure command group reject a token
+// that does not name one of its children. Cobra otherwise treats a group with
+// no Run/RunE as non-runnable and turns an unknown positional into successful
+// help output.
+func enforceGroupInputValidation(cmd *cobra.Command) {
+	if cmd.HasSubCommands() && !cmd.Runnable() {
+		cmd.RunE = chaincli.ValidateCmd
+	}
+
+	for _, child := range cmd.Commands() {
+		enforceGroupInputValidation(child)
+	}
+}
+
+// enforceOutputValidation constrains output flags copied from upstream
+// command trees. Locally defined flags already carry their exact enum and are
+// left untouched, including the workflow-only jsonl extension.
+func enforceOutputValidation(cmd *cobra.Command) {
+	seen := make(map[*pflag.Flag]struct{})
+
+	var walk func(*cobra.Command)
+	walk = func(current *cobra.Command) {
+		for _, flags := range []*pflag.FlagSet{current.LocalFlags(), current.PersistentFlags()} {
+			flag := flags.Lookup("output")
+			if flag == nil {
+				continue
+			}
+			if _, ok := seen[flag]; ok {
+				continue
+			}
+			seen[flag] = struct{}{}
+			output.ConstrainFlag(flag, "pretty", "pretty", "json", "yaml")
+		}
+
+		for _, child := range current.Commands() {
+			walk(child)
+		}
+	}
+
+	walk(cmd)
+}

--- a/internal/cli/input_contract_test.go
+++ b/internal/cli/input_contract_test.go
@@ -13,7 +13,7 @@ func TestEveryCommandGroupRejectsUnknownSubcommands(t *testing.T) {
 	root := NewRootCmd(BuildInfo{Version: "test"})
 
 	var violations []string
-	walkCommands(root, func(cmd *cobra.Command) {
+	walkInputContractCommands(root, func(cmd *cobra.Command) {
 		if cmd.HasSubCommands() && !cmd.Runnable() {
 			violations = append(violations, cmd.CommandPath())
 		}
@@ -31,7 +31,7 @@ func TestEveryOutputFlagRejectsUnknownFormats(t *testing.T) {
 
 	seen := make(map[*pflag.Flag]string)
 	var violations []string
-	walkCommands(root, func(cmd *cobra.Command) {
+	walkInputContractCommands(root, func(cmd *cobra.Command) {
 		for _, flags := range []*pflag.FlagSet{cmd.LocalFlags(), cmd.PersistentFlags()} {
 			flag := flags.Lookup("output")
 			if flag == nil {
@@ -81,10 +81,10 @@ func TestOutputEnumsAreCommandSpecific(t *testing.T) {
 	}
 }
 
-func walkCommands(cmd *cobra.Command, visit func(*cobra.Command)) {
+func walkInputContractCommands(cmd *cobra.Command, visit func(*cobra.Command)) {
 	visit(cmd)
 	for _, child := range cmd.Commands() {
-		walkCommands(child, visit)
+		walkInputContractCommands(child, visit)
 	}
 }
 

--- a/internal/cli/input_contract_test.go
+++ b/internal/cli/input_contract_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestEveryCommandGroupRejectsUnknownSubcommands(t *testing.T) {
+	t.Setenv("AKT_HOME", t.TempDir())
+	root := NewRootCmd(BuildInfo{Version: "test"})
+
+	var violations []string
+	walkCommands(root, func(cmd *cobra.Command) {
+		if cmd.HasSubCommands() && !cmd.Runnable() {
+			violations = append(violations, cmd.CommandPath())
+		}
+	})
+
+	if len(violations) != 0 {
+		t.Fatalf("command groups without an input validator:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+func TestEveryOutputFlagRejectsUnknownFormats(t *testing.T) {
+	t.Setenv("AKT_HOME", t.TempDir())
+	root := NewRootCmd(BuildInfo{Version: "test"})
+
+	seen := make(map[*pflag.Flag]string)
+	var violations []string
+	walkCommands(root, func(cmd *cobra.Command) {
+		for _, flags := range []*pflag.FlagSet{cmd.LocalFlags(), cmd.PersistentFlags()} {
+			flag := flags.Lookup("output")
+			if flag == nil {
+				continue
+			}
+			if _, ok := seen[flag]; ok {
+				continue
+			}
+			seen[flag] = cmd.CommandPath()
+			if flag.DefValue != "pretty" {
+				violations = append(violations, cmd.CommandPath()+" (default "+flag.DefValue+")")
+			}
+			if err := flag.Value.Set("josn"); err == nil {
+				violations = append(violations, cmd.CommandPath())
+			}
+		}
+	})
+
+	if len(violations) != 0 {
+		t.Fatalf("--output accepted an undocumented value on:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+func TestOutputEnumsAreCommandSpecific(t *testing.T) {
+	t.Setenv("AKT_HOME", t.TempDir())
+	root := NewRootCmd(BuildInfo{Version: "test"})
+
+	rootOutput := root.PersistentFlags().Lookup("output")
+	for _, value := range []string{"pretty", "json", "yaml"} {
+		if err := rootOutput.Value.Set(value); err != nil {
+			t.Errorf("root --output %q: %v", value, err)
+		}
+	}
+	for _, value := range []string{"table", "jsonl", "josn"} {
+		if err := rootOutput.Value.Set(value); err == nil {
+			t.Errorf("root --output unexpectedly accepted %q", value)
+		}
+	}
+
+	deploy := childCommand(root, "deploy")
+	if deploy == nil {
+		t.Fatal("deploy command not found")
+	}
+	if err := deploy.Flags().Lookup("output").Value.Set("jsonl"); err != nil {
+		t.Fatalf("deploy --output jsonl: %v", err)
+	}
+}
+
+func walkCommands(cmd *cobra.Command, visit func(*cobra.Command)) {
+	visit(cmd)
+	for _, child := range cmd.Commands() {
+		walkCommands(child, visit)
+	}
+}
+
+func childCommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if child.Name() == name {
+			return child
+		}
+	}
+	return nil
+}

--- a/internal/cli/keys/commands.go
+++ b/internal/cli/keys/commands.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
@@ -25,6 +26,7 @@ import (
 func Commands(getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "keys",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Manage keys in the current context's keyring",
 		Long:  "Add, delete, list, show, export, and import cryptographic keys used for signing transactions.",
 	}

--- a/internal/cli/network/commands.go
+++ b/internal/cli/network/commands.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
 	aktctx "pkg.akt.dev/akt/internal/context"
@@ -15,6 +16,7 @@ import (
 func Commands(mgr func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "network",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Manage network definitions",
 		Long:  "Networks define chain connectivity (chain-id, endpoints, gas-prices). They are shared resources that can be referenced by multiple contexts.",
 	}

--- a/internal/cli/provider/commands.go
+++ b/internal/cli/provider/commands.go
@@ -24,6 +24,7 @@ import (
 func Commands() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "provider",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Provider gateway operations",
 		Long:  "Interact with Akash provider gateway APIs: query status, manage leases, send manifests, and more.",
 		// Capability gating: gateway discovery and wallet auth need chain access.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -341,6 +341,8 @@ func NewRootCmd(bi BuildInfo) *cobra.Command {
 	}
 	root.AddCommand(versionCmd(bi))
 	root.AddCommand(completionCmd())
+	enforceGroupInputValidation(root)
+	enforceOutputValidation(root)
 
 	// Capability gating must also shape help output when cobra
 	// short-circuits --help before the persistent hooks run (parsed help

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,6 +35,7 @@ import (
 	aktkeyring "pkg.akt.dev/akt/internal/keyring"
 	akttui "pkg.akt.dev/akt/internal/tui"
 
+	"pkg.akt.dev/akt/internal/output"
 	"pkg.akt.dev/akt/internal/output/pretty"
 
 	arpcclient "pkg.akt.dev/go/node/client"
@@ -285,7 +286,7 @@ func NewRootCmd(bi BuildInfo) *cobra.Command {
 	// not captured into Go variables.
 	root.PersistentFlags().String("home", "", "Home directory for config, contexts, and keyrings (default: $AKT_HOME or ~/.config/akt)")
 	root.PersistentFlags().String("context", "", "Active context name (overrides current-context in config)")
-	root.PersistentFlags().StringP("output", "o", "pretty", "Output format: pretty, json, yaml")
+	root.PersistentFlags().VarP(output.NewFormatFlag("pretty"), "output", "o", "Output format: pretty, json, yaml")
 	root.PersistentFlags().BoolP("interactive", "i", false, "Launch the TUI. Currently disabled while UX feedback is collected; set AKT_EXPERIMENTAL_TUI=1 to opt in")
 	root.PersistentFlags().CountP("verbose", "v", "Increase output verbosity (-v verbose, -vv debug)")
 	root.PersistentFlags().BoolP("quiet", "q", false, "Suppress all output except errors")

--- a/internal/cli/sdl/commands.go
+++ b/internal/cli/sdl/commands.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -20,6 +21,7 @@ import (
 func Commands() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sdl",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Author and validate deployment SDLs",
 		Long: `Generate SDL manifests from built-in scaffolds and validate them offline.
 

--- a/internal/cli/store/commands.go
+++ b/internal/cli/store/commands.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
 	"pkg.akt.dev/akt/internal/output/pretty"
@@ -19,6 +20,7 @@ import (
 func Commands(homeFn func() string, ctxNameFn func() string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "store",
+		RunE:  sdkclient.ValidateCmd,
 		Short: "Manage the local deployment store",
 		Long:  "View store status, export records, and import from backups.",
 	}
@@ -50,6 +52,7 @@ func openStore(homeFn func() string, ctxNameFn func() string) (sstore.Store, err
 func statusCmd(homeFn func() string, ctxNameFn func() string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
+		Args:  cobra.NoArgs,
 		Short: "Display local store information",
 		Example: `  # Show store status for the current context
   akt store status`,
@@ -118,6 +121,7 @@ func exportCmd(homeFn func() string, ctxNameFn func() string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "export",
+		Args:  cobra.NoArgs,
 		Short: "Export the local store to YAML or JSON",
 		Example: `  # Export to stdout as YAML
   akt store export

--- a/internal/cli/workflow/commands.go
+++ b/internal/cli/workflow/commands.go
@@ -18,6 +18,7 @@ import (
 	"pkg.akt.dev/akt/internal/cliutil"
 	"pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
+	"pkg.akt.dev/akt/internal/output"
 	"pkg.akt.dev/akt/internal/transport"
 	wf "pkg.akt.dev/akt/internal/workflow"
 	"pkg.akt.dev/akt/internal/workflow/builtin"
@@ -214,6 +215,7 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 	// Common workflow flags.
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompts")
 	cmd.Flags().Bool("dry-run", false, "Show execution plan without broadcasting transactions")
+	cmd.Flags().VarP(output.NewFormatFlag(cflags.OutputPretty, outputJSONL), cflags.FlagOutput, "o", "Output format (pretty|json|yaml|jsonl)")
 
 	// Standard chain tx flags (--from, --gas, --node, ...) so keyring-auth
 	// execution can discover a chain client; flags already defined above

--- a/internal/client/context.go
+++ b/internal/client/context.go
@@ -42,8 +42,27 @@ func BuildClientContext(
 		WithKeyringDir(aktctx.KeyringDir(rc.Root, rc.Keyring))
 
 	// Set default account if configured.
+	//
+	// WithFrom records the name only; FromName and FromAddress stay empty
+	// until something resolves the name against the keyring. Tx commands do
+	// that themselves, queries never do -- so every query that falls back to
+	// the default account saw no address and reported "no default account
+	// set" on a context that had one configured and displayed. Resolve it
+	// here so both paths agree.
+	//
+	// A name that is not in the keyring is left as the bare From value rather
+	// than failing: the context is built for every command, including the
+	// keys and context commands someone would use to fix it.
 	if rc.DefaultAccount != "" {
 		cctx = cctx.WithFrom(rc.DefaultAccount)
+
+		if kr != nil {
+			if rec, err := kr.Key(rc.DefaultAccount); err == nil {
+				if addr, err := rec.GetAddress(); err == nil {
+					cctx = cctx.WithFromName(rc.DefaultAccount).WithFromAddress(addr)
+				}
+			}
+		}
 	}
 
 	// Set broadcast mode.

--- a/internal/console/types.go
+++ b/internal/console/types.go
@@ -1,6 +1,9 @@
 package console
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // FlexString unmarshals from either a JSON string or a JSON number, since the
 // Console API is inconsistent about numeric identifiers (dseq, amounts).
@@ -65,6 +68,21 @@ type Wallet struct {
 	CreditAmount float64 `json:"creditAmount"`
 	IsTrialing   bool    `json:"isTrialing"`
 	Denom        string  `json:"denom"`
+}
+
+// CreditUSD returns the wallet credit in USD.
+//
+// creditAmount is denominated in the units its own denom names, and that denom
+// is "uact" -- micro-ACT, the same 1e6 scale as /v1/balances, with ACT pegged
+// 1:1 to USD. Taking it for dollars printed an $11.35 wallet as
+// $11,350,924.00 while `wallet balance` reported $57.49 for the same account.
+// Any other denom is passed through unscaled rather than guessed at.
+func (w Wallet) CreditUSD() float64 {
+	if strings.EqualFold(w.Denom, "uact") {
+		return w.CreditAmount / 1e6
+	}
+
+	return w.CreditAmount
 }
 
 // WalletSettings holds account-level wallet settings

--- a/internal/mcp/owner_scope_test.go
+++ b/internal/mcp/owner_scope_test.go
@@ -1,0 +1,97 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+
+	ctypes "pkg.akt.dev/go/node/cert/v1"
+	cv1beta3 "pkg.akt.dev/go/node/client/v1beta3"
+	dtypes "pkg.akt.dev/go/node/deployment/v1beta4"
+	mtypes "pkg.akt.dev/go/node/market/v1beta5"
+
+	certtools "pkg.akt.dev/akt/internal/mcp/tools/cert"
+	deploymenttools "pkg.akt.dev/akt/internal/mcp/tools/deployment"
+	markettools "pkg.akt.dev/akt/internal/mcp/tools/market"
+)
+
+// refusingQueryClient fails the test if any module is reached. The whole point
+// of the owner guard is that the query never leaves, so a query client that is
+// touched at all is the bug.
+type refusingQueryClient struct {
+	cv1beta3.QueryClient
+
+	t *testing.T
+}
+
+func (q *refusingQueryClient) reject(module string) {
+	q.t.Helper()
+	q.t.Fatalf("%s query was sent with no owner to filter on; an empty filter lists the whole network", module)
+}
+
+// Reached only when a guard is missing; t.Fatalf unwinds before the nil
+// return is ever used.
+func (q *refusingQueryClient) Deployment() dtypes.QueryClient { q.reject("deployment"); return nil }
+func (q *refusingQueryClient) Market() mtypes.QueryClient     { q.reject("market"); return nil }
+func (q *refusingQueryClient) Certs() ctypes.QueryClient      { q.reject("cert"); return nil }
+
+func (q *refusingQueryClient) ClientContext() sdkclient.Context { return sdkclient.Context{} }
+
+// accountlessClient is a LightClient whose context has no default account --
+// the permanent state of a console-api context, and (before the default account
+// is resolved to an address) the state of every context on a query path.
+type accountlessClient struct {
+	q cv1beta3.QueryClient
+}
+
+func (c *accountlessClient) Query() cv1beta3.QueryClient      { return c.q }
+func (c *accountlessClient) Node() cv1beta3.NodeClient        { return nil }
+func (c *accountlessClient) ClientContext() sdkclient.Context { return sdkclient.Context{} }
+func (c *accountlessClient) PrintMessage(interface{}) error   { return nil }
+func (c *accountlessClient) PrintJSON(interface{}) error      { return nil }
+
+// TestListToolsRefuseWithoutOwner pins the MCP half of the unscoped-list bug.
+// These handlers defaulted the owner from the client context and, finding
+// nothing there, queried with Owner: "" -- which the query layer reads as "no
+// filter", so the tool answered with every matching record on the network as a
+// success. An assistant has no help text to catch that on.
+func TestListToolsRefuseWithoutOwner(t *testing.T) {
+	q := &refusingQueryClient{t: t}
+	cl := &accountlessClient{q: q}
+
+	handlers := map[string]func(cv1beta3.LightClient) mcpserver.ToolHandlerFunc{
+		"akash_list_deployments":  deploymenttools.HandleListDeployments,
+		"akash_list_certificates": certtools.HandleListCertificates,
+		"akash_list_orders":       markettools.HandleListOrders,
+		"akash_list_bids":         markettools.HandleListBids,
+		"akash_list_leases":       markettools.HandleListLeases,
+	}
+
+	for name, newHandler := range handlers {
+		t.Run(name, func(t *testing.T) {
+			res, err := newHandler(cl)(context.Background(), mcp.CallToolRequest{})
+			if err != nil {
+				t.Fatalf("handler returned a transport error: %v", err)
+			}
+			if res == nil || !res.IsError {
+				t.Fatalf("%s answered without an owner; it must refuse instead", name)
+			}
+
+			var text string
+			for _, c := range res.Content {
+				if tc, ok := c.(mcp.TextContent); ok {
+					text += tc.Text
+				}
+			}
+
+			if !strings.Contains(text, "owner address is required") {
+				t.Errorf("unhelpful refusal: %q", text)
+			}
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -41,10 +41,16 @@ type Server struct {
 // REST mutations) are additionally registered. The user must explicitly opt
 // in by passing --enable-writes.
 func New(ctx context.Context, cctx sdkclient.Context, enableWrites bool, consoleClient *aktconsole.Client) (*Server, error) {
+	// WithRecovery turns a panicking tool handler into an error result for
+	// that one call. Without it the panic unwinds through the stdio loop and
+	// takes the process down, so a single bad call ends the session and every
+	// other tool with it -- including the Console rail, which had nothing to
+	// do with it.
 	srv := mcpserver.NewMCPServer(
 		"akash-mcp",
 		"0.1.0",
 		mcpserver.WithToolCapabilities(true),
+		mcpserver.WithRecovery(),
 	)
 
 	s := &Server{mcp: srv}

--- a/internal/mcp/tools/cert/tools.go
+++ b/internal/mcp/tools/cert/tools.go
@@ -37,6 +37,10 @@ func HandleListCertificates(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			}
 		}
 
+		if owner == "" {
+			return marshal.ErrResult("owner address is required: pass owner, or configure a default account for the active context"), nil
+		}
+
 		state := marshal.OptionalString(req, "state")
 
 		resp, err := cl.Query().Certs().Certificates(ctx, &ctypes.QueryCertificatesRequest{

--- a/internal/mcp/tools/deployment/tools.go
+++ b/internal/mcp/tools/deployment/tools.go
@@ -39,6 +39,10 @@ func HandleListDeployments(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			}
 		}
 
+		if owner == "" {
+			return marshal.ErrResult("owner address is required: pass owner, or configure a default account for the active context"), nil
+		}
+
 		filters := dtypes.DeploymentFilters{
 			Owner: owner,
 			State: marshal.OptionalString(req, "state"),

--- a/internal/mcp/tools/market/tools.go
+++ b/internal/mcp/tools/market/tools.go
@@ -41,6 +41,10 @@ func HandleListOrders(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			}
 		}
 
+		if owner == "" {
+			return marshal.ErrResult("owner address is required: pass owner, or configure a default account for the active context"), nil
+		}
+
 		resp, err := cl.Query().Market().Orders(ctx, &mtypes.QueryOrdersRequest{
 			Filters: mtypes.OrderFilters{
 				Owner: owner,
@@ -140,6 +144,10 @@ func HandleListBids(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
 				owner = addr.String()
 			}
+		}
+
+		if owner == "" {
+			return marshal.ErrResult("owner address is required: pass owner, or configure a default account for the active context"), nil
 		}
 
 		filters := mtypes.BidFilters{
@@ -259,6 +267,10 @@ func HandleListLeases(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
 				owner = addr.String()
 			}
+		}
+
+		if owner == "" {
+			return marshal.ErrResult("owner address is required: pass owner, or configure a default account for the active context"), nil
 		}
 
 		filters := mv1.LeaseFilters{

--- a/internal/output/flag.go
+++ b/internal/output/flag.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// formatFlag is the pflag.Value behind --output. It rejects an unrecognised
-// format at parse time.
+// enumFlag is the pflag.Value behind a flag with a fixed set of string values.
+// It rejects an unrecognised value at parse time.
 //
 // The flag used to be a plain string, and FormatFromCmd maps anything it does
 // not recognise to the table renderer -- so `-o josn | jq` printed an
@@ -16,30 +16,74 @@ import (
 // downstream parse error, if at all. Validating here rather than in a
 // PersistentPreRunE hook covers every command: the query subtree installs its
 // own hook, and cobra runs only the closest one.
-type formatFlag string
-
-// NewFormatFlag returns the value to register --output with, seeded with the
-// default format.
-func NewFormatFlag(def string) pflag.Value {
-	v := formatFlag(def)
-
-	return &v
+type enumFlag struct {
+	value   string
+	allowed []string
 }
 
-func (v *formatFlag) String() string { return string(*v) }
+type constrainedValue struct {
+	pflag.Value
+	allowed []string
+}
+
+// NewFormatFlag returns the value to register --output with, seeded with the
+// default format. Additional values are command-specific extensions, such as
+// jsonl on workflow commands.
+func NewFormatFlag(def string, additional ...string) pflag.Value {
+	allowed := append([]string{"pretty", string(FormatJSON), string(FormatYAML)}, additional...)
+
+	return NewEnumFlag(def, allowed...)
+}
+
+// NewEnumFlag returns a string flag value restricted to allowed.
+func NewEnumFlag(def string, allowed ...string) pflag.Value {
+	return &enumFlag{
+		value:   def,
+		allowed: append([]string(nil), allowed...),
+	}
+}
+
+// ConstrainFlag applies a default and enum validation to an existing string
+// flag. Flags already created by NewEnumFlag or NewFormatFlag retain their
+// command-specific default and allowed values.
+func ConstrainFlag(flag *pflag.Flag, def string, allowed ...string) {
+	if flag == nil {
+		return
+	}
+	if _, ok := flag.Value.(*enumFlag); ok {
+		return
+	}
+
+	flag.Value = &constrainedValue{
+		Value:   flag.Value,
+		allowed: append([]string(nil), allowed...),
+	}
+	flag.DefValue = def
+	_ = flag.Value.Set(def)
+}
+
+func (v *enumFlag) String() string { return v.value }
 
 // Type is "string" so pflag's GetString keeps working on this flag.
-func (v *formatFlag) Type() string { return "string" }
+func (v *enumFlag) Type() string { return "string" }
 
-func (v *formatFlag) Set(s string) error {
-	switch s {
-	// "pretty" and "table" both select the table renderer; both spellings are
-	// already in use across the help text.
-	case "pretty", "table", string(FormatJSON), string(FormatYAML):
-		*v = formatFlag(s)
-
-		return nil
-	default:
-		return fmt.Errorf("must be one of %s", strings.Join([]string{"pretty", "json", "yaml"}, ", "))
+func (v *enumFlag) Set(s string) error {
+	for _, allowed := range v.allowed {
+		if s == allowed {
+			v.value = s
+			return nil
+		}
 	}
+
+	return fmt.Errorf("must be one of %s", strings.Join(v.allowed, ", "))
+}
+
+func (v *constrainedValue) Set(s string) error {
+	for _, allowed := range v.allowed {
+		if s == allowed {
+			return v.Value.Set(s)
+		}
+	}
+
+	return fmt.Errorf("must be one of %s", strings.Join(v.allowed, ", "))
 }

--- a/internal/output/flag.go
+++ b/internal/output/flag.go
@@ -1,0 +1,45 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// formatFlag is the pflag.Value behind --output. It rejects an unrecognised
+// format at parse time.
+//
+// The flag used to be a plain string, and FormatFromCmd maps anything it does
+// not recognise to the table renderer -- so `-o josn | jq` printed an
+// ANSI-coloured table into jq and exited 0, with the typo reported as a
+// downstream parse error, if at all. Validating here rather than in a
+// PersistentPreRunE hook covers every command: the query subtree installs its
+// own hook, and cobra runs only the closest one.
+type formatFlag string
+
+// NewFormatFlag returns the value to register --output with, seeded with the
+// default format.
+func NewFormatFlag(def string) pflag.Value {
+	v := formatFlag(def)
+
+	return &v
+}
+
+func (v *formatFlag) String() string { return string(*v) }
+
+// Type is "string" so pflag's GetString keeps working on this flag.
+func (v *formatFlag) Type() string { return "string" }
+
+func (v *formatFlag) Set(s string) error {
+	switch s {
+	// "pretty" and "table" both select the table renderer; both spellings are
+	// already in use across the help text.
+	case "pretty", "table", string(FormatJSON), string(FormatYAML):
+		*v = formatFlag(s)
+
+		return nil
+	default:
+		return fmt.Errorf("must be one of %s", strings.Join([]string{"pretty", "json", "yaml"}, ", "))
+	}
+}


### PR DESCRIPTION
A bare `akt query deployment` promises "the deployments owned by the context's default account". On a context with no default account it returned **100 deployments across 64 unrelated owners, exit 0** — none of them the caller's. That is not a display bug; the CLI answered a question nobody asked and presented it as the answer to the one they did.

Six agents were pointed at the built binary with instructions to prove every finding by running it. This PR fixes the class they found. Everything below was reproduced on mainnet before the fix and re-checked after.

## The root cause, which is worse than the symptom

`BuildClientContext` called `WithFrom(name)`, which records the *name* and leaves `FromAddress` empty. Only `ReadTxCommandFlags` ever resolved it — so `GetFromAddress()` was empty on **every query path for every user**, and the entire "owner defaults from context" feature was dead code on the query surface.

Proven with a real key and `default-account` configured:

```
akt q deployment            -> exit 0, 64 distinct owners   (should be: mine)
akt q deployment 16122570   -> exit 1 "no default account set"   (there is one)
```

This is why guarding the filter alone was not enough: it would have turned a wrong-data bug into a total outage for correctly configured keyring users. `b734b80` from #28 is cherry-picked here as the first commit for exactly that reason — **if #28 merges first this rebases away cleanly; if this merges first, #28 becomes empty.**

## What was returning the whole network

| command | before | after |
|---|---|---|
| `q deployment` | 100 rows / 64 owners, exit 0 | refused |
| `q market order` / `bid` / `lease` | 100 rows, exit 0 | refused |
| `q market bid\|lease --by provider` | 100 rows / 64 providers, exit 0 | refused |

SPEC §3.8 defines a bare listing as "all matching resources for the context's default account" and §3.8.4 marks the leading address **required** in provider mode. An empty owner reads as "no filter", not "no results". The escrow and deployment-group paths already refused; these now match them.

A context legitimately has no default account — `console-api` never sets one — so this is a normal state, not a misconfiguration.

## Input that was accepted and ignored

- **21 group commands exited 0 on a typo'd subcommand**, printing help to stdout. `akt console deploymnt list || alert` never fired.
- **15 leaf commands took a positional they never read.** `q audit list <address>` returned all 70 providers, byte-identical to the unfiltered list — with `q audit get <owner>` sitting right next to it.
- **`--by Provider` silently meant `--by owner`** — asked what a provider leased, told what an address deployed.
- **`-o josn` silently rendered a pretty table**, piping ANSI escapes into `jq` at exit 0.

## MCP

Same unscoped-list bug in `akash_list_{deployments,certificates,orders,bids,leases}`, where it is worse: an assistant has no help text to notice. The sibling `get` tools already guarded.

`akash_node_status` and `akash_block_height` **killed the server process** — one call, broken pipe, session over, including the Console tools that were working a second earlier. `WithRecovery` scopes the failure to the offending call; the nil client behind it is what #29 fixes.

## Money

`console wallet list` reported an **$11.35 wallet as `$11,350,924.00`** while `console wallet balance` said `$57.49` total for the same account. `creditAmount` is `uact` — micro-ACT — and a code comment asserted it was dollar-scale, citing a `usdc` denom the endpoint does not return.

## Verification

- New regression tests for both the CLI and MCP halves, each confirmed to **fail against the unfixed code** rather than passing vacuously.
- Full unit suite green; `go vet` clean; `gofmt` clean.
- `golangci-lint` could not run locally (built against go1.24, repo targets 1.26.1) — CI covers it.
- Local cgo builds are broken on this machine (Xcode CLT), so everything was built and tested with `CGO_ENABLED=0`. No change here touches cgo.

## Found and deliberately not fixed here

Filed rather than folded in, to keep this PR to one class:

- **`query ibc *` dials `localhost:26657`** instead of the context node — 38 commands unusable, and `ibc client params` / `ibc connection params` **panic** (exit 2, upstream ibc-go discards an error then dereferences nil).
- **`--chain-id` and `--height` are accepted and ignored** on query commands — `--chain-id sandbox-2` returns mainnet at exit 0.
- **`-o` is ignored by all ~35 `console` commands** and by `context show`, `network show`, `store status`, `sdl scaffolds`, `version`.
- **`sdl init web --gpu 4` silently drops the flag** — produces a CPU-only SDL that deploys and bills while the user believes they bought a GPU.
- **`console deployment settings <dseq>` is get-or-create** — it writes, and reports auto-top-up *enabled* for deployments that do not exist or belong to strangers.
- **`console deployment list` mis-attributes leases** to the wrong deployments (upstream scramble in `GET /v1/deployments`; akt can re-key by each lease's own dseq).
- `--quiet` and `--verbose` are dead flags on all ~400 commands; a `0` in any sequence position silently widens the query; `escrow --offset/--page/--reverse` are inert; `query gov proposals -o json` fails outright.