### PR TITLE
fix(workflow): recover partial deploys and deliver updates

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- **Workflow JSONL dry-runs emitted human prose**: `deploy`, `update`, and
+  `close` now emit one valid JSONL `planned` record per step, with a shared run
+  ID and empty error/transaction arrays, instead of silently ignoring their
+  advertised output mode.
+
 - **Console mutation responses could contradict the resulting chain state**:
   lease creation now reads the deployment back after a failed response and
   reports success only when every exact requested lease is active, without

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 
+- **Console mutation responses could contradict the resulting chain state**:
+  lease creation now reads the deployment back after a failed response and
+  reports success only when every exact requested lease is active, without
+  replaying the non-idempotent POST. Deployment updates retry the Console's
+  transient manifest-version rejection and reconcile the expected SDL hash
+  before reporting failure. Deployment details retain the API's version hash.
+  Chain deployment help now recommends `auto`, so it follows the network's
+  current minimum amount and denomination instead of advertising a stale
+  hard-coded coin.
+
 - **Workflow failures hid paid partial state and chain updates stopped at the
   transaction**: failed deploys now report their DSEQ, provider, continuing
   escrow risk, and exact retry and explicit-close commands without performing

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixed
 
+- **Workflow failures hid paid partial state and chain updates stopped at the
+  transaction**: failed deploys now report their DSEQ, provider, continuing
+  escrow risk, and exact retry and explicit-close commands without performing
+  destructive cleanup automatically. Chain-backed updates deliver the revised
+  manifest to every active lease provider, attempt all providers before
+  failing, and remain safely retryable; Console-backed updates continue to use
+  the Console API's manifest handling.
+
 - **Monitor provider loading and WebSocket discovery were underspecified**:
   provider cache loading, on-chain reconciliation, health checks, periodic
   resync, and cache persistence now form one startup-owned pipeline independent

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -375,6 +375,20 @@ graph LR
 | `NewConsole(consoleClient, chainQueries, root, ctxName)` | `KindConsole` | Mapping each message type to a Console API REST endpoint (SPEC §7.5). Query steps go straight to the chain when a chain client is available; without one, `market.bids` falls back to the Console bids endpoint. `root`/`ctxName` locate the per-context manifest cache that carries the manifest from deployment create to lease create. |
 | `NewProvider(clientCtx, authType)` | chain rail only | Provider gateway calls (JWT or mTLS). The console rail has **no** provider client: the Console API submits the manifest internally during lease creation, so provider steps are dropped from the run with a note on stderr rather than failing it. |
 
+On the chain rail, an update's provider step queries every page of active
+leases for the deployment, de-duplicates and sorts their provider addresses,
+then submits the updated manifest to every provider. A failure from one
+provider does not prevent attempts to the others, but the workflow remains
+failed until every active provider accepts the manifest. Retrying the update is
+therefore safe. The Console rail continues to omit this provider step because
+its deployment update endpoint owns manifest delivery.
+
+Workflow failures never close deployments automatically. When deploy reaches
+paid on-chain state before failing, the command surfaces the DSEQ, provider (if
+known), and exact retry and explicit-close commands in both human and JSONL
+output. This keeps irreversible cleanup under the user's control while making
+the continuing escrow liability unmistakable.
+
 **Why a translation layer and not per-rail commands**: the alternative — a `deploy` that knows about keyrings and a separate Console `deploy` — means every new action is designed twice, and the two surfaces drift on flag names, defaults, argument order, and error text. Here, adding an action is a workflow definition plus (at most) a message mapping in the console adapter. Neither rail's command handler changes, and no rail-specific redesign is required.
 
 **One argument surface**: the CLI's argument surface is *generated* from the workflow definition (`internal/cli/workflow`). Positional arguments come from the definition's required file param and its optional `dseq` param, and every non-file param also gets a flag carrying the definition's type, default, and description. Because the definition is shared, `akt deploy`, `akt update`, and `akt close` take **identical arguments on both rails** — the rail is a property of the active context (`auth-method`), not of the command line. A user switching from a keyring context to a console-api one types the same command.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -389,6 +389,16 @@ known), and exact retry and explicit-close commands in both human and JSONL
 output. This keeps irreversible cleanup under the user's control while making
 the continuing escrow liability unmistakable.
 
+Console mutation responses are not trusted as the only evidence of resulting
+state. A non-idempotent lease POST is never replayed after an error; the client
+instead reads the deployment back and accepts success only when every exact
+requested lease is active. Deployment updates are idempotent, so the Console's
+specific transient manifest-version rejection is retried within the normal
+three-attempt bound. After any failed update response, the client compares the
+deployment's API-reported version hash with the deterministic hash of the SDL
+before deciding whether the update failed. Action logs record the reconciled
+outcome, not merely the first HTTP response.
+
 **Why a translation layer and not per-rail commands**: the alternative — a `deploy` that knows about keyrings and a separate Console `deploy` — means every new action is designed twice, and the two surfaces drift on flag names, defaults, argument order, and error text. Here, adding an action is a workflow definition plus (at most) a message mapping in the console adapter. Neither rail's command handler changes, and no rail-specific redesign is required.
 
 **One argument surface**: the CLI's argument surface is *generated* from the workflow definition (`internal/cli/workflow`). Positional arguments come from the definition's required file param and its optional `dseq` param, and every non-file param also gets a flag carrying the definition's type, default, and description. Because the definition is shared, `akt deploy`, `akt update`, and `akt close` take **identical arguments on both rails** — the rail is a property of the active context (`auth-method`), not of the command line. A user switching from a keyring context to a console-api one types the same command.
@@ -398,11 +408,18 @@ the continuing escrow liability unmistakable.
 | Form | Examples | Meaning |
 |---|---|---|
 | USD | `5usd`, `$5`, `5.50usd` | A USD amount. The `usd` unit is case-insensitive and always wins over coin parsing, so a value ending in `usd` is never read as a chain denomination. |
-| Coin | `5000000uakt`, `5akt` | A chain coin amount, parsed as a decimal coin. |
+| Coin | an explicit `<amount><denom>` | A chain coin amount, parsed as a decimal coin. The denomination must match the active network's deployment deposit parameter. |
 | Bare number | `5`, `5.50` | Unit-less: USD on the console rail, rejected on the chain rail (coins have always required a denomination). |
 | `auto` / empty | `auto` | Defer to the rail default: the chain-minimum deployment deposit on the chain rail; the console rail has no default and asks for an explicit USD amount. |
 
-Every form parses on every rail; only the *interpretation* is rail-specific, and each rejection names the rail that would accept the value ("USD deposits require a console-api context; specify a coin amount like `5000000uakt`"). SPEC §7.4 carries the full per-rail acceptance table. The Console minimum is a single exported constant (`transport.MinConsoleDepositUSD`, aliasing `console.MinDepositUSD`) so every surface that enforces it — CLI commands and workflow adapters alike — shares one value.
+Every form parses on every rail; only the *interpretation* is rail-specific,
+and each rejection names the rail that would accept the value. Chain users are
+directed to `auto` first because it queries the active network's minimum amount
+and denomination; an explicit coin remains available as an override. SPEC
+§7.4 carries the full per-rail acceptance table. The Console minimum is a
+single exported constant (`transport.MinConsoleDepositUSD`, aliasing
+`console.MinDepositUSD`) so every surface that enforces it — CLI commands and
+workflow adapters alike — shares one value.
 
 ### 3.6 Capability Gating
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -579,8 +579,10 @@ The `chain-sdk` CLI package (`pkg.akt.dev/go/cli`) will be deprecated and eventu
   required, typed, and semantic parameter validators as execution. They may
   skip client discovery and every state-changing step, but they cannot skip
   SDL, deposit, duration, sequence, selector, transaction chain, or enum
-  validation. A printed plan therefore describes an invocation that could
-  enter execution, not merely one that Cobra could parse.
+  validation. A plan therefore describes an invocation that could enter
+  execution, not merely one that Cobra could parse. Pretty dry-runs render the
+  human plan; JSONL dry-runs render one `planned` record per step and never mix
+  prose into stdout.
 - **Transaction identity is checked at the boundary**: online construction,
   simulation, and broadcast require an explicit chain ID to agree with the
   selected context and accept only advertised sign modes. Explicit offline

--- a/SPEC.md
+++ b/SPEC.md
@@ -1134,16 +1134,16 @@ Steps can also define `retry` with `max` attempts and `delay` between retries.
 
 When a workflow aborts due to a step failure, the user may be left with partial on-chain state (e.g., a deployment was created but no lease was established, consuming escrow). The workflow engine handles this as follows:
 
-1. **Abort message includes partial state summary**: When a workflow aborts, the error output lists all successfully completed steps and their results (e.g., "Deployment created with DSEQ 12345"). This gives the user the information needed to clean up manually.
+1. **Abort message includes partial state summary**: When a deploy workflow aborts after `create-deployment` succeeds, both the human output and the returned command error identify the DSEQ and provider, when known. They also warn that escrow may continue to be consumed while the deployment or lease remains open. This gives the user the information needed to recover even when stdout was redirected or suppressed.
 
 2. **Recovery suggestions**: The abort message includes actionable suggestions based on which step failed:
    - Failed after `create-deployment`: Suggest `akt close <dseq>` to close the orphaned deployment and reclaim the escrow deposit.
-   - Failed after `create-lease` but before `send-manifest`: Suggest `akt provider send-manifest <sdl-file> --dseq <dseq>` to retry manifest submission.
-   - Failed during `send-manifest`: Suggest retrying with `akt provider send-manifest` directly.
+   - Failed after `create-lease` but before `send-manifest`: Suggest `akt provider send-manifest <sdl-file> --dseq <dseq> --provider <provider>` to retry manifest submission.
+   - Failed during `send-manifest`: Suggest the same complete retry command, including the SDL path, DSEQ, and provider.
 
-3. **JSONL mode**: In JSONL mode, the error line includes a `"recovery"` field with the suggested command:
+3. **JSONL mode**: In JSONL mode, the failed step includes `"dseq"`, `"provider"`, `"recovery"`, and `"cleanup"` fields when known. The recovery and cleanup values are complete copy-pasteable commands:
    ```jsonl
-   {"workflow":"deploy","id":"wf_abc123","step":"send-manifest","result":"error","errors":["provider gateway timeout"],"txs":[],"recovery":"akt provider send-manifest deploy.yaml --dseq 12345"}
+   {"workflow":"deploy","id":"wf_abc123","step":"send-manifest","result":"error","errors":["provider gateway timeout"],"txs":[],"dseq":12345,"provider":"akash1provider...","recovery":"akt provider send-manifest deploy.yaml --dseq 12345 --provider akash1provider...","cleanup":"akt close 12345"}
    ```
 
 4. **No automatic rollback**: The workflow engine does not automatically roll back completed steps. On-chain transactions are irreversible. The user must explicitly close deployments or leases they no longer want.
@@ -1251,6 +1251,17 @@ steps:
       dseq: "{{ .Params.dseq }}"
     on-error: abort
 
+  - name: send-manifest
+    type: provider
+    action: send-manifest-to-active-leases
+    params:
+      dseq: "{{ .Params.dseq }}"
+      sdl: "{{ index .Params \"sdl-file\" }}"
+    retry:
+      max: 3
+      delay: "5s"
+    on-error: abort
+
   - name: display-result
     type: output
     template: |
@@ -1258,7 +1269,13 @@ steps:
         DSEQ: {{ .Params.dseq }}
 ```
 
-Manifest re-send to providers with active leases (a `foreach` over `market.leases` running `provider`/`send-manifest` sub-steps) is planned for when the engine gains the `foreach` step type; until then, keyring users re-send manifests with `akt provider send-manifest` after an update, and console-api contexts get manifest handling from the Console API automatically.
+On the chain rail, `send-manifest-to-active-leases` queries every page of active
+leases for the owner and DSEQ, de-duplicates and sorts provider addresses, and
+attempts manifest submission to all of them. A provider failure does not stop
+delivery attempts to the remaining providers, but the step fails unless every
+provider accepts the update. No active leases is a successful no-op. The
+operation is safe to retry. Console API contexts omit the provider step because
+`PUT /v1/deployments/{dseq}` handles manifest delivery internally.
 
 **Close workflow definition:**
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -410,7 +410,10 @@ validation. Workflow commands validate required parameters and their declared
 types before printing a plan. Built-in deployment workflows additionally parse
 the SDL and validate deposit syntax, positive sequence identifiers, bid
 timeouts, bid selectors, output mode, and transaction chain identity. Invalid
-input produces a non-zero usage error and no plan.
+input produces a non-zero usage error and no plan. In `--output jsonl` mode, a
+valid dry-run emits one JSON object per planned step with `result:"planned"`,
+empty `errors` and `txs` arrays, and one generated run ID shared by every line;
+it emits no human plan text.
 
 ### 2.0 Root Command Behavior (`akt` with no subcommand)
 
@@ -1199,7 +1202,7 @@ On error:
 | `workflow` | string   | Workflow name (e.g., `deploy`, `update`, `close`)               |
 | `id`       | string   | Unique workflow run ID (generated at start, same for all steps) |
 | `step`     | string   | Step name from the workflow definition                          |
-| `result`   | string   | `completed`, `error`, or `skipped` (step skipped by its on-error policy) |
+| `result`   | string   | `planned` (dry-run), `completed`, `error`, or `skipped` (step skipped by its on-error policy) |
 | `errors`   | []string | Array of error messages (empty when `result` is `completed`)    |
 | `txs`      | []object | Array of raw transaction results (empty for non-tx steps)       |
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -984,7 +984,7 @@ params:
   deposit:
     type: deposit
     default: "auto"
-    description: "Initial deposit: 5usd or $5 (USD, console-api contexts), 5000000uakt (coin, keyring contexts), auto = chain minimum (keyring)"
+    description: "Initial deposit: auto (recommended chain minimum, keyring), 5usd or $5 (console-api), or an explicit coin in the network's deposit denomination (keyring)"
   bid-timeout:
     type: duration
     default: "5m"
@@ -1320,7 +1320,7 @@ The flagship workflow command. Orchestrates the full deployment lifecycle:
 | Flag               | Type     | Default         | Description                                                 |
 | ------------------ | -------- | --------------- | ----------------------------------------------------------- |
 | `--from`           | string   | context default | Account to deploy from                                      |
-| `--deposit`        | string   | `auto`          | Initial deposit, unified syntax on both rails (see §7.4): `5usd`/`$5`, `5000000uakt`, or `auto` |
+| `--deposit`        | string   | `auto`          | Initial deposit, unified syntax on both rails (see §7.4): `auto` (recommended for keyring), `5usd`/`$5` (Console), or an explicit network deposit coin |
 | `--bid-timeout`    | duration | `5m`            | Maximum time to wait for bids                               |
 | `--min-bids`       | int      | `1`             | Minimum bids before selection                               |
 | `--bid-select`     | string   | `"interactive"` | Bid selection: `interactive`, `cheapest`, `provider=<addr>` |
@@ -2480,7 +2480,7 @@ Select networks  ↑↓ move  space toggle  enter confirm
 **Value input prompt**: Free-form text or numeric input with an optional default. Used for deposit amounts, gas overrides, or custom names. Input is validated before acceptance.
 
 ```
-Initial deposit amount [5000000uakt]: _
+Initial deposit amount [auto]: _
 ```
 
 #### 3.9.2 Prompt Rendering Conventions
@@ -3132,7 +3132,8 @@ Returns paginated list of deployments with leases and escrow state.
 
 #### `GET /v1/deployments/{dseq}` -- Get Deployment
 
-Path parameter: `dseq` (deployment sequence ID). Returns deployment details with leases and escrow.
+Path parameter: `dseq` (deployment sequence ID). Returns deployment details,
+including the base64 deployment version `hash`, with leases and escrow.
 
 #### `PUT /v1/deployments/{dseq}` -- Update Deployment
 
@@ -3158,6 +3159,12 @@ Query parameter: `dseq` (required). Returns array of bids with provider details,
 | `leases`   | []object | yes      | Array of `{ dseq, gseq, oseq, provider }` |
 
 Returns deployment with created leases and escrow state.
+
+`POST /v1/leases` is not replayed after an error because it is not
+idempotent. Instead, the client reads each referenced deployment back and
+treats the operation as successful only when every exact requested
+`dseq/gseq/oseq/provider` lease is present and active. If read-back does not
+prove that state, the original POST error is returned.
 
 #### `POST /v1/deposit-deployment` -- Add Deposit
 
@@ -3196,8 +3203,8 @@ When a workflow runs in a context with `auth-method: console-api`, the workflow 
 
 | Form | Examples | `keyring` (chain rail) | `console-api` (console rail) |
 |---|---|---|---|
-| USD | `5usd`, `$5`, `5.50usd` | Error: `USD deposits require a console-api context; specify a coin amount like 5000000uakt` | Sent as USD in the Console API's `data.deposit` field (Console minimum: 0.50 USD) |
-| Coin | `5000000uakt`, `5akt` | Attached to the deployment as the coin deposit | Error: `console deposits are in USD; use e.g. 5usd` |
+| USD | `5usd`, `$5`, `5.50usd` | Error directs the user to `auto` (recommended) or an explicit coin in the network's deployment deposit denomination | Sent as USD in the Console API's `data.deposit` field (Console minimum: 0.50 USD) |
+| Coin | explicit `<amount><denom>` | Attached to the deployment; the denomination must match the active network's deployment deposit parameter | Error: `console deposits are in USD; use e.g. 5usd` |
 | Bare number | `5`, `5.50` | Error (coins require a denomination — the historical chain behavior, with cross-rail guidance) | Interpreted as USD, same as `5usd` |
 | `auto` / empty | `auto` | Chain-minimum deployment deposit, queried on chain | Error: an explicit USD deposit is required |
 
@@ -3233,6 +3240,14 @@ Use a context with auth-method: keyring for this operation.
 | 404         | Deployment not found (dseq does not exist or not owned by user).  |
 | 429         | Rate limited. Retry with backoff (safe for every method: the request was rejected before processing). |
 | 5xx         | Console API server error. Retry with backoff (max 3 attempts) for idempotent methods (GET/HEAD/PUT/DELETE) only. POST is never replayed on 5xx: the request may have been processed despite the error (e.g. a gateway 502 after a completed write), and replaying it could duplicate a deployment or a USD deposit. |
+
+The Console may transiently reject an otherwise valid deployment PUT with
+`422 manifest version validation failed`. Because PUT is idempotent, that exact
+response is retried within the same three-attempt bound. After any failed PUT,
+the client reads the deployment back and compares its base64 `hash` with the
+deterministic SDL version; a match proves success despite the failed response.
+All other 4xx responses remain terminal. A failed lease POST follows the
+read-back rule in §7.3 and is never replayed.
 
 ### 7.7 Differences from Keyring Auth
 

--- a/internal/cli/workflow/commands.go
+++ b/internal/cli/workflow/commands.go
@@ -201,15 +201,20 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 			out := cmd.OutOrStdout()
 			jsonl := outputFormat(cmd) == outputJSONL
 
-			// Print the execution plan, except in JSONL mode where stdout
-			// must carry only JSONL step lines.
-			if dryRun || !jsonl {
-				printPlan(out, rtDef, params)
-			}
-
 			if dryRun {
+				if jsonl {
+					return emitDryRunJSONL(out, rtDef)
+				}
+
+				printPlan(out, rtDef, params)
 				fmt.Fprintln(out, "\nDry run — no transactions broadcast.")
 				return nil
+			}
+
+			// During execution, keep stdout pure in JSONL mode; other modes
+			// retain the human plan before step results.
+			if !jsonl {
+				printPlan(out, rtDef, params)
 			}
 
 			return executeWorkflow(cmd, rtDef, params, mgrFn, ctxNameFn, jsonl, discoverErr)
@@ -651,6 +656,30 @@ func emitJSONL(out io.Writer, state *wf.RunState, recovery *workflowRecovery) {
 
 		_ = enc.Encode(line)
 	}
+}
+
+// emitDryRunJSONL renders the validated plan without executing or discovering
+// clients. Every line shares one run ID so consumers can treat it like an
+// execution stream, while "planned" distinguishes it from completed work.
+func emitDryRunJSONL(out io.Writer, def *wf.WorkflowDef) error {
+	enc := json.NewEncoder(out)
+	runID := wf.GenerateWorkflowID()
+
+	for _, step := range def.Steps {
+		line := jsonlLine{
+			Workflow: def.Name,
+			ID:       runID,
+			Step:     step.Name,
+			Result:   "planned",
+			Errors:   []string{},
+			Txs:      []jsonlTx{},
+		}
+		if err := enc.Encode(line); err != nil {
+			return fmt.Errorf("render workflow dry-run JSONL: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // outputFormat returns the effective --output value for the command,

--- a/internal/cli/workflow/commands.go
+++ b/internal/cli/workflow/commands.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -362,15 +363,16 @@ func executeWorkflow(
 	engine := wf.NewEngine(registry, logger)
 
 	state, runErr := engine.Run(cmd.Context(), rtDef, account, params)
+	recovery := deployRecoveryAdvice(state, runErr)
 
 	if jsonl {
-		emitJSONL(out, state)
+		emitJSONL(out, state, recovery)
 	} else {
-		printResults(out, state, runErr)
+		printResults(out, state, runErr, recovery)
 	}
 
 	if runErr != nil {
-		return fmt.Errorf("workflow %q failed: %w", rtDef.Name, runErr)
+		return workflowFailureError(rtDef.Name, runErr, recovery)
 	}
 
 	return nil
@@ -454,7 +456,7 @@ func printPlan(out io.Writer, rtDef *wf.WorkflowDef, params map[string]any) {
 
 // printResults renders per-step outcomes and the overall workflow status in
 // simple aligned text.
-func printResults(out io.Writer, state *wf.RunState, runErr error) {
+func printResults(out io.Writer, state *wf.RunState, runErr error, recovery *workflowRecovery) {
 	fmt.Fprintln(out, "\nResults:")
 
 	for _, name := range state.StepOrder {
@@ -475,7 +477,110 @@ func printResults(out io.Writer, state *wf.RunState, runErr error) {
 
 	if runErr == nil {
 		fmt.Fprintf(out, "\nWorkflow %q completed successfully.\n", state.Workflow)
+	} else if recovery != nil {
+		fmt.Fprintln(out, "\nPartial deployment state:")
+		fmt.Fprintf(out, "  DSEQ: %d\n", recovery.DSeq)
+		if recovery.Provider != "" {
+			fmt.Fprintf(out, "  Provider: %s\n", recovery.Provider)
+		}
+		fmt.Fprintln(out, "  WARNING: This deployment remains open; escrow may continue to be consumed.")
+		if recovery.Recovery != "" {
+			fmt.Fprintf(out, "  Recovery: %s\n", recovery.Recovery)
+		}
+		fmt.Fprintf(out, "  Explicit cleanup: %s\n", recovery.Cleanup)
 	}
+}
+
+type workflowRecovery struct {
+	DSeq     uint64
+	Provider string
+	Recovery string
+	Cleanup  string
+}
+
+func deployRecoveryAdvice(state *wf.RunState, runErr error) *workflowRecovery {
+	if state == nil || runErr == nil || state.Workflow != "deploy" {
+		return nil
+	}
+
+	created := state.Steps["create-deployment"]
+	if created == nil || created.Status != "success" {
+		return nil
+	}
+
+	dseq, err := workflowOutputUint64(created.Output, "dseq")
+	if err != nil || dseq == 0 {
+		return nil
+	}
+
+	provider := workflowOutputString(state.Steps["create-lease"], "provider")
+	if provider == "" {
+		provider = workflowOutputString(state.Steps["select-bid"], "provider")
+	}
+
+	recovery := &workflowRecovery{
+		DSeq:     dseq,
+		Provider: provider,
+		Cleanup:  fmt.Sprintf("akt close %d", dseq),
+	}
+	if provider != "" {
+		if sdlPath, ok := state.Params["sdl-file"].(string); ok && strings.TrimSpace(sdlPath) != "" {
+			recovery.Recovery = fmt.Sprintf(
+				"akt provider send-manifest %s --dseq %d --provider %s",
+				shellQuote(sdlPath), dseq, provider,
+			)
+		}
+	}
+
+	return recovery
+}
+
+func workflowOutputUint64(output map[string]any, key string) (uint64, error) {
+	if output == nil || output[key] == nil {
+		return 0, fmt.Errorf("workflow output %q is missing", key)
+	}
+
+	value := strings.TrimSpace(fmt.Sprint(output[key]))
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("workflow output %q is not an unsigned integer: %w", key, err)
+	}
+
+	return parsed, nil
+}
+
+func workflowOutputString(result *wf.StepResult, key string) string {
+	if result == nil || result.Output == nil || result.Output[key] == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(fmt.Sprint(result.Output[key]))
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func workflowFailureError(workflow string, runErr error, recovery *workflowRecovery) error {
+	if recovery == nil {
+		return fmt.Errorf("workflow %q failed: %w", workflow, runErr)
+	}
+
+	provider := ""
+	if recovery.Provider != "" {
+		provider = fmt.Sprintf(" with provider %s", recovery.Provider)
+	}
+	retry := ""
+	if recovery.Recovery != "" {
+		retry = fmt.Sprintf("\nretry manifest delivery: %s", recovery.Recovery)
+	}
+
+	return fmt.Errorf(
+		"workflow %q failed: %w\n"+
+			"deployment DSEQ %d%s remains open; escrow may continue to be consumed.%s\n"+
+			"explicit cleanup: %s",
+		workflow, runErr, recovery.DSeq, provider, retry, recovery.Cleanup,
+	)
 }
 
 // jsonlTx is the tx object of a JSONL step line (SPEC §2.3.8).
@@ -494,10 +599,14 @@ type jsonlLine struct {
 	Result   string    `json:"result"`
 	Errors   []string  `json:"errors"`
 	Txs      []jsonlTx `json:"txs"`
+	DSeq     uint64    `json:"dseq,omitempty"`
+	Provider string    `json:"provider,omitempty"`
+	Recovery string    `json:"recovery,omitempty"`
+	Cleanup  string    `json:"cleanup,omitempty"`
 }
 
 // emitJSONL writes one JSONL line per completed step (SPEC §2.3.8).
-func emitJSONL(out io.Writer, state *wf.RunState) {
+func emitJSONL(out io.Writer, state *wf.RunState, recovery *workflowRecovery) {
 	enc := json.NewEncoder(out)
 
 	for _, name := range state.StepOrder {
@@ -525,6 +634,12 @@ func emitJSONL(out io.Writer, state *wf.RunState) {
 
 		if sr.Error != "" {
 			line.Errors = append(line.Errors, sr.Error)
+		}
+		if line.Result == "error" && recovery != nil {
+			line.DSeq = recovery.DSeq
+			line.Provider = recovery.Provider
+			line.Recovery = recovery.Recovery
+			line.Cleanup = recovery.Cleanup
 		}
 
 		if sr.TxHash != "" {

--- a/internal/cli/workflow/commands_test.go
+++ b/internal/cli/workflow/commands_test.go
@@ -200,6 +200,13 @@ func TestCommandFromDefDeploy(t *testing.T) {
 			t.Fatalf("deploy command missing --%s flag", flag)
 		}
 	}
+	depositHelp := cmd.Flags().Lookup("deposit").Usage
+	if !strings.Contains(depositHelp, "auto (recommended") {
+		t.Errorf("--deposit help %q does not recommend the network-derived default", depositHelp)
+	}
+	if strings.Contains(depositHelp, "uakt") {
+		t.Errorf("--deposit help %q advertises a network-specific denomination", depositHelp)
+	}
 }
 
 // TestUserWorkflowOverridesBuiltin verifies that a user workflow with the

--- a/internal/cli/workflow/commands_test.go
+++ b/internal/cli/workflow/commands_test.go
@@ -368,6 +368,70 @@ func TestExecuteDryRunNeedsNoClient(t *testing.T) {
 	}
 }
 
+func TestExecuteDryRunJSONLEmitsPlannedSteps(t *testing.T) {
+	homeFn, ctxNameFn := staticFns(t.TempDir())
+	sdl := writeValidWorkflowSDL(t)
+	tests := []struct {
+		name  string
+		args  []string
+		steps []string
+	}{
+		{name: "deploy", args: []string{sdl, "--dry-run", "--output", "jsonl"}, steps: []string{"create-deployment", "wait-for-bids", "select-bid", "create-lease", "send-manifest", "display-result"}},
+		{name: "update", args: []string{sdl, "456", "--dry-run", "--output", "jsonl"}, steps: []string{"update-deployment", "send-manifest", "display-result"}},
+		{name: "close", args: []string{"456", "--dry-run", "--output", "jsonl"}, steps: []string{"close-deployment", "display-result"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := findCommand(Commands(homeFn, ctxNameFn), tc.name)
+			if cmd == nil {
+				t.Fatalf("workflow command %q not found", tc.name)
+			}
+
+			out, err := executeCommand(t, cmd, tc.args...)
+			if err != nil {
+				t.Fatalf("JSONL dry-run execute: %v\noutput:\n%s", err, out)
+			}
+			if strings.Contains(out, "Workflow:") || strings.Contains(out, "Dry run") {
+				t.Fatalf("JSONL dry-run mixed human text into stdout:\n%s", out)
+			}
+
+			lines := strings.Split(strings.TrimSpace(out), "\n")
+			if len(lines) != len(tc.steps) {
+				t.Fatalf("JSONL dry-run emitted %d lines, want %d:\n%s", len(lines), len(tc.steps), out)
+			}
+
+			var runID string
+			for i, raw := range lines {
+				var got struct {
+					Workflow string            `json:"workflow"`
+					ID       string            `json:"id"`
+					Step     string            `json:"step"`
+					Result   string            `json:"result"`
+					Errors   []string          `json:"errors"`
+					Txs      []json.RawMessage `json:"txs"`
+				}
+				if err := json.Unmarshal([]byte(raw), &got); err != nil {
+					t.Fatalf("line %d is not JSON: %v\n%s", i+1, err, raw)
+				}
+				if got.Workflow != tc.name || got.Step != tc.steps[i] || got.Result != "planned" {
+					t.Errorf("line %d = %+v, want workflow=%q step=%q result=planned", i+1, got, tc.name, tc.steps[i])
+				}
+				if got.ID == "" {
+					t.Errorf("line %d has empty run ID", i+1)
+				} else if runID == "" {
+					runID = got.ID
+				} else if got.ID != runID {
+					t.Errorf("line %d run ID = %q, want %q", i+1, got.ID, runID)
+				}
+				if got.Errors == nil || len(got.Errors) != 0 || got.Txs == nil || len(got.Txs) != 0 {
+					t.Errorf("line %d errors/txs = %#v/%#v, want empty arrays", i+1, got.Errors, got.Txs)
+				}
+			}
+		})
+	}
+}
+
 // TestExecuteKeyringContextWithoutChainClient verifies the clear
 // wallet/chain-client error when a keyring context has no chain client in
 // the command context (the "neither credential" case).

--- a/internal/cli/workflow/commands_test.go
+++ b/internal/cli/workflow/commands_test.go
@@ -595,6 +595,74 @@ func TestBuiltinWorkflowParamTypesMatchPreflightContracts(t *testing.T) {
 	}
 }
 
+func TestBuiltinUpdateSendsManifestBeforeReportingSuccess(t *testing.T) {
+	update := loadBuiltin(t, "update")
+	if len(update.Steps) != 3 {
+		t.Fatalf("update steps = %+v, want update, manifest delivery, display", update.Steps)
+	}
+
+	manifest := update.Steps[1]
+	if manifest.Name != "send-manifest" || manifest.Type != wf.StepProvider || manifest.Action != "send-manifest-to-active-leases" {
+		t.Fatalf("update manifest step = %+v", manifest)
+	}
+	if manifest.Retry == nil || manifest.Retry.Max != 3 || manifest.Retry.Delay != "5s" {
+		t.Errorf("update manifest retry = %+v, want 3 attempts at 5s", manifest.Retry)
+	}
+	if update.Steps[2].Type != wf.StepOutput {
+		t.Errorf("success output must follow manifest delivery: %+v", update.Steps)
+	}
+}
+
+func TestExecuteConsoleUpdateUsesConsoleManifestHandling(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(aktctx.EnvConsoleAPIKey, "secret-key")
+
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/deployments/4242" {
+			t.Errorf("unexpected console request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"owner":"o","dseq":"4242"},"state":"active"},"leases":[]}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	m := newTestManager(t, home, "console", aktctx.AuthMethodConsoleAPI)
+	if err := m.UpdateContext("console", func(c *aktctx.Context) error {
+		c.ConsoleAPIURL = srv.URL
+		return nil
+	}); err != nil {
+		t.Fatalf("UpdateContext: %v", err)
+	}
+
+	cmd := findCommand(CommandsWithManager(
+		func() string { return home },
+		func() string { return "console" },
+		func() *aktctx.Manager { return m },
+	), "update")
+	if cmd == nil {
+		t.Fatal("CommandsWithManager() did not surface update")
+	}
+
+	out, err := executeCommand(t, cmd, writeValidWorkflowSDL(t), "4242")
+	if err != nil {
+		t.Fatalf("update execute: %v\noutput:\n%s", err, out)
+	}
+	if requests != 1 {
+		t.Errorf("Console requests = %d, want one update request", requests)
+	}
+	for _, want := range []string{
+		"skipping step \"send-manifest\" (manifest submission handled by Console)",
+		"update-deployment", "display-result", "completed successfully",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output does not contain %q:\n%s", want, out)
+		}
+	}
+}
+
 func writeValidWorkflowSDL(t *testing.T) string {
 	t.Helper()
 

--- a/internal/cli/workflow/helpers_test.go
+++ b/internal/cli/workflow/helpers_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -64,7 +65,7 @@ func TestEmitJSONLShape(t *testing.T) {
 	state.SetStepResult("boom", &wf.StepResult{Name: "boom", Status: "failed", Error: "out of gas"})
 
 	var buf bytes.Buffer
-	emitJSONL(&buf, state)
+	emitJSONL(&buf, state, nil)
 
 	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
 	if len(lines) != 3 {
@@ -124,10 +125,133 @@ func TestEmitJSONLSkipsMissingResults(t *testing.T) {
 	state.SetStepResult("ghost", nil)
 
 	var buf bytes.Buffer
-	emitJSONL(&buf, state)
+	emitJSONL(&buf, state, nil)
 
 	if strings.TrimSpace(buf.String()) != "" {
 		t.Errorf("a nil step result must emit nothing, got %q", buf.String())
+	}
+}
+
+func TestDeployRecoveryAdviceSurfacesPaidPartialState(t *testing.T) {
+	state := wf.NewRunState("run-1", "deploy", "akash1owner", map[string]any{
+		"sdl-file": "/tmp/my deployment.yaml",
+	})
+	state.SetStepResult("create-deployment", &wf.StepResult{
+		Name:   "create-deployment",
+		Status: "success",
+		Output: map[string]any{"dseq": "4242"},
+	})
+	state.SetStepResult("select-bid", &wf.StepResult{
+		Name:   "select-bid",
+		Status: "success",
+		Output: map[string]any{"provider": "akash1provider"},
+	})
+	state.SetStepResult("create-lease", &wf.StepResult{
+		Name:   "create-lease",
+		Status: "success",
+		Output: map[string]any{"dseq": "4242", "provider": "akash1provider"},
+	})
+	state.SetStepResult("send-manifest", &wf.StepResult{
+		Name:   "send-manifest",
+		Status: "failed",
+		Error:  "gateway timeout",
+	})
+
+	advice := deployRecoveryAdvice(state, errors.New("send manifest failed"))
+	if advice == nil {
+		t.Fatal("deploy failure after create-deployment returned no recovery advice")
+	}
+	if advice.DSeq != 4242 || advice.Provider != "akash1provider" {
+		t.Fatalf("partial state = %+v, want dseq 4242 and provider", advice)
+	}
+	if advice.Recovery != "akt provider send-manifest '/tmp/my deployment.yaml' --dseq 4242 --provider akash1provider" {
+		t.Errorf("recovery command = %q", advice.Recovery)
+	}
+	if advice.Cleanup != "akt close 4242" {
+		t.Errorf("cleanup command = %q", advice.Cleanup)
+	}
+
+	var human bytes.Buffer
+	printResults(&human, state, errors.New("send manifest failed"), advice)
+	for _, want := range []string{
+		"Partial deployment state",
+		"DSEQ: 4242",
+		"Provider: akash1provider",
+		"escrow may continue to be consumed",
+		advice.Recovery,
+		advice.Cleanup,
+	} {
+		if !strings.Contains(human.String(), want) {
+			t.Errorf("human failure output missing %q:\n%s", want, human.String())
+		}
+	}
+
+	err := workflowFailureError("deploy", errors.New("send manifest failed"), advice)
+	for _, want := range []string{"DSEQ 4242", "akash1provider", "escrow may continue", advice.Recovery, advice.Cleanup} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("returned error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestDeployRecoveryAdviceJSONLFields(t *testing.T) {
+	state := wf.NewRunState("run-1", "deploy", "akash1owner", map[string]any{"sdl-file": "deploy.yaml"})
+	state.SetStepResult("create-deployment", &wf.StepResult{
+		Name:   "create-deployment",
+		Status: "success",
+		Output: map[string]any{"dseq": float64(77)},
+	})
+	state.SetStepResult("send-manifest", &wf.StepResult{Name: "send-manifest", Status: "failed", Error: "refused"})
+
+	advice := deployRecoveryAdvice(state, errors.New("refused"))
+	var buf bytes.Buffer
+	emitJSONL(&buf, state, advice)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("JSONL lines = %d, want 2:\n%s", len(lines), buf.String())
+	}
+
+	var failed struct {
+		Result   string `json:"result"`
+		DSeq     uint64 `json:"dseq"`
+		Provider string `json:"provider"`
+		Recovery string `json:"recovery"`
+		Cleanup  string `json:"cleanup"`
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &failed); err != nil {
+		t.Fatalf("decode failed JSONL line: %v", err)
+	}
+	if failed.Result != "error" || failed.DSeq != 77 || failed.Provider != "" {
+		t.Errorf("failed JSONL identity = %+v", failed)
+	}
+	if failed.Recovery != "" || failed.Cleanup != "akt close 77" {
+		t.Errorf("failed JSONL recovery = %+v", failed)
+	}
+}
+
+func TestDeployRecoveryAdviceRequiresCompletedCreate(t *testing.T) {
+	state := wf.NewRunState("run-1", "deploy", "akash1owner", map[string]any{"sdl-file": "deploy.yaml"})
+	state.SetStepResult("create-deployment", &wf.StepResult{Name: "create-deployment", Status: "failed"})
+
+	if got := deployRecoveryAdvice(state, errors.New("broadcast refused")); got != nil {
+		t.Fatalf("failed create has no paid partial state, got %+v", got)
+	}
+
+	state.Workflow = "update"
+	state.Steps["create-deployment"] = &wf.StepResult{
+		Name:   "create-deployment",
+		Status: "success",
+		Output: map[string]any{"dseq": "42"},
+	}
+	if got := deployRecoveryAdvice(state, errors.New("update failed")); got != nil {
+		t.Fatalf("non-deploy workflow got deploy recovery advice: %+v", got)
+	}
+}
+
+func TestShellQuoteKeepsRecoveryCommandsCopyPasteable(t *testing.T) {
+	if got, want := shellQuote("/tmp/operator's deployment.yaml"), `'/tmp/operator'"'"'s deployment.yaml'`; got != want {
+		t.Errorf("shellQuote = %q, want %q", got, want)
 	}
 }
 

--- a/internal/console/client.go
+++ b/internal/console/client.go
@@ -266,14 +266,23 @@ func (c *Client) doJSON(ctx context.Context, method, path string, reqBody, resul
 
 		// Backoff before retry for 429 and (idempotent-only) 5xx.
 		if attempt < maxRetries-1 {
-			backoff := time.Duration(1<<uint(attempt)) * 100 * time.Millisecond
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(backoff):
+			if err := waitForRetry(ctx, attempt); err != nil {
+				return err
 			}
 		}
 	}
 
 	return lastErr
+}
+
+// waitForRetry applies the client's bounded exponential backoff while still
+// allowing the caller's timeout or cancellation to stop the operation.
+func waitForRetry(ctx context.Context, attempt int) error {
+	backoff := time.Duration(1<<uint(attempt)) * 100 * time.Millisecond
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(backoff):
+		return nil
+	}
 }

--- a/internal/console/deployments.go
+++ b/internal/console/deployments.go
@@ -2,12 +2,15 @@ package console
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"pkg.akt.dev/go/sdl"
 )
 
 // CreateDeployment creates a deployment via the managed wallet. Deposit is in
@@ -123,14 +126,61 @@ func (c *Client) GetDeployment(ctx context.Context, dseq string) (*DeploymentDet
 func (c *Client) UpdateDeployment(ctx context.Context, dseq, sdl string) (*DeploymentDetail, error) {
 	body := envelope(map[string]any{"sdl": sdl})
 
-	var out DeploymentDetail
-	err := c.doData(ctx, http.MethodPut, "/v1/deployments/"+url.PathEscape(dseq), body, &out)
-	c.record("update-deployment", dseq, err)
-	if err != nil {
-		return nil, err
+	var lastErr error
+	for attempt := range maxRetries {
+		var out DeploymentDetail
+		lastErr = c.doData(ctx, http.MethodPut, "/v1/deployments/"+url.PathEscape(dseq), body, &out)
+		if lastErr == nil {
+			c.record("update-deployment", dseq, nil)
+			return &out, nil
+		}
+
+		// A gateway or API handler can return an error after the idempotent
+		// update reached chain state. The deployment hash is authoritative
+		// proof, so do not replay a write whose desired version is present.
+		if detail, ok := c.reconcileDeploymentUpdate(ctx, dseq, sdl); ok {
+			c.record("update-deployment", dseq, nil)
+			return detail, nil
+		}
+
+		if !isTransientManifestVersionError(lastErr) || attempt == maxRetries-1 {
+			break
+		}
+		if err := waitForRetry(ctx, attempt); err != nil {
+			lastErr = err
+			break
+		}
 	}
 
-	return &out, nil
+	c.record("update-deployment", dseq, lastErr)
+	return nil, lastErr
+}
+
+func (c *Client) reconcileDeploymentUpdate(ctx context.Context, dseq, rawSDL string) (*DeploymentDetail, bool) {
+	doc, err := sdl.Read([]byte(rawSDL))
+	if err != nil {
+		return nil, false
+	}
+
+	version, err := doc.Version()
+	if err != nil {
+		return nil, false
+	}
+
+	detail, err := c.GetDeployment(ctx, dseq)
+	if err != nil {
+		return nil, false
+	}
+
+	expected := base64.StdEncoding.EncodeToString(version)
+	return detail, detail.Deployment.Hash == expected
+}
+
+func isTransientManifestVersionError(err error) bool {
+	var httpErr *HTTPError
+	return errors.As(err, &httpErr) &&
+		httpErr.StatusCode == http.StatusUnprocessableEntity &&
+		strings.Contains(strings.ToLower(httpErr.Body), "manifest version validation failed")
 }
 
 // CloseDeployment closes a deployment. If the deployment is already closed
@@ -236,12 +286,70 @@ func (c *Client) CreateLease(ctx context.Context, manifest string, leases []Leas
 
 	var out DeploymentDetail
 	err := c.doData(ctx, http.MethodPost, "/v1/leases", body, &out)
-	c.record("create-lease", leaseDSeq, err)
 	if err != nil {
+		// Never replay this POST: the live API can return an error after the
+		// lease transaction succeeded. Read back the exact lease identities
+		// and accept only authoritative active state.
+		if detail, ok := c.reconcileCreatedLeases(ctx, leases); ok {
+			c.record("create-lease", leaseDSeq, nil)
+			return detail, nil
+		}
+
+		c.record("create-lease", leaseDSeq, err)
 		return nil, err
 	}
 
+	c.record("create-lease", leaseDSeq, nil)
 	return &out, nil
+}
+
+func (c *Client) reconcileCreatedLeases(ctx context.Context, requested []LeaseRequest) (*DeploymentDetail, bool) {
+	if len(requested) == 0 || requested[0].DSeq == "" {
+		return nil, false
+	}
+
+	dseq := requested[0].DSeq
+	for _, req := range requested[1:] {
+		if req.DSeq != dseq {
+			return nil, false
+		}
+	}
+
+	for attempt := range maxRetries {
+		detail, err := c.GetDeployment(ctx, dseq)
+		if err == nil && requestedLeasesActive(detail.Leases, requested) {
+			return detail, true
+		}
+
+		if attempt < maxRetries-1 {
+			if err := waitForRetry(ctx, attempt); err != nil {
+				return nil, false
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func requestedLeasesActive(actual []Lease, requested []LeaseRequest) bool {
+	for _, req := range requested {
+		matched := false
+		for _, lease := range actual {
+			if lease.ID.DSeq.String() == req.DSeq &&
+				lease.ID.GSeq == req.GSeq &&
+				lease.ID.OSeq == req.OSeq &&
+				lease.ID.Provider == req.Provider &&
+				strings.EqualFold(lease.State, "active") {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	return len(requested) > 0
 }
 
 // GetDeploymentSettings fetches auto-top-up settings for a deployment.

--- a/internal/console/deployments_test.go
+++ b/internal/console/deployments_test.go
@@ -2,16 +2,63 @@ package console_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"pkg.akt.dev/akt/internal/console"
+	"pkg.akt.dev/go/sdl"
 )
+
+const validUpdateSDL = `version: "2.0"
+services:
+  web:
+    image: nginx:1.27-alpine
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 512Mi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uact
+          amount: 10000
+deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1
+`
+
+func versionHash(t *testing.T, rawSDL string) string {
+	t.Helper()
+
+	doc, err := sdl.Read([]byte(rawSDL))
+	require.NoError(t, err)
+
+	version, err := doc.Version()
+	require.NoError(t, err)
+
+	return base64.StdEncoding.EncodeToString(version)
+}
 
 func TestCreateDeployment(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -73,7 +120,7 @@ func TestGetDeployment(t *testing.T) {
 		assert.Equal(t, "/v1/deployments/777", r.URL.Path)
 
 		_, _ = w.Write([]byte(`{"data":{
-			"deployment":{"id":{"owner":"akash1x","dseq":"777"},"state":"active"},
+			"deployment":{"id":{"owner":"akash1x","dseq":"777"},"state":"active","hash":"version-hash"},
 			"leases":[{
 				"id":{"owner":"akash1x","dseq":"777","gseq":1,"oseq":1,"provider":"akash1p"},
 				"state":"active",
@@ -89,6 +136,7 @@ func TestGetDeployment(t *testing.T) {
 	resp, err := c.GetDeployment(context.Background(), "777")
 	require.NoError(t, err)
 	assert.Equal(t, "777", resp.Deployment.ID.DSeq.String())
+	assert.Equal(t, "version-hash", resp.Deployment.Hash)
 	require.Len(t, resp.Leases, 1)
 
 	lease := resp.Leases[0]
@@ -116,6 +164,61 @@ func TestUpdateDeployment(t *testing.T) {
 	resp, err := c.UpdateDeployment(context.Background(), "555", "new-sdl")
 	require.NoError(t, err)
 	assert.Equal(t, "555", resp.Deployment.ID.DSeq.String())
+}
+
+func TestUpdateDeploymentReconcilesFailedResponseByVersionHash(t *testing.T) {
+	expectedHash := versionHash(t, validUpdateSDL)
+	var puts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			puts.Add(1)
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"manifest version validation failed"}`))
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"owner":"akash1x","dseq":"555"},"state":"active","hash":"` + expectedHash + `"}}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	resp, err := console.New(srv.URL, "test-key").UpdateDeployment(
+		context.Background(), "555", validUpdateSDL,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expectedHash, resp.Deployment.Hash)
+	assert.Equal(t, int32(1), puts.Load(), "a proven update must not be replayed")
+}
+
+func TestUpdateDeploymentRetriesTransientManifestValidation(t *testing.T) {
+	var puts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			if puts.Add(1) == 1 {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`{"message":"manifest version validation failed"}`))
+				return
+			}
+
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"owner":"akash1x","dseq":"555"},"state":"active","hash":"new-hash"}}}`))
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"owner":"akash1x","dseq":"555"},"state":"active","hash":"old-hash"}}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	resp, err := console.New(srv.URL, "test-key").UpdateDeployment(
+		context.Background(), "555", validUpdateSDL,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "new-hash", resp.Deployment.Hash)
+	assert.Equal(t, int32(2), puts.Load())
 }
 
 func TestCloseDeployment(t *testing.T) {
@@ -257,6 +360,65 @@ func TestCreateLeaseBodyNotEnveloped(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Leases, 1)
 	assert.Equal(t, "active", resp.Leases[0].State)
+}
+
+func TestCreateLeaseReconcilesFailedResponseWithoutReplayingPost(t *testing.T) {
+	var posts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			posts.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodGet:
+			assert.Equal(t, "/v1/deployments/888", r.URL.Path)
+			_, _ = w.Write([]byte(`{"data":{
+				"deployment":{"id":{"owner":"akash1x","dseq":"888"},"state":"active"},
+				"leases":[{"id":{"owner":"akash1x","dseq":"888","gseq":1,"oseq":1,"provider":"akash1p"},"state":"active"}]
+			}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	resp, err := console.New(srv.URL, "test-key").CreateLease(
+		context.Background(), "manifest-json", []console.LeaseRequest{
+			{DSeq: "888", GSeq: 1, OSeq: 1, Provider: "akash1p"},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, resp.Leases, 1)
+	assert.Equal(t, "active", resp.Leases[0].State)
+	assert.Equal(t, int32(1), posts.Load(), "the non-idempotent POST must not be replayed")
+}
+
+func TestCreateLeaseKeepsOriginalErrorWhenReadBackDoesNotMatch(t *testing.T) {
+	var posts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			posts.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{
+				"deployment":{"id":{"owner":"akash1x","dseq":"888"},"state":"open"},
+				"leases":[]
+			}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := console.New(srv.URL, "test-key").CreateLease(
+		context.Background(), "manifest-json", []console.LeaseRequest{
+			{DSeq: "888", GSeq: 1, OSeq: 1, Provider: "akash1p"},
+		},
+	)
+	require.ErrorIs(t, err, console.ErrNotFound)
+	assert.Equal(t, int32(1), posts.Load())
 }
 
 func TestGetDeploymentSettings(t *testing.T) {

--- a/internal/console/types.go
+++ b/internal/console/types.go
@@ -112,6 +112,7 @@ type DeploymentID struct {
 type Deployment struct {
 	ID        DeploymentID    `json:"id"`
 	State     string          `json:"state"`
+	Hash      string          `json:"hash,omitempty"`
 	CreatedAt json.RawMessage `json:"created_at,omitempty"`
 }
 

--- a/internal/transport/deposit.go
+++ b/internal/transport/deposit.go
@@ -106,7 +106,7 @@ func ParseDeposit(s string) (Deposit, error) {
 	}
 
 	return Deposit{}, fmt.Errorf(
-		"invalid deposit %q: use a USD amount (e.g. 5usd or $5) or a coin amount (e.g. 5000000uakt)", s)
+		"invalid deposit %q: use auto, a USD amount (e.g. 5usd or $5), or an explicit chain coin amount", s)
 }
 
 // RailValue returns the rail-native deposit string for the given transport
@@ -129,10 +129,10 @@ func (d Deposit) RailValue(kind Kind) (string, error) {
 			return d.Coin, nil
 		case d.Bare:
 			return "", fmt.Errorf(
-				"deposit %q: a bare amount is a USD deposit, and USD deposits require a console-api context; specify a coin amount like 5000000uakt", d.Raw)
+				"deposit %q: a bare amount is a USD deposit, and USD deposits require a console-api context; use auto (recommended), or specify an explicit coin amount in the network's deployment deposit denomination", d.Raw)
 		default:
 			return "", fmt.Errorf(
-				"deposit %q: USD deposits require a console-api context; specify a coin amount like 5000000uakt", d.Raw)
+				"deposit %q: USD deposits require a console-api context; use auto (recommended), or specify an explicit coin amount in the network's deployment deposit denomination", d.Raw)
 		}
 
 	case KindConsole:

--- a/internal/transport/deposit_test.go
+++ b/internal/transport/deposit_test.go
@@ -80,9 +80,9 @@ func TestDepositRailValueChain(t *testing.T) {
 		{"auto", "auto", ""},
 		{"5000000uakt", "5000000uakt", ""},
 		{"5akt", "5akt", ""},
-		{"5usd", "", "USD deposits require a console-api context; specify a coin amount like 5000000uakt"},
-		{"$5", "", "USD deposits require a console-api context; specify a coin amount like 5000000uakt"},
-		{"5", "", "console-api context; specify a coin amount like 5000000uakt"},
+		{"5usd", "", "USD deposits require a console-api context; use auto (recommended)"},
+		{"$5", "", "USD deposits require a console-api context; use auto (recommended)"},
+		{"5", "", "console-api context; use auto (recommended)"},
 	}
 
 	for _, tt := range tests {
@@ -107,6 +107,24 @@ func TestDepositRailValueChain(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("RailValue(chain) for %q = %q, want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+func TestDepositRailValueChainDoesNotAdvertiseOneNetworkDenomination(t *testing.T) {
+	dep, err := ParseDeposit("5usd")
+	if err != nil {
+		t.Fatalf("ParseDeposit: %v", err)
+	}
+
+	_, err = dep.RailValue(KindChain)
+	if err == nil {
+		t.Fatal("RailValue(chain): expected cross-rail error")
+	}
+	if strings.Contains(err.Error(), "uakt") {
+		t.Errorf("error %q advertises a network-specific denomination", err)
+	}
+	if !strings.Contains(err.Error(), "network's deployment deposit denomination") {
+		t.Errorf("error %q does not explain the explicit-coin requirement", err)
 	}
 }
 

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -190,7 +190,7 @@ func TestChainTransportRejectsUSDDeposit(t *testing.T) {
 			t.Errorf("deposit %q: expected cross-rail error", deposit)
 			continue
 		}
-		for _, want := range []string{"console-api context", "5000000uakt"} {
+		for _, want := range []string{"console-api context", "auto", "network's deployment deposit denomination"} {
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("deposit %q: error %q does not mention %q", deposit, err, want)
 			}

--- a/internal/workflow/adapters/provider.go
+++ b/internal/workflow/adapters/provider.go
@@ -3,16 +3,21 @@ package adapters
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
 
 	aktprovider "pkg.akt.dev/akt/internal/provider"
 	"pkg.akt.dev/akt/internal/workflow/steps"
+	manifest "pkg.akt.dev/go/manifest/v2beta3"
 	mv1 "pkg.akt.dev/go/node/market/v1"
+	mtypes "pkg.akt.dev/go/node/market/v1beta5"
 	ptypes "pkg.akt.dev/go/node/provider/v1beta4"
 	rest "pkg.akt.dev/go/provider/client"
 	"pkg.akt.dev/go/sdl"
@@ -52,16 +57,64 @@ func (p *providerClient) SendManifest(ctx context.Context, provider string, dseq
 		return fmt.Errorf("send manifest: dseq is required")
 	}
 
-	sdlManifest, err := readSDL(sdlData)
+	mani, err := manifestFromSDL(sdlData)
 	if err != nil {
 		return err
 	}
 
-	mani, err := sdlManifest.Manifest()
-	if err != nil {
-		return fmt.Errorf("build manifest from SDL: %w", err)
+	return p.submitManifest(ctx, provider, dseq, mani)
+}
+
+// SendManifestToActiveLeases submits an updated manifest to every provider
+// with an active lease for the deployment. Every provider is attempted even
+// when an earlier one rejects the manifest; the returned addresses are the
+// providers that accepted it.
+func (p *providerClient) SendManifestToActiveLeases(ctx context.Context, dseq uint64, sdlData []byte) ([]string, error) {
+	if dseq == 0 {
+		return nil, fmt.Errorf("send manifest to active leases: dseq is required")
 	}
 
+	owner := p.cctx.GetFromAddress().String()
+	if owner == "" {
+		return nil, fmt.Errorf("send manifest to active leases: owner address is required")
+	}
+
+	mani, err := manifestFromSDL(sdlData)
+	if err != nil {
+		return nil, err
+	}
+
+	queryClient := mtypes.NewQueryClient(p.cctx)
+	providers, err := activeLeaseProviders(ctx, owner, dseq, func(
+		ctx context.Context,
+		request *mtypes.QueryLeasesRequest,
+	) (*mtypes.QueryLeasesResponse, error) {
+		return queryClient.Leases(ctx, request)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return sendManifestToProviders(ctx, providers, func(ctx context.Context, provider string) error {
+		return p.submitManifest(ctx, provider, dseq, mani)
+	})
+}
+
+func manifestFromSDL(sdlData []byte) (manifest.Manifest, error) {
+	sdlManifest, err := readSDL(sdlData)
+	if err != nil {
+		return nil, err
+	}
+
+	mani, err := sdlManifest.Manifest()
+	if err != nil {
+		return nil, fmt.Errorf("build manifest from SDL: %w", err)
+	}
+
+	return mani, nil
+}
+
+func (p *providerClient) submitManifest(ctx context.Context, provider string, dseq uint64, mani manifest.Manifest) error {
 	cl, err := p.gatewayClient(ctx, provider)
 	if err != nil {
 		return err
@@ -72,6 +125,92 @@ func (p *providerClient) SendManifest(ctx context.Context, provider string, dseq
 	}
 
 	return nil
+}
+
+type leasePageFetcher func(context.Context, *mtypes.QueryLeasesRequest) (*mtypes.QueryLeasesResponse, error)
+
+func activeLeaseProviders(
+	ctx context.Context,
+	owner string,
+	dseq uint64,
+	fetch leasePageFetcher,
+) ([]string, error) {
+	providers := make(map[string]struct{})
+	seenPageKeys := make(map[string]struct{})
+	var pageKey []byte
+
+	for {
+		response, err := fetch(ctx, &mtypes.QueryLeasesRequest{
+			Filters: mv1.LeaseFilters{
+				Owner: owner,
+				DSeq:  dseq,
+				State: "active",
+			},
+			Pagination: &sdkquery.PageRequest{
+				Key:   append([]byte(nil), pageKey...),
+				Limit: 100,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("query active leases for deployment %d: %w", dseq, err)
+		}
+		if response == nil {
+			return nil, fmt.Errorf("query active leases for deployment %d: empty response", dseq)
+		}
+
+		for _, lease := range response.Leases {
+			if provider := lease.Lease.ID.Provider; provider != "" {
+				providers[provider] = struct{}{}
+			}
+		}
+
+		var nextKey []byte
+		if response.Pagination != nil {
+			nextKey = response.Pagination.NextKey
+		}
+		if len(nextKey) == 0 {
+			break
+		}
+
+		key := string(nextKey)
+		if _, seen := seenPageKeys[key]; seen {
+			return nil, fmt.Errorf("query active leases for deployment %d: repeated pagination key", dseq)
+		}
+		seenPageKeys[key] = struct{}{}
+		pageKey = append(pageKey[:0], nextKey...)
+	}
+
+	result := make([]string, 0, len(providers))
+	for provider := range providers {
+		result = append(result, provider)
+	}
+	sort.Strings(result)
+
+	return result, nil
+}
+
+func sendManifestToProviders(
+	ctx context.Context,
+	providers []string,
+	submit func(context.Context, string) error,
+) ([]string, error) {
+	sent := make([]string, 0, len(providers))
+	var failures []error
+
+	for _, provider := range providers {
+		if err := ctx.Err(); err != nil {
+			failures = append(failures, err)
+			break
+		}
+
+		if err := submit(ctx, provider); err != nil {
+			failures = append(failures, fmt.Errorf("provider %s: %w", provider, err))
+			continue
+		}
+		sent = append(sent, provider)
+	}
+
+	return sent, errors.Join(failures...)
 }
 
 // LeaseStatus queries the live status of a lease from the provider gateway

--- a/internal/workflow/adapters/provider_test.go
+++ b/internal/workflow/adapters/provider_test.go
@@ -2,8 +2,15 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"os"
+	"reflect"
 	"testing"
+
+	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
+
+	mv1 "pkg.akt.dev/go/node/market/v1"
+	mtypes "pkg.akt.dev/go/node/market/v1beta5"
 )
 
 func TestReadSDLFromPath(t *testing.T) {
@@ -57,10 +64,106 @@ func TestSendManifestRequiresDSeq(t *testing.T) {
 	}
 }
 
+func TestSendManifestToActiveLeasesRequiresDSeq(t *testing.T) {
+	p := NewProviderClient(testClientContext(), "")
+
+	if _, err := p.SendManifestToActiveLeases(context.Background(), 0, []byte(testSDLPath)); err == nil {
+		t.Error("expected error for zero dseq")
+	}
+}
+
 func TestLeaseStatusRequiresDSeq(t *testing.T) {
 	p := NewProviderClient(testClientContext(), "")
 
 	if _, err := p.LeaseStatus(context.Background(), testProviderAddr().String(), 0); err == nil {
 		t.Error("expected error for zero dseq")
+	}
+}
+
+func TestActiveLeaseProvidersPaginatesDeduplicatesAndSorts(t *testing.T) {
+	var requests []*mtypes.QueryLeasesRequest
+	fetch := func(_ context.Context, req *mtypes.QueryLeasesRequest) (*mtypes.QueryLeasesResponse, error) {
+		requests = append(requests, req)
+		switch len(requests) {
+		case 1:
+			return leasePage([]string{"akash1z", "akash1a"}, []byte("next")), nil
+		case 2:
+			return leasePage([]string{"akash1a", "akash1m"}, nil), nil
+		default:
+			t.Fatalf("unexpected page %d", len(requests))
+			return nil, nil
+		}
+	}
+
+	got, err := activeLeaseProviders(context.Background(), "akash1owner", 4242, fetch)
+	if err != nil {
+		t.Fatalf("activeLeaseProviders: %v", err)
+	}
+	want := []string{"akash1a", "akash1m", "akash1z"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("providers = %v, want %v", got, want)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	for _, req := range requests {
+		if req.Filters.Owner != "akash1owner" || req.Filters.DSeq != 4242 || req.Filters.State != "active" {
+			t.Errorf("filters = %+v", req.Filters)
+		}
+		if req.Pagination == nil || req.Pagination.Limit != 100 {
+			t.Errorf("pagination = %+v, want limit 100", req.Pagination)
+		}
+	}
+	if string(requests[0].Pagination.Key) != "" || string(requests[1].Pagination.Key) != "next" {
+		t.Errorf("page keys = %q, %q", requests[0].Pagination.Key, requests[1].Pagination.Key)
+	}
+}
+
+func TestActiveLeaseProvidersRejectsRepeatedPageKey(t *testing.T) {
+	fetch := func(_ context.Context, _ *mtypes.QueryLeasesRequest) (*mtypes.QueryLeasesResponse, error) {
+		return leasePage(nil, []byte("same")), nil
+	}
+
+	_, err := activeLeaseProviders(context.Background(), "akash1owner", 1, fetch)
+	if err == nil {
+		t.Fatal("expected repeated pagination key error")
+	}
+}
+
+func TestSendManifestToProvidersAttemptsAll(t *testing.T) {
+	wantErr := errors.New("provider b refused")
+	var attempted []string
+
+	sent, err := sendManifestToProviders(
+		context.Background(),
+		[]string{"akash1a", "akash1b", "akash1c"},
+		func(_ context.Context, provider string) error {
+			attempted = append(attempted, provider)
+			if provider == "akash1b" {
+				return wantErr
+			}
+			return nil
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want wrapped provider failure", err)
+	}
+	if !reflect.DeepEqual(attempted, []string{"akash1a", "akash1b", "akash1c"}) {
+		t.Errorf("attempted = %v", attempted)
+	}
+	if !reflect.DeepEqual(sent, []string{"akash1a", "akash1c"}) {
+		t.Errorf("successful sends = %v", sent)
+	}
+}
+
+func leasePage(providers []string, nextKey []byte) *mtypes.QueryLeasesResponse {
+	leases := make([]mtypes.QueryLeaseResponse, 0, len(providers))
+	for _, provider := range providers {
+		leases = append(leases, mtypes.QueryLeaseResponse{Lease: mv1.Lease{ID: mv1.LeaseID{Provider: provider}}})
+	}
+
+	return &mtypes.QueryLeasesResponse{
+		Leases:     leases,
+		Pagination: &sdkquery.PageResponse{NextKey: nextKey},
 	}
 }

--- a/internal/workflow/builtin/deploy.yaml
+++ b/internal/workflow/builtin/deploy.yaml
@@ -10,7 +10,7 @@ params:
   deposit:
     type: deposit
     default: "auto"
-    description: "Initial deposit: 5usd or $5 (USD, console-api contexts), 5000000uakt (coin, keyring contexts), auto = chain minimum (keyring)"
+    description: "Initial deposit: auto (recommended chain minimum, keyring), 5usd or $5 (console-api), or an explicit coin in the network's deposit denomination (keyring)"
   bid-timeout:
     type: duration
     default: "5m"

--- a/internal/workflow/builtin/update.yaml
+++ b/internal/workflow/builtin/update.yaml
@@ -21,6 +21,17 @@ steps:
       dseq: "{{ .Params.dseq }}"
     on-error: abort
 
+  - name: send-manifest
+    type: provider
+    action: send-manifest-to-active-leases
+    params:
+      dseq: "{{ .Params.dseq }}"
+      sdl: "{{ index .Params \"sdl-file\" }}"
+    retry:
+      max: 3
+      delay: "5s"
+    on-error: abort
+
   - name: display-result
     type: output
     template: |

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -43,7 +43,7 @@ func NewEngine(registry StepRegistry, logger Logger) *Engine {
 // Run executes a workflow definition with the given parameters.
 // It returns the final run state containing all step results.
 func (e *Engine) Run(ctx context.Context, wf *WorkflowDef, account string, params map[string]any) (*RunState, error) {
-	workflowID := generateWorkflowID()
+	workflowID := GenerateWorkflowID()
 	state := NewRunState(workflowID, wf.Name, account, params)
 
 	for i, step := range wf.Steps {
@@ -133,8 +133,9 @@ func (e *Engine) executeStep(ctx context.Context, step StepDef, state *RunState)
 	return lastResult, lastErr
 }
 
-// generateWorkflowID creates a short random hex ID for correlating log entries.
-func generateWorkflowID() string {
+// GenerateWorkflowID creates a short random hex ID for correlating one run's
+// output and action-log entries.
+func GenerateWorkflowID() string {
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 

--- a/internal/workflow/steps/provider.go
+++ b/internal/workflow/steps/provider.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -42,11 +43,48 @@ func (e *ProviderExecutor) Execute(ctx context.Context, step workflow.StepDef, s
 
 	switch step.Action {
 	case "send-manifest":
-		dseq, _ := strconv.ParseUint(params["dseq"], 10, 64)
+		dseq, parseErr := parseProviderDSeq(params["dseq"])
+		if parseErr != nil {
+			return failedProviderResult(step, start, parseErr), parseErr
+		}
 		sdl := []byte(params["sdl"])
 		err = e.provider.SendManifest(ctx, params["provider"], dseq, sdl)
+	case "send-manifest-to-active-leases":
+		dseq, parseErr := parseProviderDSeq(params["dseq"])
+		if parseErr != nil {
+			return failedProviderResult(step, start, parseErr), parseErr
+		}
+
+		providers, sendErr := e.provider.SendManifestToActiveLeases(ctx, dseq, []byte(params["sdl"]))
+		outputs := map[string]any{
+			"providers": providers,
+			"count":     len(providers),
+		}
+		raw, marshalErr := json.Marshal(outputs)
+		if marshalErr != nil {
+			return failedProviderResult(step, start, marshalErr), fmt.Errorf("marshal provider result: %w", marshalErr)
+		}
+		if sendErr != nil {
+			result := failedProviderResult(step, start, sendErr)
+			result.Output = outputs
+			result.RawResult = raw
+
+			return result, sendErr
+		}
+
+		return &workflow.StepResult{
+			Name:      step.Name,
+			Type:      step.Type,
+			Status:    "success",
+			Output:    outputs,
+			RawResult: raw,
+			Duration:  time.Since(start),
+		}, nil
 	case "lease-status":
-		dseq, _ := strconv.ParseUint(params["dseq"], 10, 64)
+		dseq, parseErr := parseProviderDSeq(params["dseq"])
+		if parseErr != nil {
+			return failedProviderResult(step, start, parseErr), parseErr
+		}
 		var data []byte
 		data, err = e.provider.LeaseStatus(ctx, params["provider"], dseq)
 		if err == nil {
@@ -80,4 +118,27 @@ func (e *ProviderExecutor) Execute(ctx context.Context, step workflow.StepDef, s
 		Status:   "success",
 		Duration: time.Since(start),
 	}, nil
+}
+
+func parseProviderDSeq(value string) (uint64, error) {
+	dseq, err := strconv.ParseUint(value, 10, 64)
+	if err != nil || dseq == 0 {
+		if err != nil {
+			return 0, fmt.Errorf("invalid dseq %q: %w", value, err)
+		}
+
+		return 0, fmt.Errorf("invalid dseq %q: must be greater than zero", value)
+	}
+
+	return dseq, nil
+}
+
+func failedProviderResult(step workflow.StepDef, start time.Time, err error) *workflow.StepResult {
+	return &workflow.StepResult{
+		Name:     step.Name,
+		Type:     step.Type,
+		Status:   "failed",
+		Error:    err.Error(),
+		Duration: time.Since(start),
+	}
 }

--- a/internal/workflow/steps/provider_test.go
+++ b/internal/workflow/steps/provider_test.go
@@ -1,0 +1,111 @@
+package steps
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"pkg.akt.dev/akt/internal/workflow"
+)
+
+type fakeWorkflowProvider struct {
+	providers []string
+	err       error
+}
+
+func (p *fakeWorkflowProvider) SendManifest(context.Context, string, uint64, []byte) error {
+	return p.err
+}
+
+func (p *fakeWorkflowProvider) SendManifestToActiveLeases(context.Context, uint64, []byte) ([]string, error) {
+	return p.providers, p.err
+}
+
+func (p *fakeWorkflowProvider) LeaseStatus(context.Context, string, uint64) (json.RawMessage, error) {
+	return nil, p.err
+}
+
+func TestProviderExecutorSendsManifestToAllActiveLeases(t *testing.T) {
+	providerErr := errors.New("one provider refused")
+	executor := &ProviderExecutor{provider: &fakeWorkflowProvider{
+		providers: []string{"akash1accepted"},
+		err:       providerErr,
+	}}
+	state := workflow.NewRunState("run-1", "update", "akash1owner", map[string]any{
+		"dseq":     4242,
+		"sdl-file": "deploy.yaml",
+	})
+	step := workflow.StepDef{
+		Name:   "send-manifest",
+		Type:   workflow.StepProvider,
+		Action: "send-manifest-to-active-leases",
+		Params: map[string]string{
+			"dseq": "{{ .Params.dseq }}",
+			"sdl":  "{{ index .Params \"sdl-file\" }}",
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), step, state)
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("error = %v, want provider failure", err)
+	}
+	if result.Status != "failed" || result.Output["count"] != 1 {
+		t.Fatalf("result = %+v, want failed with one successful delivery", result)
+	}
+	providers, ok := result.Output["providers"].([]string)
+	if !ok || len(providers) != 1 || providers[0] != "akash1accepted" {
+		t.Errorf("successful providers = %#v", result.Output["providers"])
+	}
+	var raw struct {
+		Providers []string `json:"providers"`
+		Count     int      `json:"count"`
+	}
+	if err := json.Unmarshal(result.RawResult, &raw); err != nil {
+		t.Fatalf("raw result is not JSON: %v", err)
+	}
+	if raw.Count != 1 || len(raw.Providers) != 1 {
+		t.Errorf("raw result = %+v", raw)
+	}
+}
+
+func TestProviderExecutorTreatsNoActiveLeasesAsSuccess(t *testing.T) {
+	executor := &ProviderExecutor{provider: &fakeWorkflowProvider{}}
+	state := workflow.NewRunState("run-1", "update", "akash1owner", nil)
+	step := workflow.StepDef{
+		Name:   "send-manifest",
+		Type:   workflow.StepProvider,
+		Action: "send-manifest-to-active-leases",
+		Params: map[string]string{"dseq": "4242", "sdl": "deploy.yaml"},
+	}
+
+	result, err := executor.Execute(context.Background(), step, state)
+	if err != nil {
+		t.Fatalf("no active leases: %v", err)
+	}
+	if result.Status != "success" || result.Output["count"] != 0 {
+		t.Errorf("result = %+v, want successful no-op", result)
+	}
+}
+
+func TestProviderExecutorRejectsInvalidDSeq(t *testing.T) {
+	executor := &ProviderExecutor{provider: &fakeWorkflowProvider{}}
+	for _, action := range []string{"send-manifest", "send-manifest-to-active-leases", "lease-status"} {
+		t.Run(action, func(t *testing.T) {
+			step := workflow.StepDef{
+				Name:   action,
+				Type:   workflow.StepProvider,
+				Action: action,
+				Params: map[string]string{"dseq": "not-a-number", "provider": "akash1provider"},
+			}
+			result, err := executor.Execute(context.Background(), step, workflow.NewRunState("run", "test", "owner", nil))
+			if err == nil || !strings.Contains(err.Error(), "invalid dseq") {
+				t.Fatalf("error = %v, want invalid dseq", err)
+			}
+			if result == nil || result.Status != "failed" {
+				t.Fatalf("result = %+v, want failed result", result)
+			}
+		})
+	}
+}

--- a/internal/workflow/steps/registry.go
+++ b/internal/workflow/steps/registry.go
@@ -30,6 +30,7 @@ type TxResult struct {
 // Implemented by the provider client package (Phase 2).
 type ProviderClient interface {
 	SendManifest(ctx context.Context, provider string, dseq uint64, sdl []byte) error
+	SendManifestToActiveLeases(ctx context.Context, dseq uint64, sdl []byte) ([]string, error)
 	LeaseStatus(ctx context.Context, provider string, dseq uint64) (json.RawMessage, error)
 }
 


### PR DESCRIPTION
## Summary

- surface paid partial deployment state with DSEQ, provider, escrow warning, and exact retry/cleanup commands
- send chain-backed deployment updates to every active lease provider
- preserve partial delivery evidence while attempting all providers
- keep Console updates on the Console API manifest path

## Verification

- `GOWORK=off CGO_ENABLED=0 go test -tags "osusergo,netgo,nolink_libwasmvm" ./... -count=1`
- `GOWORK=off CGO_ENABLED=0 go vet -tags "osusergo,netgo,nolink_libwasmvm" ./internal/...`
- CGO-free tagged build
- `akt update ... --dry-run` reports tx, provider fanout, then success output

Stacked on #37; merge after its base lands.