### PR TITLE
fix(cli): close final live verification gaps

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixed
 
+- **Final live verification exposed shell and key-output boundary failures**:
+  an explicit provider or Console shell command launched from a terminal now
+  detaches stdin by default so a completed remote process cannot hang waiting
+  for terminal input; interactive shells, pipes, and explicit `--stdin`
+  overrides remain supported. `context keys add` now honors JSON/YAML for
+  local, recovered, Ledger, and multisig keys while preserving the mnemonic
+  backup contract for newly generated keys.
+
 - **Workflow JSONL dry-runs emitted human prose**: `deploy`, `update`, and
   `close` now emit one valid JSONL `planned` record per step, with a shared run
   ID and empty error/transaction arrays, instead of silently ignoring their

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- **The built-in sandbox context targeted a retired network**: the sandbox
+  template now uses the live `sandbox-2` chain ID and the RPC, API, and gRPC
+  endpoints published by the Akash network registry, restoring context
+  switching and sandbox queries created from the built-in template.
+
 - **Final live verification exposed shell and key-output boundary failures**:
   an explicit provider or Console shell command launched from a terminal now
   detaches stdin by default so a completed remote process cannot hang waiting

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -215,6 +215,8 @@ graph TB
 - Defines chain connectivity: chain-id, RPC/API/gRPC endpoints, gas prices, gas adjustment.
 - Can be shared by multiple contexts (e.g., a "mainnet" network used by both "prod" and "monitoring" contexts).
 - Instantiatable from built-in templates (mainnet, testnet, sandbox).
+- Built-in templates track the Akash network registry's current chain IDs and
+  endpoints; the sandbox template targets the live `sandbox-2` network.
 - When a shared network's config is edited within a context, two modes are offered:
   - **Edit parent**: Modify the network definition. Change applies to all contexts using it.
   - **Fork**: Create a copy of the network for this context only. The context switches to the forked copy.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -319,8 +319,12 @@ URI unless the user supplies an explicit URL override, verifies a lease before
 opening its log, event, or shell stream, applies bounded log filters locally, and
 treats an EOF as normal completion only for one-shot streams. Shell stdin EOF
 is held until the remote result arrives so a successful command cannot print
-its output and then fail locally. Gateway HTTP errors retain the provider's
-response detail so rejected operations remain actionable on both rails.
+its output and then fail locally. Interactive shells and piped commands attach
+stdin automatically. A one-shot command launched from a terminal does not
+advertise stdin to the provider unless the user explicitly supplies `--stdin`;
+otherwise providers can keep an already-finished command open waiting for
+terminal input. Gateway HTTP errors retain the provider's response detail so
+rejected operations remain actionable on both rails.
 Shell output crosses one shared formatting boundary on both rails: pretty mode
 streams an interactive PTY unchanged, while JSON and YAML require an explicit
 remote command, disable the PTY, capture stdout and stderr separately, and emit

--- a/SPEC.md
+++ b/SPEC.md
@@ -935,6 +935,16 @@ Show full network details.
 
 ### 2.2.2 Keys Commands
 
+#### `akt context keys add <name>`
+
+Create, recover, or register a key. Pretty output retains the human backup
+warning and mnemonic for a newly generated local key. JSON and YAML emit one
+object with `name`, `address`, and `type`; multisig results also include
+`threshold` and `pubkeys`, and a newly generated local key includes `mnemonic`
+unless `--no-backup` was selected. Recovered keys never repeat their input
+mnemonic. The selected output format applies equally to local, Ledger, and
+multisig keys.
+
 #### `akt context keys show <name|address>`
 
 Show key details. By default prints name, type, address, and public key. Use `--address` (short `-a`) to print only the bech32 address for scripting.
@@ -1560,10 +1570,14 @@ Open an interactive shell into a running container.
 | `--from`      | string | context default | Owner account       |
 | `--service`   | string | required        | Service name        |
 | `--tty`       | bool   | `true`          | Allocate a TTY      |
-| `--stdin`     | bool   | `true`          | Attach stdin        |
+| `--stdin`     | bool   | `false`         | Force stdin attachment for an explicit terminal command |
 | `--auth-type` | string | context default | Auth type           |
 
 Remaining arguments after `--` are passed as the shell command. Default: `/bin/sh`.
+Interactive shells and explicit commands receiving piped input attach stdin
+automatically. An explicit command launched from a terminal leaves stdin
+detached so its remote exit can complete; `--stdin` opts back into attachment,
+and `--stdin=false` explicitly detaches piped input.
 EOF on attached stdin is not a command failure: `akt` waits for the provider's
 remote exit result and returns that result. This prevents a successful
 non-interactive command from printing its output and then exiting non-zero
@@ -2059,7 +2073,7 @@ the shared gateway boundary verifies the lease before opening a stream.
 | `akt console logs <dseq> [service]`                | `--follow`, `--tail N`, `--service` (alternative) — **disabled pending feedback** (positional only, 2026-07) | Stream container logs from the lease's provider (JWT scopes `logs,status`).                    |
 | `akt console events <dseq>`                        | `--follow`                                  | Stream Kubernetes events from the lease's provider (JWT scopes `events,status`).                     |
 | `akt console status <dseq>`                        | `--watch`, `--interval` (5s)                | Live lease status from the provider gateway (JWT scope `status`); with `--watch`, snapshots are re-printed each interval until interrupted. `deployment get` remains the Console-API view. |
-| `akt console shell <dseq> <service> [-- command...]` |                                           | Interactive shell in a lease container, default `/bin/sh`; exec is the same operation with an explicit command (JWT scopes `shell,status`). TTY auto-detected. |
+| `akt console shell <dseq> <service> [-- command...]` | `--stdin`                                 | Interactive shell in a lease container, default `/bin/sh`; exec is the same operation with an explicit command (JWT scopes `shell,status`). TTY auto-detected; terminal stdin is detached from explicit commands unless `--stdin` is supplied. |
 | `akt console screen <sdl-file>`                    |                                             | Client-side bid screening: derive resources from the SDL and list the providers able to run it (public endpoint, no key needed). |
 
 Per the positional-primary convention (§3.8), every console command takes its primary value(s) positionally; the equivalent flags remain as overrides and a positional value wins when both are given. (2026-07: the flag twins marked *disabled pending feedback* above are commented out in code for the positional-only UX trial — the positional form is the only way while the trial runs; the original flag definitions are preserved in `FEEDBACK(2026-07)` comments for restoration.) Default structured reads are indented JSON, while human acknowledgements and streams use the command-specific pretty forms described below; USD values render as `$X.XX` in human output. State-changing calls are recorded in the context's action log as `type=console` entries (§5.6). No command ever prints a Console API key, except the one-time secret from `apikey create`.
@@ -2078,7 +2092,11 @@ interactive byte stream. With `--output json` or `--output yaml`, shell requires
 an explicit command after `--`, runs it without a PTY, and emits exactly one
 object with string fields `stdout` and `stderr`. A structured interactive shell
 is refused before opening the provider connection. The same contract applies
-to `console shell` and `provider lease-shell`. If both the remote command and
+to `console shell` and `provider lease-shell`. Interactive shells and commands
+with piped input attach stdin automatically. Explicit commands launched from a
+terminal leave it detached unless `--stdin` is supplied, so the provider can
+deliver the remote exit result without waiting indefinitely for terminal
+input. If both the remote command and
 structured-output rendering fail, the returned error preserves both causes so
 callers can classify either failure with `errors.Is`.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -82,14 +82,14 @@ networks:
     gas-adjustment: "1.5"
 
   - name: sandbox
-    chain-id: sandbox-01
+    chain-id: sandbox-2
     endpoints:
       rpc:
-        - https://rpc.sandbox-01.aksh.pw:443
+        - https://rpc.sandbox-2.aksh.pw:443
       api:
-        - https://api.sandbox-01.aksh.pw:443
+        - https://api.sandbox-2.aksh.pw:443
       grpc:
-        - grpc.sandbox-01.aksh.pw:443
+        - grpc.sandbox-2.aksh.pw:9090
     gas-prices: "0.025uakt"
     gas-adjustment: "1.5"
 
@@ -341,14 +341,14 @@ gas-adjustment: "1.5"
 **Template: `sandbox`**
 ```yaml
 name: sandbox
-chain-id: sandbox-01
+chain-id: sandbox-2
 endpoints:
   rpc:
-    - https://rpc.sandbox-01.aksh.pw:443
+    - https://rpc.sandbox-2.aksh.pw:443
   api:
-    - https://api.sandbox-01.aksh.pw:443
+    - https://api.sandbox-2.aksh.pw:443
   grpc:
-    - grpc.sandbox-01.aksh.pw:443
+    - grpc.sandbox-2.aksh.pw:9090
 gas-prices: "0.025uakt"
 gas-adjustment: "1.5"
 ```
@@ -925,7 +925,7 @@ $ akt context network list
   NAME              CHAIN-ID       RPC                          USED BY
   mainnet           akashnet-2     rpc.akt.dev:443/rpc          prod, monitoring
   testnet           testnet-02     rpc.testnet-02.aksh.pw:443   staging
-  sandbox           sandbox-01     rpc.sandbox-01.aksh.pw:443
+  sandbox           sandbox-2      rpc.sandbox-2.aksh.pw:443
   mainnet-custom    akashnet-2     my-private-rpc:443           (none)
 ```
 
@@ -2633,7 +2633,7 @@ Select networks  ↑↓ move  space toggle  enter confirm
 
     [x]  mainnet             akashnet-2        [3 rpc, 2 api, 1 grpc]
     [x]  testnet             testnet-02        [1 rpc, 1 api, 1 grpc]
-    [x]  sandbox             sandbox-01        [1 rpc, 1 api, 1 grpc]
+    [x]  sandbox             sandbox-2         [1 rpc, 1 api, 1 grpc]
 
   q quit
 ```

--- a/internal/bootstrap/networks_test.go
+++ b/internal/bootstrap/networks_test.go
@@ -305,7 +305,7 @@ func TestInteractiveSelectorsFallBackWithoutATerminal(t *testing.T) {
 
 	networks := []aktctx.Network{
 		{Name: "mainnet", ChainID: "akashnet-2"},
-		{Name: "sandbox", ChainID: "sandbox-01"},
+		{Name: "sandbox", ChainID: "sandbox-2"},
 	}
 
 	got := multiSelect(networks)

--- a/internal/cli/console/gateway.go
+++ b/internal/cli/console/gateway.go
@@ -389,7 +389,7 @@ func statusCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 }
 
 func shellCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "shell <dseq> <service> [-- command...]",
 		Short: "Open a shell or run a command in a lease container",
 		Long: "Open an interactive shell (default command /bin/sh) or run an explicit command in a " +
@@ -431,13 +431,26 @@ func shellCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 				return err
 			}
 			tty := term.IsTerminal(int(os.Stdin.Fd()))
+			stdinOverride, _ := cmd.Flags().GetBool("stdin")
+			stdin := aktprovider.SelectShellStdin(
+				shellCtx,
+				os.Stdin,
+				interactive,
+				tty,
+				cmd.Flags().Changed("stdin"),
+				stdinOverride,
+			)
 
 			return output.RunShellOutput(cmd, interactive, tty, func(stdout, stderr io.Writer, shellTTY bool) error {
 				return aktprovider.RunLeaseShell(shellCtx, gw, lid, service, 0, command,
-					aktprovider.HoldEOF(shellCtx, os.Stdin), stdout, stderr, shellTTY, nil)
+					stdin, stdout, stderr, shellTTY, nil)
 			})
 		},
 	}
+
+	cmd.Flags().Bool("stdin", false, "Force stdin attachment for an explicit terminal command")
+
+	return cmd
 }
 
 // --- bid screening ------------------------------------------------------------

--- a/internal/cli/console/gateway_test.go
+++ b/internal/cli/console/gateway_test.go
@@ -549,6 +549,17 @@ func TestShellRejectsStructuredInteractiveModeBeforeContextResolution(t *testing
 	}
 }
 
+func TestShellStdinOverrideDefaultsToAutomaticSelection(t *testing.T) {
+	cmd := shellCmd(func() *aktctx.Manager { return nil })
+	flag := cmd.Flags().Lookup("stdin")
+	if flag == nil {
+		t.Fatal("console shell has no --stdin override")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("--stdin default = %q, want false force-override default", flag.DefValue)
+	}
+}
+
 func TestMatchesService(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/keys/commands.go
+++ b/internal/cli/keys/commands.go
@@ -30,6 +30,15 @@ type keyDetails struct {
 	PubKey  string `json:"pubkey"  yaml:"pubkey"`
 }
 
+type keyAddResult struct {
+	Name      string `json:"name"                yaml:"name"`
+	Address   string `json:"address"             yaml:"address"`
+	Type      string `json:"type"                yaml:"type"`
+	Mnemonic  string `json:"mnemonic,omitempty"  yaml:"mnemonic,omitempty"`
+	Threshold int    `json:"threshold,omitempty" yaml:"threshold,omitempty"`
+	PubKeys   int    `json:"pubkeys,omitempty"   yaml:"pubkeys,omitempty"`
+}
+
 type addressParseResult struct {
 	Format    string            `json:"format"          yaml:"format"`
 	HRP       string            `json:"hrp,omitempty"   yaml:"hrp,omitempty"`
@@ -104,7 +113,7 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 			multisigKeys, _ := cmd.Flags().GetString("multisig")
 			if multisigKeys != "" {
 				threshold, _ := cmd.Flags().GetInt("multisig-threshold")
-				return addMultisig(kr, name, multisigKeys, threshold)
+				return addMultisig(cmd, kr, name, multisigKeys, threshold)
 			}
 
 			coinType, _ := cmd.Flags().GetUint32("coin-type")
@@ -130,11 +139,11 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 					return fmt.Errorf("get address: %w", err)
 				}
 
-				fmt.Printf("- name: %s\n", record.Name)
-				fmt.Printf("  address: %s\n", addr.String())
-				fmt.Printf("  type: ledger\n")
-
-				return nil
+				return printAddedKey(cmd, keyAddResult{
+					Name:    record.Name,
+					Address: addr.String(),
+					Type:    "ledger",
+				})
 			}
 
 			recoverKey, _ := cmd.Flags().GetBool("recover")
@@ -150,7 +159,7 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 
 				mnemonic = strings.TrimSpace(string(data))
 			} else if recoverKey {
-				fmt.Print("Enter your mnemonic: ")
+				_, _ = fmt.Fprint(cmd.ErrOrStderr(), "Enter your mnemonic: ")
 
 				reader := bufio.NewReader(os.Stdin)
 				mnemonic, _ = reader.ReadString('\n')
@@ -168,7 +177,7 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 
 			interactive, _ := cmd.Flags().GetBool("interactive")
 			if interactive {
-				fmt.Print("Enter BIP39 passphrase (leave empty for none): ")
+				_, _ = fmt.Fprint(cmd.ErrOrStderr(), "Enter BIP39 passphrase (leave empty for none): ")
 
 				reader := bufio.NewReader(os.Stdin)
 				bip39Passphrase, _ = reader.ReadString('\n')
@@ -188,19 +197,16 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 			keyType, _ := cmd.Flags().GetString("key-type")
 			noBackup, _ := cmd.Flags().GetBool("no-backup")
 
-			fmt.Printf("- name: %s\n", record.Name)
-			fmt.Printf("  address: %s\n", addr.String())
-			fmt.Printf("  type: %s\n", keyType)
-
+			result := keyAddResult{
+				Name:    record.Name,
+				Address: addr.String(),
+				Type:    keyType,
+			}
 			if !noBackup && !recoverKey && source == "" {
-				fmt.Println("")
-				fmt.Println("**Important** write this mnemonic phrase in a safe place.")
-				fmt.Println("It is the only way to recover your account if you ever forget your password.")
-				fmt.Println("")
-				fmt.Println(mnemonic)
+				result.Mnemonic = mnemonic
 			}
 
-			return nil
+			return printAddedKey(cmd, result)
 		},
 	}
 
@@ -220,7 +226,7 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
 	return cmd
 }
 
-func addMultisig(kr sdkkeyring.Keyring, name, keyNames string, threshold int) error {
+func addMultisig(cmd *cobra.Command, kr sdkkeyring.Keyring, name, keyNames string, threshold int) error {
 	names := strings.Split(keyNames, ",")
 	pks := make([]cryptotypes.PubKey, 0, len(names))
 
@@ -251,11 +257,36 @@ func addMultisig(kr sdkkeyring.Keyring, name, keyNames string, threshold int) er
 		return fmt.Errorf("get address: %w", err)
 	}
 
-	fmt.Printf("- name: %s\n", record.Name)
-	fmt.Printf("  address: %s\n", addr.String())
-	fmt.Printf("  type: multi\n")
-	fmt.Printf("  threshold: %d\n", threshold)
-	fmt.Printf("  pubkeys: %d\n", len(pks))
+	return printAddedKey(cmd, keyAddResult{
+		Name:      record.Name,
+		Address:   addr.String(),
+		Type:      "multi",
+		Threshold: threshold,
+		PubKeys:   len(pks),
+	})
+}
+
+func printAddedKey(cmd *cobra.Command, result keyAddResult) error {
+	format := output.FormatFromCmd(cmd)
+	if format != output.FormatTable {
+		return output.Fprint(cmd.OutOrStdout(), format, result)
+	}
+
+	w := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(w, "- name: %s\n", result.Name)
+	_, _ = fmt.Fprintf(w, "  address: %s\n", result.Address)
+	_, _ = fmt.Fprintf(w, "  type: %s\n", result.Type)
+	if result.Threshold > 0 {
+		_, _ = fmt.Fprintf(w, "  threshold: %d\n", result.Threshold)
+		_, _ = fmt.Fprintf(w, "  pubkeys: %d\n", result.PubKeys)
+	}
+	if result.Mnemonic != "" {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "**Important** write this mnemonic phrase in a safe place.")
+		_, _ = fmt.Fprintln(w, "It is the only way to recover your account if you ever forget your password.")
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, result.Mnemonic)
+	}
 
 	return nil
 }

--- a/internal/cli/keys/commands_test.go
+++ b/internal/cli/keys/commands_test.go
@@ -3,6 +3,8 @@ package keys
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -47,6 +49,42 @@ func runKeysCommand(t *testing.T, kr sdkkeyring.Keyring, args ...string) (string
 
 	err := cmd.Execute()
 	return out.String(), err
+}
+
+func TestKeysAddRecoveryHonorsStructuredOutput(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "mnemonic.txt")
+	if err := os.WriteFile(source, []byte("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\n"), 0o600); err != nil {
+		t.Fatalf("write mnemonic fixture: %v", err)
+	}
+
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			kr := aktkeyring.NewInMemory(aktcodec.MakeEncodingConfig().Codec)
+			out, err := runKeysCommand(t, kr,
+				"add", "recovered", "--recover", "--source", source, "--output", format)
+			if err != nil {
+				t.Fatalf("add recovered key: %v", err)
+			}
+
+			var got map[string]any
+			if format == "json" {
+				err = json.Unmarshal([]byte(out), &got)
+			} else {
+				err = yaml.Unmarshal([]byte(out), &got)
+			}
+			if err != nil {
+				t.Fatalf("parse %s key result %q: %v", format, out, err)
+			}
+			for _, field := range []string{"name", "address", "type"} {
+				if value, ok := got[field].(string); !ok || value == "" {
+					t.Errorf("%s field %q = %#v", format, field, got[field])
+				}
+			}
+			if _, exists := got["mnemonic"]; exists {
+				t.Errorf("recovered key repeated its mnemonic: %#v", got)
+			}
+		})
+	}
 }
 
 func TestKeysShowStructuredOutput(t *testing.T) {

--- a/internal/cli/provider/commands.go
+++ b/internal/cli/provider/commands.go
@@ -11,6 +11,7 @@ import (
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	mtypes "pkg.akt.dev/go/node/market/v1"
 	ptypes "pkg.akt.dev/go/node/provider/v1beta4"
@@ -287,11 +288,15 @@ func leaseShellCmd() *cobra.Command {
 				return fmt.Errorf("--service is required for lease-shell")
 			}
 			tty, _ := cmd.Flags().GetBool("tty")
-			attachStdin, _ := cmd.Flags().GetBool("stdin")
-			var stdin io.Reader
-			if attachStdin {
-				stdin = aktprovider.HoldEOF(shellCtx, os.Stdin)
-			}
+			stdinOverride, _ := cmd.Flags().GetBool("stdin")
+			stdin := aktprovider.SelectShellStdin(
+				shellCtx,
+				os.Stdin,
+				interactive,
+				term.IsTerminal(int(os.Stdin.Fd())),
+				cmd.Flags().Changed("stdin"),
+				stdinOverride,
+			)
 
 			err = output.RunShellOutput(cmd, interactive, tty, func(stdout, stderr io.Writer, shellTTY bool) error {
 				return aktprovider.RunLeaseShell(shellCtx, cl, lid, service, 0, leaseShellCommand(args),
@@ -306,7 +311,7 @@ func leaseShellCmd() *cobra.Command {
 	addLeaseShellFlags(cmd)
 	cmd.Flags().String("service", "", "Service name (required)")
 	cmd.Flags().BoolP("tty", "t", true, "Allocate a TTY")
-	cmd.Flags().Bool("stdin", true, "Attach stdin")
+	cmd.Flags().Bool("stdin", false, "Force stdin attachment for an explicit terminal command")
 
 	return cmd
 }

--- a/internal/context/defaults.go
+++ b/internal/context/defaults.go
@@ -43,16 +43,16 @@ func NetworkTemplates() map[string]Network {
 		},
 		"sandbox": {
 			Name:    "sandbox",
-			ChainID: "sandbox-01",
+			ChainID: "sandbox-2",
 			Endpoints: Endpoints{
 				RPC: []string{
-					"https://rpc.sandbox-01.aksh.pw:443",
+					"https://rpc.sandbox-2.aksh.pw:443",
 				},
 				API: []string{
-					"https://api.sandbox-01.aksh.pw:443",
+					"https://api.sandbox-2.aksh.pw:443",
 				},
 				GRPC: []string{
-					"grpc.sandbox-01.aksh.pw:443",
+					"grpc.sandbox-2.aksh.pw:9090",
 				},
 			},
 			GasPrices:     "0.025uakt",

--- a/internal/context/defaults_test.go
+++ b/internal/context/defaults_test.go
@@ -1,0 +1,28 @@
+package context
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNetworkTemplatesSandboxTargetsLiveNetwork(t *testing.T) {
+	got, ok := NetworkTemplates()["sandbox"]
+	if !ok {
+		t.Fatal("sandbox network template is missing")
+	}
+
+	want := Network{
+		Name:    "sandbox",
+		ChainID: "sandbox-2",
+		Endpoints: Endpoints{
+			RPC:  []string{"https://rpc.sandbox-2.aksh.pw:443"},
+			API:  []string{"https://api.sandbox-2.aksh.pw:443"},
+			GRPC: []string{"grpc.sandbox-2.aksh.pw:9090"},
+		},
+		GasPrices:     "0.025uakt",
+		GasAdjustment: "1.5",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sandbox template = %#v, want %#v", got, want)
+	}
+}

--- a/internal/provider/gateway.go
+++ b/internal/provider/gateway.go
@@ -168,6 +168,33 @@ func HoldEOF(ctx context.Context, reader io.Reader) io.Reader {
 	return &holdEOFReader{ctx: ctx, reader: reader}
 }
 
+// SelectShellStdin chooses whether a shell invocation advertises stdin to the
+// provider. Interactive shells and piped commands attach automatically. An
+// explicit command launched from a terminal detaches by default so a provider
+// cannot keep the completed command open waiting for terminal input.
+func SelectShellStdin(
+	ctx context.Context,
+	reader io.Reader,
+	interactive bool,
+	inputIsTerminal bool,
+	overrideSet bool,
+	overrideValue bool,
+) io.Reader {
+	if reader == nil {
+		return nil
+	}
+
+	attach := interactive || !inputIsTerminal
+	if overrideSet {
+		attach = overrideValue
+	}
+	if !attach {
+		return nil
+	}
+
+	return HoldEOF(ctx, reader)
+}
+
 type holdEOFReader struct {
 	ctx    context.Context
 	reader io.Reader

--- a/internal/provider/gateway_test.go
+++ b/internal/provider/gateway_test.go
@@ -148,6 +148,40 @@ func TestHoldEOFUntilContextDone(t *testing.T) {
 	}
 }
 
+func TestSelectShellStdin(t *testing.T) {
+	input := strings.NewReader("input")
+	tests := []struct {
+		name          string
+		interactive   bool
+		terminal      bool
+		overrideSet   bool
+		overrideValue bool
+		wantAttached  bool
+	}{
+		{name: "interactive terminal", interactive: true, terminal: true, wantAttached: true},
+		{name: "explicit terminal command", terminal: true, wantAttached: false},
+		{name: "explicit piped command", terminal: false, wantAttached: true},
+		{name: "forced terminal stdin", terminal: true, overrideSet: true, overrideValue: true, wantAttached: true},
+		{name: "detached interactive stdin", interactive: true, terminal: true, overrideSet: true, overrideValue: false, wantAttached: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SelectShellStdin(
+				context.Background(),
+				input,
+				tc.interactive,
+				tc.terminal,
+				tc.overrideSet,
+				tc.overrideValue,
+			)
+			if attached := got != nil; attached != tc.wantAttached {
+				t.Fatalf("stdin attached = %v, want %v", attached, tc.wantAttached)
+			}
+		})
+	}
+}
+
 type signaledEOFReader struct {
 	called chan struct{}
 }


### PR DESCRIPTION
## Summary

- detach stdin by default for explicit terminal shell commands while preserving interactive, piped, and explicit override behavior
- make `context keys add` honor JSON and YAML output across key types
- replace the retired sandbox template with the live `sandbox-2` chain and official RPC, API, and gRPC endpoints
- document each CLI contract before implementation and add regression coverage

## Verification

- `GOWORK=off CGO_ENABLED=0 go test -tags "osusergo,netgo,nolink_libwasmvm" ./... -count=1`
- `GOWORK=off CGO_ENABLED=0 go vet -tags "osusergo,netgo,nolink_libwasmvm" ./internal/...`
- `GOWORK=off CGO_ENABLED=0 golangci-lint run --timeout=10m --build-tags=osusergo,netgo,nolink_libwasmvm`
- full live Console read matrix: 72/72 exit 0 across pretty, JSON, and YAML
- live Console `shell ... -- pwd`: pretty, JSON, and YAML all exit 0
- generated key JSON/YAML parse and contain no mnemonic with `--no-backup`
- fresh `context create sandbox-2 --network sandbox-2` reaches the live sandbox and returns a staking pool different from mainnet

## Stack

This PR is stacked on `chalabi/workflow-recovery-reliability`.
