### PR TITLE
ci: update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,24 +18,24 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           # Must match GOLANGCI_LINT_VERSION in the Makefile, and must be
           # built with Go >= the go directive in go.mod — older releases
           # refuse to load a config targeting a newer language version.
-          # golangci-lint v2 needs action v7; v6 rejects a v2 version string.
+          # The action major must support golangci-lint v2.
           version: v2.11.4
           args: --timeout=10m
 
   build-and-unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Build
@@ -49,8 +49,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       # Gates the akt-authored packages that carry risk (money, credentials,
@@ -76,7 +76,7 @@ jobs:
         run: make test-coverage-check
       - name: Repo-wide coverage (reported, not gated)
         run: make test-coverage
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage
@@ -86,8 +86,8 @@ jobs:
   e2e-offline:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Build akt binary
@@ -102,8 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Build akt binary
@@ -127,8 +127,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Build akt binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       # packages and checksums to it.
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # The version baked into the binary comes from `git describe`, so the
           # single-commit default checkout is not enough.
@@ -45,7 +45,7 @@ jobs:
         # and goreleaser needs the annotation to build the changelog.
         run: git fetch --force --tags
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload artifacts
         if: github.event_name == 'workflow_dispatch' && inputs.mode != 'check'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: akt-${{ inputs.mode }}
           path: |

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- **CI and release workflows used outdated GitHub Actions runtimes**:
+  checkout, Go setup, and artifact upload now use their maintained v7
+  releases, while golangci-lint uses the v9 action with the repository's lint
+  binary still pinned at v2.11.4 for reproducible results.
+
 - **Root help described deployment as the whole CLI**: the introduction now
   presents akt as the unified interface for chain queries and transactions,
   deployments on either payment rail, provider operations, context and key

--- a/SPEC.md
+++ b/SPEC.md
@@ -5420,6 +5420,11 @@ Cobra provides this feature via `Command.SuggestionsMinimumDistance` and `Comman
 | 1.15 | Shell completion      | bash, zsh, fish completion scripts                                                                                                                                                          | Tab completion works for commands, flags, and context/network names                                     |
 | 1.16 | E2E test suite        | Core test coverage for context, network, tx, query                                                                                                                                          | Tests pass in CI against a local testnet                                                                |
 
+GitHub-hosted CI and release workflows pin third-party actions to maintained
+major versions. Action-major upgrades must pass `actionlint`, every required PR
+check, and the release workflow's manual `check` mode before merge. Tool
+versions remain explicitly pinned where reproducible results require them.
+
 ### Phase 2: Store + Workflow Commands
 
 **Duration**: ~4-6 weeks


### PR DESCRIPTION
## Summary

- update checkout, setup-go, and upload-artifact to v7
- update golangci-lint-action to v9 while keeping lint v2.11.4 pinned
- document the validation contract for action-major upgrades

## Validation

- [x] actionlint -color
- [x] git diff --check
- [x] required pull request checks
- [x] release workflow manual check mode ([run](https://github.com/akash-network/akt/actions/runs/30733055841))