### PR TITLE
fix(keyring): defer identity access until commands need it

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -41,10 +41,53 @@
   Both flags are now global, bound to Viper so the environment variables work,
   and applied to every keyring the invocation opens — including the one behind
   `akt context keys`. The transaction-local duplicates are removed: they
-   shadowed the global flag, and their non-empty `os` default stood ready to
-   override a context's persisted backend. A new `akt context keyring`
-   group (`create`, `list`, `set`) makes the change persistent, which until now
-   required hand-editing `config.yaml`.
+  shadowed the global flag, and their non-empty `os` default stood ready to
+  override a context's persisted backend. A new `akt context keyring`
+  group (`create`, `list`, `set`) makes the change persistent, which until now
+  required hand-editing `config.yaml`.
+
+- **First run left users on mainnet, in an unnamed directory, without their
+  existing keys**: the bootstrap wizard silently preferred mainnet for
+  `current-context`, so the shortest path through setup — Enter, Enter — armed
+  the next transaction to spend real AKT on a network the user was never asked
+  about. Choosing the active context is now an explicit prompt whose cursor
+  starts on a test network (`sandbox`, else `testnet`, else any non-mainnet
+  selection), with mainnet one keystroke away and each row stating in plain
+  language what transacting there costs. The preference is a pure
+  `pickInitialContext` helper so the safety property is testable, which nothing
+  in the wizard's interactive body previously was.
+
+  The wizard also never said where it was writing until the closing summary, so
+  anyone who abandoned it, or who had `AKT_HOME`/`XDG_CONFIG_HOME` set by
+  another tool, could not tell which of the four resolution steps had won. The
+  resolved config root and config file path are now announced before the first
+  prompt, together with the `--home` and `AKT_HOME` overrides and a note that
+  nothing is written until the prompts complete. The closing summary grew from
+  two lines to the full set of locations — config file, active context with its
+  chain ID, context directory, store, action log, and keyring — using the same
+  labels as `akt context show`, marking directories that do not exist yet as
+  created on first use, and naming the system keyring service instead of a
+  directory for the `os` backend. No generated context gets a
+  `default-account`, so the summary now ends with the `akt context keys add`
+  commands that make the configuration usable.
+
+  Finally, nothing told users of the legacy `akash` CLI that their keys and
+  certificates do not carry over. A read-only detector (`os.Stat` plus a `*.pem`
+  glob — akt never reads, moves, modifies, or deletes anything under `~/.akash`)
+  now triggers a notice naming all three reasons the legacy state is invisible:
+  the OS keyring service name (`akash` vs `akt`), the keyring directory, and the
+  client home directory used to locate `<address>.pem`. The notice states that
+  the account is recoverable with `akt context keys add <name> --recover` at the
+  same address, that the published certificate remains valid on chain
+  (`akt query cert list <address>`), and that copying
+  `~/.akash/<address>.pem` into the akt home restores mTLS for free — its
+  password is derived from a keyring signature over the address — while
+  regenerating with `akt tx cert generate client` / `akt tx cert publish client`
+  costs a transaction.
+
+  All wizard rendering — prompts, progress, summary, and the Console onboarding
+  prompts — moved from stdout to stderr as SPEC §3.9.2 and §10.1.1 require; the
+  wizard now writes nothing to stdout.
 
 - **Root help described deployment as the whole CLI**: the introduction now
   presents akt as the unified interface for chain queries and transactions,

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -9,6 +9,43 @@
   it. Only an omitted owner filter that needs the account opens the keyring;
   network-wide reads and explicitly scoped queries remain non-interactive.
 
+- **Offline commands asked for the wallet passphrase**: startup resolved the
+  context's named `default-account` for every command, and resolving a name
+  means unlocking the keyring — so `akt sdl validate` and `akt monitor`, both
+  documented to run entirely locally, prompted for a file passphrase or an OS
+  keychain unlock. Whether an invocation needs the local signing identity is
+  now an explicit decision (`requiresLocalIdentity`, alongside
+  `requiresConfig`/`requiresContext`) that the root passes down to the client
+  context builder. Commands defined to run without a signer neither open a
+  keyring nor resolve a named account; an address-valued default still
+  resolves, because parsing bech32 costs nothing.
+
+- **A configured `os` keyring silently became a different store**: the Cosmos
+  SDK opens the `os` backend without pinning the backend list, and the
+  underlying library skips past any backend whose opener fails — so a headless
+  host with no session bus landed on `pass` or, failing that, an encrypted
+  file keyring, while `config.yaml` and `akt context show` went on reporting
+  `os`. That is also where the mysterious passphrase prompt came from. akt now
+  resolves `os` to the platform's system credential store itself (Keychain,
+  Windows Credential Manager, Secret Service/KWallet) with the backend list
+  pinned, and fails fast when the host has none, naming both remedies instead
+  of substituting a store the user never chose. `akt context show` and
+  `akt context keyring list` report the *effective* backend next to the
+  configured one, and the first-run wizard no longer offers `os` on a host
+  that cannot provide it.
+
+- **Key storage could not be chosen where it mattered**: `--keyring-backend`
+  and `--keyring-dir` existed only on `tx` commands, so the documented
+  `AKT_KEYRING_BACKEND`/`AKT_KEYRING_DIR` variables did nothing and there was
+  no way to add a key to a `file` keyring on a box whose context said `os`.
+  Both flags are now global, bound to Viper so the environment variables work,
+  and applied to every keyring the invocation opens — including the one behind
+  `akt context keys`. The transaction-local duplicates are removed: they
+   shadowed the global flag, and their non-empty `os` default stood ready to
+   override a context's persisted backend. A new `akt context keyring`
+   group (`create`, `list`, `set`) makes the change persistent, which until now
+   required hand-editing `config.yaml`.
+
 - **Root help described deployment as the whole CLI**: the introduction now
   presents akt as the unified interface for chain queries and transactions,
   deployments on either payment rail, provider operations, context and key

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- **Network-wide queries unlocked the configured keyring unnecessarily**:
+  query initialization now carries a named default account without resolving
+  it. Only an omitted owner filter that needs the account opens the keyring;
+  network-wide reads and explicitly scoped queries remain non-interactive.
+
 - **Root help described deployment as the whole CLI**: the introduction now
   presents akt as the unified interface for chain queries and transactions,
   deployments on either payment rail, provider operations, context and key

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- **Strict keyring validation blocked commands that never used a key**: the
+  startup identity boundary now distinguishes no access, deferred access, and
+  required access. Public queries, provider status, MCP startup, workflow
+  dry-runs, and address-only transaction generation/simulation no longer open
+  an unavailable OS backend. Owner-defaulting and authenticated calls still
+  resolve named accounts at the first operation that needs them.
+
 - **Network-wide queries unlocked the configured keyring unnecessarily**:
   query initialization now carries a named default account without resolving
   it. Only an omitted owner filter that needs the account opens the keyring;

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -260,27 +260,24 @@ such as `tcp://localhost:26657` must never replace a resolved endpoint. Local
 transaction leaves use the same pre-run boundary; a leaf that needs codecs or
 clients cannot reach its handler without that initialization.
 
-Step 2 loads the keyring only for commands that declare a need for the local
-signing identity. The startup boundary is uniform, but "resolve the context"
-and "unlock the user's keys" are separate decisions: opening a keyring can
-prompt for a passphrase or an OS unlock, so a command that will never sign must
-not trigger one. The decision lives next to the existing `requiresConfig` /
-`requiresContext` predicates as `requiresLocalIdentity`, and the root passes it
-down explicitly rather than letting the client layer guess from command names.
-When it is false the client context is built with a nil keyring and a named
-`default-account` is left unresolved; an address-valued default is still parsed,
-because that costs nothing. This is what makes `akt sdl validate` and
-`akt monitor` keep the "runs entirely locally" promise on a machine that has a
-context configured.
+Step 2 assigns one of three identity modes: none, on demand, or required.
+"Resolve the context" and "open the user's key store" are separate decisions
+because opening a backend can prompt, fail on a headless host, or request an OS
+unlock. None supplies no keyring. On demand supplies a deferred keyring whose
+backend opens on the first real key operation. Required opens and resolves the
+signer during startup. The decision lives next to `requiresConfig` and
+`requiresContext` as `localIdentityMode`; the root passes the typed result down
+rather than making the client layer infer behavior from command names.
 
-Queries declare the need but do not spend it eagerly. Query context assembly
-carries the configured default-account reference without unlocking the keyring
-merely because the context has one: a named default account is resolved only
-when the query's own omitted owner filter requires that address. Network-wide
-queries and queries given an explicit owner never read a key. An address-valued
-default is parsed directly and costs nothing either way. Transaction, workflow,
-and authenticated provider paths keep their existing signer resolution because
-those operations actually need the local identity.
+Queries, public provider status, and MCP startup use the deferred form. A named
+default account resolves only when an omitted owner or protected gateway call
+needs it, so network-wide and explicitly scoped reads never open a key store.
+Address-based transaction generation and simulation also stay deferred; the SDK
+can build or simulate from the bech32 address without proving that the key is
+local. Signing transactions, executing workflows, and protected provider calls
+remain eager. `mcp --enable-writes` promotes a keyring context to eager so its
+advertised chain writes are usable, but a Console-only context remains
+keyring-free. Purely local commands and workflow dry-runs receive no keyring.
 
 #### 3.1.2.1 Keyring Backend Resolution
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -619,7 +619,7 @@ pkg.akt.dev/akt/                         # module path (repo: github.com/akash-n
 │   │   └── theme/                       # Unified color palette and base styles
 │   ├── glyphs/                          # ASCII-safe glyph registry (§3.2)
 │   ├── context/                         # Context management core
-│   ├── bootstrap/                       # First-run config initialization wizard
+│   ├── bootstrap/                       # First-run config initialization wizard (§7.4)
 │   ├── capability/                      # Feature set derived from the context (§3.6)
 │   ├── transport/                       # Action-to-rail translation layer (§3.5)
 │   ├── actionlog/                       # Action log (unique per context)
@@ -1110,3 +1110,49 @@ These remain in their respective repositories:
 - `provider-services migrate-*` -- all migration commands
 - `provider-services sdl-to-manifest` -- SDL conversion utility (provider-internal)
 - `provider-services show-cluster-ns` -- Kubernetes namespace utility
+
+### 7.4 First Run Is a Migration, Not an Installation
+
+The command mappings above describe what a returning `akash` user types. They do
+not describe what that user's machine already contains, and the first-run wizard
+is where the two meet. Three properties follow from treating first run as a
+migration step rather than a fresh install.
+
+**The destination is announced before anything is asked.** The akt home resolves
+through a four-step chain (`--home`, `AKT_HOME`, `$XDG_CONFIG_HOME/akt`,
+`~/.config/akt`), and a returning user is exactly the person likely to have one
+of those set from another tool. Printing the resolved root only in the closing
+summary means a user who abandons the wizard, or who is diagnosing why akt "did
+not find" their config, never learns which of the four won. The wizard therefore
+states the root and the overrides up front and notes that nothing is written
+until the prompts complete, so the announcement is informative rather than a
+claim about what already exists.
+
+**The active network is chosen, never inherited.** Creating a context per
+selected network is cheap and reversible; deciding which one is
+`current-context` is neither. The wizard used to prefer mainnet silently, which
+made "press Enter three times" — the path of least resistance for someone
+evaluating a new tool — produce a configuration whose very next transaction
+spends real AKT. That is the wrong direction for a default to fail in. The
+choice is now an explicit prompt whose cursor starts on a test network, with
+mainnet one keystroke away. The selection logic is a pure function over the
+selected networks so it can be tested; the surrounding raw-mode prompt cannot
+be, and should not be where the safety property lives.
+
+**What does not carry over is stated, not discovered.** Keys and client
+certificates in `~/.akash` are invisible to akt for three independent reasons
+(keyring service name, keyring directory, and client home directory — see
+SPEC §1.12). Silence here reads as data loss: the user sees an empty key list
+and concludes akt broke something. The wizard therefore detects the legacy home
+and says plainly what happened and what to do about it — recover the account
+from its mnemonic, and either copy the existing PEM or regenerate the
+certificate — including the fact that the on-chain certificate is still valid
+and that the recovered address is unchanged.
+
+akt deliberately stops at the notice rather than importing. An importer would
+have to open a legacy keyring, which means prompting for a passphrase and
+writing key material on a path the user did not ask for, during a wizard they
+ran to look around. Detection is therefore restricted to `os.Stat` and a
+filename glob: akt never reads, moves, modifies, or deletes anything under
+`~/.akash`, and the notice says so, because a tool that has just told you your
+keys are elsewhere has not yet earned the benefit of the doubt.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -260,14 +260,53 @@ such as `tcp://localhost:26657` must never replace a resolved endpoint. Local
 transaction leaves use the same pre-run boundary; a leaf that needs codecs or
 clients cannot reach its handler without that initialization.
 
-Query context assembly carries the configured default-account reference
-without opening the keyring merely because the context has one. A query
-resolves a named default account only when its own omitted owner filter
-requires that address. Network-wide queries and queries with an explicit owner
-never unlock the keyring. An address-valued default is parsed directly and also
-requires no keyring access. Transaction, workflow, and authenticated provider
-paths keep their existing signer resolution because those operations actually
-need the local identity.
+Step 2 loads the keyring only for commands that declare a need for the local
+signing identity. The startup boundary is uniform, but "resolve the context"
+and "unlock the user's keys" are separate decisions: opening a keyring can
+prompt for a passphrase or an OS unlock, so a command that will never sign must
+not trigger one. The decision lives next to the existing `requiresConfig` /
+`requiresContext` predicates as `requiresLocalIdentity`, and the root passes it
+down explicitly rather than letting the client layer guess from command names.
+When it is false the client context is built with a nil keyring and a named
+`default-account` is left unresolved; an address-valued default is still parsed,
+because that costs nothing. This is what makes `akt sdl validate` and
+`akt monitor` keep the "runs entirely locally" promise on a machine that has a
+context configured.
+
+Queries declare the need but do not spend it eagerly. Query context assembly
+carries the configured default-account reference without unlocking the keyring
+merely because the context has one: a named default account is resolved only
+when the query's own omitted owner filter requires that address. Network-wide
+queries and queries given an explicit owner never read a key. An address-valued
+default is parsed directly and costs nothing either way. Transaction, workflow,
+and authenticated provider paths keep their existing signer resolution because
+those operations actually need the local identity.
+
+#### 3.1.2.1 Keyring Backend Resolution
+
+The Cosmos SDK asks `github.com/99designs/keyring` to open the `os` backend
+without pinning `AllowedBackends`, and that library walks its registered
+backends and skips any whose opener errors. On a headless Linux host neither
+Secret Service nor KWallet registers (no session bus) and the kernel keyring
+opener fails, so the walk reaches `pass` — or, failing that, the file backend,
+which always registers and never errors. The user asked for the system keyring
+and got an encrypted file, while the config and `akt context show` kept
+reporting `os`.
+
+akt therefore resolves the backend itself before handing the request to the
+SDK. `internal/keyring` maps `os` to the platform's system store (Keychain,
+Windows Credential Manager, Secret Service/KWallet) and opens *only* that store,
+with `AllowedBackends` pinned to it. Because the library's own preference order
+puts every OS-specific backend ahead of `pass` and `file`, a pinned probe that
+succeeds proves the SDK's unpinned open would select the same store — so the
+probe is a check, not a second implementation of the choice. A pinned probe
+that fails is a fail-fast error naming the platform store that was missing and
+the two remedies (`--keyring-backend file` for one invocation,
+`akt context keyring set` to persist). Never a substitution.
+
+The same resolver answers the display question without opening anything a
+second time, which is how `akt context show` can report an *effective* backend
+instead of echoing the configured one back at the user.
 
 #### 3.1.3 Live Reload
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -260,6 +260,15 @@ such as `tcp://localhost:26657` must never replace a resolved endpoint. Local
 transaction leaves use the same pre-run boundary; a leaf that needs codecs or
 clients cannot reach its handler without that initialization.
 
+Query context assembly carries the configured default-account reference
+without opening the keyring merely because the context has one. A query
+resolves a named default account only when its own omitted owner filter
+requires that address. Network-wide queries and queries with an explicit owner
+never unlock the keyring. An address-valued default is parsed directly and also
+requires no keyring access. Transaction, workflow, and authenticated provider
+paths keep their existing signer resolution because those operations actually
+need the local identity.
+
 #### 3.1.3 Live Reload
 
 The context is **live-reloadable**. The config file is watched for changes (via fsnotify or polling):

--- a/SPEC.md
+++ b/SPEC.md
@@ -257,6 +257,15 @@ The context is resolved once at application startup and propagated through the e
 
 The resolved context is injected into every service: chain client, provider gateway, sync engine, store, action log, and TUI models.
 
+Building the client context for a query MUST NOT read or unlock a keyring solely
+because `default-account` is configured. A named default account is resolved
+against the keyring only when an omitted owner filter needs its address. A
+network-wide query, or an owner-scoped query supplied an explicit owner address,
+MUST execute without keyring access. An address-valued `default-account` is
+parsed directly without opening the keyring. Commands that sign, authenticate
+to a provider, or otherwise require the local identity keep resolving it at
+their existing execution boundary.
+
 ### 1.8 Live Reload
 
 The config file (`config.yaml`) is watched for changes using Viper's built-in `WatchConfig()` which uses fsnotify.

--- a/SPEC.md
+++ b/SPEC.md
@@ -229,6 +229,36 @@ Keyrings are shared wallet storage. Adding a key to a keyring makes it immediate
 | `backend` | string | no       | `"os"`  | Backend type: `os`, `file`, `test`, `kwallet`, `pass`  |
 | `dir`     | string | no       | `""`    | Keyring directory (default: `<root>/keyrings/<name>/`) |
 
+**Backend resolution is pinned.** The configured `backend` names the credential
+store that akt will use, not a preference to be negotiated. `file`, `test`,
+`kwallet`, and `pass` each resolve to exactly that store. `os` resolves to the
+platform's system credential store and to nothing else:
+
+| Platform  | System store for `os`             |
+| --------- | ---------------------------------- |
+| `darwin`  | Keychain                           |
+| `windows` | Windows Credential Manager         |
+| `linux`   | Secret Service (or KWallet)        |
+
+akt MUST NOT substitute a different store when the configured one is
+unavailable. In particular, a headless host with no session bus MUST NOT fall
+back to an encrypted file keyring, a `pass` store, or the kernel keyring while
+the configuration and `akt context show` continue to report `os`: that
+silently changes where the user's keys live and prompts for a passphrase the
+user never knowingly set. Opening a keyring whose configured backend cannot be
+provided is a normal, fail-fast error (§2.10) that names the backend, the
+platform store it needed, and the remedy — rerun with
+`--keyring-backend file`, or persist the change with
+`akt context keyring set <name> file`.
+
+**Effective backend.** Because `os` is an alias, akt distinguishes the
+*configured* backend from the *effective* one — the concrete store that serves
+it on this host (`keychain`, `wincred`, `secret-service`, `kwallet`). Every
+surface that reports a keyring reports both whenever they differ, and reports
+the backend as unavailable rather than claiming a store that is not there.
+Resolution is inspection only: determining the effective backend MUST NOT read
+a key, unlock a store, or prompt.
+
 ### 1.6 Config Management (Viper)
 
 Configuration is managed via [Viper](https://github.com/spf13/viper). Viper handles config file reading/writing, environment variable binding, flag binding, and live-reload (via fsnotify built into Viper).
@@ -257,14 +287,26 @@ The context is resolved once at application startup and propagated through the e
 
 The resolved context is injected into every service: chain client, provider gateway, sync engine, store, action log, and TUI models.
 
-Building the client context for a query MUST NOT read or unlock a keyring solely
-because `default-account` is configured. A named default account is resolved
-against the keyring only when an omitted owner filter needs its address. A
-network-wide query, or an owner-scoped query supplied an explicit owner address,
-MUST execute without keyring access. An address-valued `default-account` is
-parsed directly without opening the keyring. Commands that sign, authenticate
-to a provider, or otherwise require the local identity keep resolving it at
-their existing execution boundary.
+**Local identity is resolved only where it is needed.** A command declares
+whether it needs the local signing identity — the keyring and the account
+`default-account` names. Startup opens the context's keyring and resolves a
+named `default-account` only for commands that declare that need: transactions,
+workflow execution, provider gateway operations, owner-scoped queries, key
+management, and the MCP server. Commands that are defined to run without a
+signer — SDL authoring (§2.11), monitoring (§2.6), version, completion, store,
+context management, and the Console rail — MUST NOT open a keyring and MUST NOT
+resolve a named account, because both actions can prompt for a passphrase or an
+OS unlock that the command has no use for. An address-valued `default-account`
+is parsed directly and never requires keyring access.
+
+Queries are the one case where declaring the need does not imply using it.
+Building the client context for a query MUST NOT *unlock* a keyring solely
+because `default-account` is configured: a named default account is resolved
+only when an omitted owner filter needs its address. A network-wide query, or an
+owner-scoped query supplied an explicit owner address, MUST execute without any
+keyring read. The keyring is opened so the address can be resolved on demand;
+opening is not unlocking, and no passphrase is requested unless a name has to be
+turned into an address.
 
 ### 1.8 Live Reload
 
@@ -300,8 +342,8 @@ All environment variables use the `AKT_` prefix. When set, they override the cor
 | `AKT_NODE`            | `networks[*].endpoints.rpc[0]` (via context's network)  | `https://rpc.akt.dev:443/rpc` |
 | `AKT_GRPC_ADDR`       | `networks[*].endpoints.grpc[0]` (via context's network) | `grpc.akashnet.net:443`        |
 | `AKT_FROM`            | `contexts[*].default-account`                           | `alice`                        |
-| `AKT_KEYRING_BACKEND` | `keyrings[*].backend` (via context's keyring)           | `os`                           |
-| `AKT_KEYRING_DIR`     | `keyrings[*].dir` (via context's keyring)               | `/path/to/keyring`             |
+| `AKT_KEYRING_BACKEND` | `keyrings[*].backend` (via context's keyring); same value as `--keyring-backend` (§3.1) | `os`                           |
+| `AKT_KEYRING_DIR`     | `keyrings[*].dir` (via context's keyring); same value as `--keyring-dir` (§3.1) | `/path/to/keyring`             |
 | `AKT_GAS`             | `contexts[*].gas`                                       | `auto`                         |
 | `AKT_GAS_PRICES`      | `networks[*].gas-prices` (via context's network)        | `0.025uakt`                    |
 | `AKT_GAS_ADJUSTMENT`  | `networks[*].gas-adjustment` (via context's network)    | `1.5`                          |
@@ -465,6 +507,10 @@ akt
 │   │   ├── edit <name>                  # Edit network definition
 │   │   ├── list                         # List all networks (show which contexts use each)
 │   │   └── show <name>                  # Show network details
+│   ├── keyring                          # Keyring definition management (shared resource)
+│   │   ├── create <name> <backend>      # Create a new keyring definition
+│   │   ├── list                         # List keyrings (configured + effective backend)
+│   │   └── set <name> <backend>         # Change a keyring's stored backend/dir
 │   └── keys                             # Key management
 │       ├── add <name>                   # Add key (mnemonic, ledger, or multisig)
 │       ├── delete <name>                # Delete key
@@ -787,6 +833,14 @@ output includes the fully resolved network and keyring, effective gas/provider
 settings, capability booleans, `store_path`, and `action_log_path`; it never
 includes the Console API key.
 
+The keyring line reports the *configured* backend. When that backend is an
+alias for a platform store — `os` (§1.5) — the concrete store that serves it is
+reported on an `Effective` sub-line, and a configured backend the host cannot
+provide is reported as unavailable together with its remedy. Structured output
+carries the same two facts as `keyring_backend_effective` (empty when
+unavailable) and `keyring_backend_available`. Rendering this view never opens a
+key store and never prompts.
+
 ```bash
 $ akt context show
 Context:         prod
@@ -798,6 +852,7 @@ Network:         mainnet
   Gas Prices:    0.025uakt
   Gas Adj:       1.5
 Keyring:         default (backend: os)
+  Effective:     keychain
 Default Account: alice
 Gas:             auto
 Fees:            (none)
@@ -948,7 +1003,60 @@ $ akt context network list
 
 Show full network details.
 
-### 2.2.2 Keys Commands
+### 2.2.2 Keyring Commands
+
+Keyrings are a shared resource (§1.5), managed independently of the contexts
+that reference them. Without these commands the only way to change where a
+context stores its keys after first run is to hand-edit `config.yaml`.
+
+#### `akt context keyring create <name> <backend>`
+
+Create a new keyring definition. `<backend>` is one of `os`, `file`, `test`,
+`kwallet`, `pass`, `memory`; any other value is a usage error.
+
+| Flag    | Type   | Default | Description                                                |
+| ------- | ------ | ------- | ---------------------------------------------------------- |
+| `--dir` | string | `""`    | Keyring directory (empty = `<root>/keyrings/<name>/`)      |
+
+```bash
+akt context keyring create headless file
+```
+
+#### `akt context keyring list`
+
+List every configured keyring with its configured backend, the effective
+backend on this host (§1.5), its directory, and the contexts that reference it.
+A configured backend that cannot be provided here is reported as
+`unavailable`, never as if it were in use.
+
+```bash
+$ akt context keyring list
+  NAME       BACKEND   EFFECTIVE   DIR                        USED BY
+  default    os        keychain    ~/.config/akt/keyrings/default   prod
+  headless   file      file        ~/.config/akt/keyrings/headless  (none)
+```
+
+#### `akt context keyring set <name> <backend>`
+
+Change a keyring's stored backend, and optionally its directory. This is the
+persistent counterpart of the per-invocation `--keyring-backend` /
+`--keyring-dir` overrides (§3.1) and is the remedy named by the fail-fast error
+raised when a configured backend is unavailable (§1.5).
+
+Changing the backend does **not** migrate existing keys: each backend has its
+own store, so keys added under the previous backend remain there. The command
+says so on stdout.
+
+| Flag    | Type   | Default   | Description                                            |
+| ------- | ------ | --------- | ------------------------------------------------------ |
+| `--dir` | string | unchanged | Keyring directory (empty string is not "unchanged" only when the flag is set) |
+
+```bash
+akt context keyring set default file
+akt context keyring set default file --dir /mnt/secure/keys
+```
+
+### 2.2.3 Keys Commands
 
 #### `akt context keys add <name>`
 
@@ -1780,7 +1888,7 @@ describe both controls as one ambiguous "switch tabs" action.
 An embedded monitor receives exactly the height remaining after the shell's
 chrome; the parent MUST NOT size it for one height and clip it to another.
 
-**Standalone operation**: `akt monitor` (and all subcommands) requires only an RPC endpoint. It does not require a keyring, default account, or chain-id. A monitoring-only context (with no `default-account`) or a bare `--rpc` flag is sufficient, making it usable by anyone observing the network.
+**Standalone operation**: `akt monitor` (and all subcommands) requires only an RPC endpoint. It does not require a keyring, default account, or chain-id. A monitoring-only context (with no `default-account`) or a bare `--rpc` flag is sufficient, making it usable by anyone observing the network. The group declares no local identity (§1.7): a context that *does* carry a keyring and a named `default-account` must not cause the monitor to open that keyring or prompt for it.
 
 #### `akt monitor network [rpc-endpoint]`
 
@@ -2166,7 +2274,7 @@ Example: a network-less `console-api` context (API key only) lists and runs only
 
 ### 2.11 SDL Commands
 
-Transport-independent SDL authoring, ported from console-axi (`src/sdl/templates`, `src/sdl/lint.ts`). All `akt sdl` subcommands run entirely locally: no context, key, or RPC endpoint is required, and the group declares no capability requirements.
+Transport-independent SDL authoring, ported from console-axi (`src/sdl/templates`, `src/sdl/lint.ts`). All `akt sdl` subcommands run entirely locally: no context, key, or RPC endpoint is required, and the group declares no capability requirements. The group declares no local identity either (§1.7), so a configured keyring is never opened and a named `default-account` is never resolved — `akt sdl validate` on a context with a `file` or `os` keyring must not prompt for a passphrase or an OS unlock.
 
 #### `akt sdl scaffolds`
 
@@ -2296,10 +2404,24 @@ Applied to every command via the root command's `PersistentFlags()`.
 | ----------- | ----- | ------ | ------------------------ | ---------------------------------------------------------------- |
 | `--home`    |       | string | `$AKT_HOME` or XDG default | Home directory for config, contexts, and keyrings             |
 | `--context` |       | string | config `current-context` | Active context name (overrides AKT_CONTEXT)                      |
+| `--keyring-backend` |  | string | context's keyring `backend` | Keyring backend for this invocation: `os`, `file`, `test`, `kwallet`, `pass`, `memory` (overrides AKT_KEYRING_BACKEND) |
+| `--keyring-dir` |     | string | context's keyring `dir`  | Keyring directory for this invocation (overrides AKT_KEYRING_DIR) |
 | `--output`  | `-o`  | string | `"pretty"`               | Output format: `pretty`, `json`, `yaml`. For workflows, also accepts `jsonl` (see 2.3.8). |
 | `--interactive` | `-i` | bool | `false`              | Force interactive mode even when `defaults.interactive` is `false` in config or no TTY is detected. Has no effect when interactive mode is already enabled (the default). **Two effects**: (1) Workflow commands (`deploy`, `update`, `close`) use TUI progress display instead of JSONL. (2) Commands that auto-suppress prompts and spinners in non-TTY contexts will show them. Does **not** launch the root TUI application. |
 | `--verbose` | `-v`  | count  | `0`                      | Increase output verbosity. Stacks: `-v` (level 1) shows operational detail (gas estimates, endpoint selection, config resolution); `-vv` (level 2) adds debug diagnostics (RPC request/response dumps, full stack traces). Default (no flag) shows progress/status messages. Mutually exclusive with `--quiet`. |
 | `--quiet`   | `-q`  | bool   | `false`                  | Suppress all informational output (progress messages, status lines, confirmations). Only data output (query results, transaction results) and errors are emitted. Useful for scripting. Mutually exclusive with `-v`. |
+
+`--keyring-backend` and `--keyring-dir` are **global**, not transaction-local.
+Key storage is a property of the invocation, not of signing: listing, adding,
+exporting, and querying keys need the same override that a transaction does,
+and on a host whose configured backend is unavailable (§1.5) the override is
+the only way to reach the keys at all. They are registered once on the root
+command, carry an empty default so that leaving them unset never shadows the
+context's persisted `keyrings[*].backend` / `keyrings[*].dir`, and are bound to
+Viper so `AKT_KEYRING_BACKEND` / `AKT_KEYRING_DIR` (§1.9) resolve through the
+normal flag > env > config > default chain. An unknown backend value is a usage
+error. A supplied override applies to every keyring the invocation opens,
+including the one behind `akt context keys`.
 
 #### 3.1.1 Confirmation and Override Conventions
 
@@ -2325,8 +2447,6 @@ Added to all `tx` commands via `AddTxFlagsToCmd()`.
 | `--fees`             |       | string   | `""`                        | Fixed fees (overrides gas-prices)                             |
 | `--broadcast-mode`   | `-b`  | string   | `"sync"`                    | `sync`, `async`, or `block`                                   |
 | `--sign-mode`        |       | string   | `"direct"`                  | Signing mode: `direct`, `amino-json`, `direct-aux`, `eip-191` |
-| `--keyring-backend`  |       | string   | context default             | Keyring backend override                                      |
-| `--keyring-dir`      |       | string   | context default             | Keyring directory override                                    |
 | `--note`             |       | string   | `""`                        | Transaction memo/note                                         |
 | `--timeout-height`   |       | uint64   | `0`                         | Block height timeout                                          |
 | `--timeout-duration` |       | duration | `0`                         | Time-based timeout                                            |
@@ -2340,6 +2460,13 @@ Added to all `tx` commands via `AddTxFlagsToCmd()`.
 | `--yes`              | `-y`  | bool     | `false`                     | Skip confirmation prompts                                     |
 | `--ledger`           |       | bool     | `false`                     | Use Ledger hardware wallet                                    |
 | `--unordered`        |       | bool     | `false`                     | Unordered transaction                                         |
+
+Key storage is selected by the global `--keyring-backend` / `--keyring-dir`
+flags (§3.1), which every command inherits. Transaction commands do not
+register their own copies: a transaction-local duplicate shadowed the global
+flag, so the documented `AKT_KEYRING_BACKEND` / `AKT_KEYRING_DIR` environment
+variables never reached a `tx` invocation, and its non-empty `os` default
+stood ready to override the context's persisted backend.
 
 `--sign-mode` and `--broadcast-mode` are closed enums: values outside their
 advertised sets are usage errors. For online construction, simulation, and
@@ -2654,6 +2781,14 @@ Select keyring backend  ↑↓ move  enter confirm
     [ ]  file        File-based encrypted keyring
     [ ]  test        Unencrypted test keyring (development only)
 ```
+
+An option the host cannot provide is not offered as if it could be. When the
+platform has no system credential store (§1.5) the `os` row is annotated as
+unavailable, is not selectable, and is not the default cursor position — the
+first selectable option is. The non-TTY fallback follows the same rule: it
+resolves to `os` only where `os` is actually available, and to `file`
+otherwise. Offering `os` on a host that will silently store keys elsewhere is
+the bug this rule exists to prevent.
 
 **Multi-select prompt**: The user toggles items on/off and confirms the batch. Space toggles; Enter confirms. A "Select all" row is the first item. Used for network selection during bootstrap.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -287,26 +287,29 @@ The context is resolved once at application startup and propagated through the e
 
 The resolved context is injected into every service: chain client, provider gateway, sync engine, store, action log, and TUI models.
 
-**Local identity is resolved only where it is needed.** A command declares
-whether it needs the local signing identity — the keyring and the account
-`default-account` names. Startup opens the context's keyring and resolves a
-named `default-account` only for commands that declare that need: transactions,
-workflow execution, provider gateway operations, owner-scoped queries, key
-management, and the MCP server. Commands that are defined to run without a
-signer — SDL authoring (§2.11), monitoring (§2.6), version, completion, store,
-context management, and the Console rail — MUST NOT open a keyring and MUST NOT
-resolve a named account, because both actions can prompt for a passphrase or an
-OS unlock that the command has no use for. An address-valued `default-account`
-is parsed directly and never requires keyring access.
+**Local identity is resolved only where it is needed.** Identity access has
+three modes, selected at the command boundary:
 
-Queries are the one case where declaring the need does not imply using it.
-Building the client context for a query MUST NOT *unlock* a keyring solely
-because `default-account` is configured: a named default account is resolved
-only when an omitted owner filter needs its address. A network-wide query, or an
-owner-scoped query supplied an explicit owner address, MUST execute without any
-keyring read. The keyring is opened so the address can be resolved on demand;
-opening is not unlocking, and no passphrase is requested unless a name has to be
-turned into an address.
+- **none** — the command never receives a keyring. SDL authoring (§2.11),
+  monitoring (§2.6), version, completion, store, context management, the
+  Console rail, and workflow dry-runs use this mode.
+- **on demand** — the client context receives a deferred keyring that does not
+  open its configured backend until an operation actually asks for a key. Chain
+  queries, read-only MCP startup, public provider status, and address-based
+  transaction construction or simulation use this mode.
+- **required** — startup opens the keyring and resolves a named account before
+  execution. Transactions that sign, workflow execution, and authenticated
+  provider operations use this mode.
+
+Opening a file or OS keyring can itself prompt, fail on a headless host, or ask
+the desktop to unlock. An on-demand command therefore MUST NOT open the backend
+merely because `default-account` is configured. A named default account is
+resolved only when an omitted owner or an authenticated operation needs its
+address. Network-wide queries, explicitly scoped queries, `akt provider
+status`, and MCP startup MUST run without any keyring access. An address-valued
+`default-account` or `--from` is parsed directly and never requires keyring
+access for `--generate-only` or `--dry-run`; a signer name opens the deferred
+keyring when it is resolved.
 
 ### 1.8 Live Reload
 
@@ -2149,6 +2152,14 @@ observing these process signals.
 
 **Default account handling:** Tools that accept an `owner` parameter (e.g., `akash_list_deployments`, `akash_list_leases`) default to the context's `default-account` when the parameter is omitted. If no `default-account` is configured (e.g., a monitoring-only context), the `owner` parameter is **required** — the tool returns an error explaining that the owner must be specified explicitly when no default account is available.
 
+Starting the MCP server is an on-demand identity operation (§1.7). Listing
+tools and invoking public or explicitly scoped read tools MUST NOT open the
+configured keyring. A read tool that omits its owner resolves a named
+`default-account` when that call is handled. On a keyring context,
+`--enable-writes` explicitly opts into resolving the signer during startup so
+every advertised chain/provider write tool is usable. Enabling writes on a
+Console-only context does not make that context require a local keyring.
+
 **Numeric argument contract:** Sequence identifiers (`dseq`, `gseq`, and
 `oseq`) are positive whole numbers. Pagination values (`skip` and `limit`) are
 non-negative whole numbers; zero retains the documented default behavior.
@@ -2552,7 +2563,10 @@ never an SDK panic.
 
 `--generate-only` accepts a signer address that is not stored in the local
 keyring. The address identifies the unsigned message and does not imply a
-signing-key lookup. A signer name still resolves through the selected keyring.
+signing-key lookup or even opening the configured backend. `--dry-run` has the
+same address-only identity contract because simulation does not sign. A signer
+name still resolves through the selected keyring on demand. A transaction that
+will sign opens and validates its keyring during startup.
 Multisign assembly accepts only a legacy amino multisig record and validates
 that each signature batch contains an entry for every transaction before
 indexing it; ordinary keys and short batches are normal input errors, never

--- a/SPEC.md
+++ b/SPEC.md
@@ -424,6 +424,46 @@ gas-adjustment: "1.5"
 | `DotFilled` | `*` | Selected version dot |
 | `DotOpen` | `o` | Unselected version dot |
 
+### 1.12 Legacy `akash` Home
+
+The legacy `akash` and `provider-services` CLIs keep their state in `~/.akash`.
+`akt` uses its own home (§1.1) and **never** reads, writes, moves, or deletes
+anything under `~/.akash`. Nothing carries over implicitly, and there is no
+importer.
+
+Three concrete incompatibilities make the legacy home unusable as-is:
+
+| Artifact | Legacy location | `akt` location | Why it does not carry over |
+|---|---|---|---|
+| `os` keyring entries | Keychain/libsecret service `akash` | Keychain/libsecret service `akt` | The service name is the lookup key; entries written under `akash` are invisible to `akt`. |
+| `file` / `test` keyring | `~/.akash/keyring-file`, `~/.akash/keyring-test` | `<home>/keyrings/<keyring-name>` (§1.5) | Different directory; `akt` never scans outside its own home. |
+| Client mTLS certificate | `~/.akash/<address>.pem` | `<home>/<address>.pem` | The chain client's home directory is the `akt` home, so the PEM is looked up there. |
+
+What this costs the user, precisely:
+
+- **An account is recoverable, not lost.** `akt context keys add <name>
+  --recover` with the original mnemonic reproduces the same address and the same
+  on-chain identity. Nothing on chain changes.
+- **A published certificate is not lost.** The certificate is on-chain state and
+  remains valid and queryable with `akt query cert list <address>`. Only the
+  local PEM half is in the wrong directory. Its encryption password is derived
+  deterministically from a keyring signature over the account address, so once
+  the same key is present in the `akt` keyring, copying
+  `~/.akash/<address>.pem` to `<home>/<address>.pem` restores it byte-for-byte
+  with no re-publish and no transaction. Regenerating instead
+  (`akt tx cert generate client` then `akt tx cert publish client`) costs a
+  transaction.
+
+**Detection.** The first-run wizard (§2.0) detects a legacy home so the user is
+told this up front instead of discovering it as a missing key. Detection is
+read-only and strictly bounded to three operations: `os.Stat` on `~/.akash`, a
+`*.pem` filename glob inside it, and `os.Stat` on `keyring-file/` and
+`keyring-test/`. File contents are never read and legacy keyrings are never
+opened. The notice is emitted only when the directory exists **and** at least
+one of those artifacts is present; a bare or unrelated `~/.akash` produces no
+output. The notice states explicitly that nothing in `~/.akash` is read,
+modified, or deleted.
+
 ---
 
 ## 2. CLI Command Reference
@@ -474,7 +514,23 @@ it emits no human plan text.
 
 When `akt` is invoked with no subcommand, the following flow determines what happens:
 
-1. **No config exists** (first run): The bootstrap wizard runs (§1.11, `internal/bootstrap/wizard.go`). It prompts the user to select networks, select a keyring backend (`os`, `file`, or `test`; default: `os`), and configure an initial context. It then offers optional Akash Console onboarding: the user may enter a Console API key (validated best-effort against `/v1/user/me`, stored as the initial context's per-context credential per §7.1) and choose whether deployments for that context should be routed through Console (`auth-method: console-api`). Both prompts default to "no" and are skipped entirely in non-interactive runs. The wizard runs only when stdin is a terminal: in headless environments it declines to bootstrap (no network fetch, no config written) and prints guidance to create a config via `akt context network create` / `akt context create`; the root command then continues to step 2 without a config. After bootstrap completes, the root command continues to step 2.
+1. **No config exists** (first run): The bootstrap wizard runs (`internal/bootstrap/`; glyphs per §1.11, prompt rendering per §3.9). The wizard runs only when stdin is a terminal: in headless environments it declines to bootstrap (no network fetch, no config written) and prints guidance to create a config via `akt context network create` / `akt context create`; the root command then continues to step 2 without a config. After bootstrap completes, the root command continues to step 2.
+
+In a terminal the wizard performs the following steps, in order. All of its output — announcements, prompts, progress, and the closing summary — goes to stderr (§3.9.2, §10.1.1); the wizard writes nothing to stdout.
+
+**a. Announce the destination.** *Before the first prompt*, the wizard prints the resolved config root and the `config.yaml` path it will write, and names the `--home` flag and the `AKT_HOME` environment variable as the overrides that relocate them (full resolution order in §1.1). It states that nothing is written until the prompts complete. A user who abandons the wizard, or who is unsure whether `AKT_HOME`/`XDG_CONFIG_HOME` is in effect, MUST still learn where akt would place its files without having to finish setup. Printing the destination only in the closing summary does not satisfy this.
+
+**b. Select networks.** A multi-select over the network definitions fetched from `github.com/akash-network/net`, with every network pre-selected. One context is created per selected network, named after that network.
+
+**c. Select the keyring backend.** Single-select over `os`, `file`, and `test`; default `os`.
+
+**d. Select the active context.** The wizard asks explicitly which of the created contexts becomes `current-context`. It MUST NOT choose one silently. The cursor starts on a test network — `sandbox` if it was selected, otherwise `testnet`, otherwise any other non-mainnet selection — so that accepting the default lands on a network where a mistake costs nothing. Mainnet is always present in the list and reachable in a single keystroke, but is never the pre-selected row: the first command a new user runs must not be able to spend real AKT because the active network was inherited from a default rather than chosen. The prompt is shown even when only one network was selected, so the active network is always something the user saw and confirmed.
+
+**e. Optional Akash Console onboarding.** The user may enter a Console API key (validated best-effort against `/v1/user/me`, stored as the initial context's per-context credential per §7.1) and choose whether deployments for that context should be routed through Console (`auth-method: console-api`). Both prompts default to "no" and are skipped entirely in non-interactive runs.
+
+**f. Summary.** After the config is written the wizard prints the config file path; the active context with its chain ID; and that context's context directory, store, action log, and keyring location, using the same labels as `akt context show` (`Store`, `Action Log`). `SaveConfig` creates only the home directory, so paths that do not exist yet are described as where they *will* be created rather than presented as existing. For the `os` backend the keyring line names the system keychain and the `akt` service name rather than a directory, because no directory is used. No context receives a `default-account`, so the summary closes with the next steps that make the configuration usable: `akt context keys add <name>` for a new account, `akt context keys add <name> --recover` for an existing mnemonic, and `akt context show`.
+
+**g. Legacy Akash CLI notice.** Last, the wizard prints the legacy-home notice of §1.12 when — and only when — a legacy `~/.akash` with recoverable artifacts is detected. It is printed after the summary so it is the last thing on screen when the user goes looking for their existing keys.
 > **TUI shell status (2026-07): DISABLED pending UX feedback.** Bare `akt` prints the help text and `--interactive`/`-i` reports that the TUI is disabled. The launch path remains compiled behind `AKT_EXPERIMENTAL_TUI=1` for feedback sessions, and `akt monitor` (§2.6) is unaffected. Steps 2–5 below describe the behavior that resumes when the TUI is re-enabled.
 
 The root help introduction describes `akt` as the unified Akash Network CLI.
@@ -2802,6 +2858,16 @@ Select networks  ↑↓ move  space toggle  enter confirm
     [x]  sandbox             sandbox-2         [1 rpc, 1 api, 1 grpc]
 
   q quit
+```
+
+**Active-context prompt**: A single-select over the contexts just created, used at the end of network selection during bootstrap (§2.0 step d). The cursor starts on a test network, never on mainnet, and each row states in plain language what transacting on that network costs.
+
+```
+Select the active context  ↑↓ move  enter confirm
+
+  > [x]  sandbox     sandbox-2    test network - tokens have no value
+    [ ]  testnet     testnet-02   test network - tokens have no value
+    [ ]  mainnet     akashnet-2   live network - transactions spend real AKT
 ```
 
 **Value input prompt**: Free-form text or numeric input with an optional default. Used for deposit amounts, gas overrides, or custom names. Input is validated before acceptance.

--- a/e2e/offline_test.go
+++ b/e2e/offline_test.go
@@ -714,6 +714,12 @@ func TestAllCommandsHelp(t *testing.T) {
 		{"context", "network", "list"},
 		{"context", "network", "show"},
 
+		// context keyring
+		{"context", "keyring"},
+		{"context", "keyring", "create"},
+		{"context", "keyring", "list"},
+		{"context", "keyring", "set"},
+
 		// context keys
 		{"context", "keys"},
 		{"context", "keys", "add"},
@@ -868,6 +874,162 @@ func TestConfigFreeCommandsSkipBootstrap(t *testing.T) {
 				t.Fatalf("akt %s wrote a config on an unconfigured machine", name)
 			}
 		})
+	}
+}
+
+// TestOfflineCommandsDoNotUnlockTheKeyring is the sibling of
+// TestConfigFreeCommandsSkipBootstrap for a machine that *is* configured. The
+// commands documented to run entirely locally (SPEC §2.11, §2.6) must stay
+// that way when the active context carries a file-backed keyring and a named
+// default-account: turning that name into an address means unlocking the
+// keyring, which asks for a passphrase the command has no use for.
+//
+// The home is deliberately seeded with a keyring that has never been created,
+// so any attempt to read it prompts. stdin is empty, so the prompt shows up on
+// stderr rather than hanging.
+func TestOfflineCommandsDoNotUnlockTheKeyring(t *testing.T) {
+	home := t.TempDir()
+	initHomeWithLockedKeyring(t, home)
+
+	sdlPath := filepath.Join(home, "deploy.yaml")
+	writeFile(t, sdlPath, minimalSDL)
+
+	commands := [][]string{
+		{"sdl", "validate", sdlPath},
+		{"context", "show"},
+		{"version"},
+	}
+
+	for _, path := range commands {
+		name := strings.Join(path, " ")
+		t.Run(name, func(t *testing.T) {
+			stdout, stderr, exitCode := runAkt(t, home, path...)
+
+			if exitCode != 0 {
+				t.Fatalf("akt %s exited %d\nstdout: %s\nstderr: %s", name, exitCode, stdout, stderr)
+			}
+			if strings.Contains(stderr, "keyring passphrase") {
+				t.Fatalf("akt %s prompted for the keyring passphrase\nstderr: %s", name, stderr)
+			}
+		})
+	}
+}
+
+// initHomeWithLockedKeyring writes a config whose active context uses a
+// file-backed keyring and a default-account given by name.
+func initHomeWithLockedKeyring(t *testing.T, home string) {
+	t.Helper()
+
+	cfg := `---
+version: 1
+current-context: locked
+networks:
+  - name: mainnet
+    chain-id: akashnet-2
+    endpoints:
+      rpc:
+        - https://rpc.example.test:443
+    gas-prices: 0.025uakt
+    gas-adjustment: "1.5"
+keyrings:
+  - name: locked
+    backend: file
+contexts:
+  - name: locked
+    network: mainnet
+    keyring: locked
+    default-account: alice
+defaults:
+  output: pretty
+  broadcast-mode: sync
+`
+	if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed to write config.yaml: %v", err)
+	}
+}
+
+const minimalSDL = `---
+version: "2.0"
+services:
+  web:
+    image: nginx:1.27
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 512Mi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uact
+          amount: 10000
+deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1
+`
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestContextKeyringSetPersistsTheBackend covers the persistent remedy for a
+// host whose configured backend is unavailable: before this command the only
+// way to change key storage after first run was to hand-edit config.yaml.
+func TestContextKeyringSetPersistsTheBackend(t *testing.T) {
+	home := t.TempDir()
+	initHomeWithLockedKeyring(t, home)
+
+	stdout, stderr, exitCode := runAkt(t, home, "context", "keyring", "set", "locked", "test")
+	if exitCode != 0 {
+		t.Fatalf("keyring set exited %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "not migrated") {
+		t.Errorf("expected a warning that keys are not migrated, got:\n%s", stdout)
+	}
+
+	stdout, stderr, exitCode = runAkt(t, home, "context", "keyring", "list", "--output", "json")
+	if exitCode != 0 {
+		t.Fatalf("keyring list exited %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	}
+
+	var keyrings []struct {
+		Name      string `json:"name"`
+		Backend   string `json:"backend"`
+		Effective string `json:"effective"`
+		Available bool   `json:"available"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &keyrings); err != nil {
+		t.Fatalf("decode keyring list: %v\n%s", err, stdout)
+	}
+	if len(keyrings) != 1 {
+		t.Fatalf("expected 1 keyring, got %d: %s", len(keyrings), stdout)
+	}
+	if keyrings[0].Backend != "test" {
+		t.Errorf("backend = %q, want the persisted override", keyrings[0].Backend)
+	}
+	if keyrings[0].Effective != "test" || !keyrings[0].Available {
+		t.Errorf("effective = %q available = %v, want (test, true)", keyrings[0].Effective, keyrings[0].Available)
+	}
+
+	if _, _, exitCode := runAkt(t, home, "context", "keyring", "set", "locked", "nonsense"); exitCode == 0 {
+		t.Error("an unknown backend must be rejected")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	cosmossdk.io/x/feegrant v0.2.0
 	cosmossdk.io/x/tx v0.14.0
 	cosmossdk.io/x/upgrade v0.2.0
+	github.com/99designs/keyring v1.2.2
 	github.com/CosmWasm/wasmd v0.61.7
 	github.com/CosmWasm/wasmvm/v3 v3.0.2
 	github.com/boz/go-lifecycle v0.1.1
@@ -91,7 +92,6 @@ require (
 	cosmossdk.io/schema v1.1.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
-	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/DataDog/datadog-go v4.8.3+incompatible // indirect
 	github.com/DataDog/zstd v1.5.7 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 // indirect

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -16,6 +16,7 @@ import (
 
 	aktctx "pkg.akt.dev/akt/internal/context"
 	"pkg.akt.dev/akt/internal/glyphs"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
 )
 
 const (
@@ -328,25 +329,44 @@ func allSelected(checked []bool) bool {
 
 // keyringOption describes one selectable keyring backend.
 type keyringOption struct {
-	value string
-	label string
-	desc  string
+	value       string
+	label       string
+	desc        string
+	unavailable bool
 }
 
 // selectKeyringBackend presents a single-select menu for keyring backend.
 // Returns the selected backend string (e.g. "os", "file", "test").
+//
+// A backend this host cannot provide is shown but not offered: "os" is an
+// alias for the platform credential store, and choosing it on a machine
+// without one used to end with keys in an encrypted file while the context
+// went on reporting "os" (SPEC §1.5, §3.9.1).
 func selectKeyringBackend() string {
+	systemKeyring := aktkeyring.SystemKeyringAvailable()
+
+	osDesc := "System keyring (recommended)"
+	if !systemKeyring {
+		osDesc = "System keyring — unavailable on this host"
+	}
+
 	options := []keyringOption{
-		{value: "os", label: "os", desc: "System keyring (recommended)"},
+		{value: "os", label: "os", desc: osDesc, unavailable: !systemKeyring},
 		{value: "file", label: "file", desc: "File-based encrypted keyring"},
 		{value: "test", label: "test", desc: "Unencrypted test keyring (development only)"},
 	}
 
-	cursor := 0 // default to "os"
+	// Start on the first backend that actually works here.
+	cursor := 0
+	for cursor < len(options) && options[cursor].unavailable {
+		cursor++
+	}
 
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
-		return "os" // fallback
+		// Non-TTY fallback (SPEC §3.9.3): the default option, which is the
+		// first selectable one -- never a backend this host cannot provide.
+		return options[cursor].value
 	}
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
@@ -363,6 +383,14 @@ func selectKeyringBackend() string {
 			prefix := "  "
 			rowStart := ""
 			rowEnd := ""
+			if opt.unavailable {
+				// Listed so the absence is visible, never highlighted as a
+				// choice: the cursor cannot rest here.
+				b.WriteString(fmt.Sprintf("  %s%s %s  %-10s %s%s\r\n",
+					prefix, ansiDim+g.CheckboxOff, ansiReset+ansiDim, opt.label,
+					opt.desc, ansiReset))
+				continue
+			}
 			if i == cursor {
 				icon = ansiGreen + g.CheckboxOn + ansiReset
 				nameStyle = ansiReset
@@ -393,6 +421,18 @@ func selectKeyringBackend() string {
 
 	buf := make([]byte, 3)
 	totalItems := len(options)
+
+	// step advances the cursor past any backend this host cannot provide, so
+	// an unavailable row can never be selected.
+	step := func(delta int) {
+		for i := 0; i < totalItems; i++ {
+			cursor = (cursor + delta + totalItems) % totalItems
+			if !options[cursor].unavailable {
+				return
+			}
+		}
+	}
+
 	for {
 		nr, err := os.Stdin.Read(buf)
 		if err != nil {
@@ -407,11 +447,11 @@ func selectKeyringBackend() string {
 				return options[cursor].value
 			case 'j':
 				clearLines()
-				cursor = (cursor + 1) % totalItems
+				step(1)
 				render()
 			case 'k':
 				clearLines()
-				cursor = (cursor - 1 + totalItems) % totalItems
+				step(-1)
 				render()
 			case 'q', 3:
 				os.Stdout.WriteString("\r\n")
@@ -423,9 +463,9 @@ func selectKeyringBackend() string {
 			clearLines()
 			switch buf[2] {
 			case 65: // Up
-				cursor = (cursor - 1 + totalItems) % totalItems
+				step(-1)
 			case 66: // Down
-				cursor = (cursor + 1) % totalItems
+				step(1)
 			}
 			render()
 		}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -22,6 +22,17 @@ import (
 const (
 	netRepoAPI = "https://api.github.com/repos/akash-network/net/contents"
 	netRepoRaw = "https://raw.githubusercontent.com/akash-network/net/main"
+
+	// defaultKeyringName is the name of the single keyring the wizard
+	// creates. Every generated context references it.
+	defaultKeyringName = "default"
+
+	// pendingSuffix marks a path the wizard reports but does not create.
+	// SaveConfig creates only the config root, so the context, store, and
+	// action log directories do not exist when the summary prints; naming
+	// them without this would be a claim about the filesystem that is not
+	// yet true.
+	pendingSuffix = "  (created on first use)"
 )
 
 type githubEntry struct {
@@ -66,10 +77,20 @@ func Run(cfgRoot string) error {
 		return nil
 	}
 
-	fmt.Println("Welcome to akt! No configuration found.")
-	fmt.Println()
-	fmt.Println("Fetching available networks from github.com/akash-network/net ...")
-	fmt.Println()
+	// Every byte the wizard emits is a prompt, progress, or a report about
+	// them -- never data (SPEC §3.9.2, §10.1.1). stdout stays empty.
+	out := os.Stderr
+
+	fmt.Fprintln(out, "Welcome to akt! No configuration found.")
+	fmt.Fprintln(out)
+
+	// Say where this is going before asking anything. Someone who abandons
+	// the wizard, or who has AKT_HOME/XDG_CONFIG_HOME set by another tool,
+	// must not have to finish setup to learn which path won (SPEC §2.0a).
+	writeDestination(out, cfgRoot)
+
+	fmt.Fprintln(out, "Fetching available networks from github.com/akash-network/net ...")
+	fmt.Fprintln(out)
 
 	networks, err := fetchAllNetworks()
 	if err != nil {
@@ -83,28 +104,23 @@ func Run(cfgRoot string) error {
 	// Interactive multi-select.
 	selected := multiSelect(networks)
 	if len(selected) == 0 {
-		fmt.Println("No networks selected. Aborted.")
+		fmt.Fprintln(out, "No networks selected. Aborted.")
 		os.Exit(0)
 	}
 
 	// Keyring backend selection.
 	backend := selectKeyringBackend()
 
-	// Pick current-context: prefer mainnet, else first selected.
-	currentCtx := selected[0].Name
-	for _, n := range selected {
-		if n.Name == "mainnet" || strings.Contains(n.Name, "mainnet") {
-			currentCtx = n.Name
-			break
-		}
-	}
+	// Which context is active is asked, never assumed: the answer decides
+	// whether the user's first transaction spends real AKT (SPEC §2.0d).
+	currentCtx := selectActiveContext(selected)
 
 	cfg := &aktctx.Config{
 		Version:        aktctx.ConfigVersion,
 		CurrentContext: currentCtx,
 		Networks:       selected,
 		Keyrings: []aktctx.Keyring{
-			{Name: "default", Backend: backend},
+			{Name: defaultKeyringName, Backend: backend},
 		},
 		Defaults: aktctx.Defaults{
 			Output:        "pretty",
@@ -116,7 +132,7 @@ func Run(cfgRoot string) error {
 		cfg.Contexts = append(cfg.Contexts, aktctx.Context{
 			Name:    n.Name,
 			Network: aktctx.Network{Name: n.Name},
-			Keyring: aktctx.Keyring{Name: "default"},
+			Keyring: aktctx.Keyring{Name: defaultKeyringName},
 			Gas:     "auto",
 			ProviderDefaults: aktctx.ProviderDefaults{
 				AuthType: "jwt",
@@ -144,13 +160,110 @@ func Run(cfgRoot string) error {
 			return fmt.Errorf("store console api key: %w", err)
 		}
 
-		fmt.Printf("Console API key stored for context %q.\n", currentCtx)
+		fmt.Fprintf(out, "Console API key stored for context %q.\n", currentCtx)
 	}
 
-	fmt.Printf("\nConfig written to %s\n", aktctx.ConfigPath(cfgRoot))
-	fmt.Printf("Active context: %s\n\n", currentCtx)
+	writeSummary(out, cfgRoot, currentCtx, chainIDOf(selected, currentCtx), backend)
+
+	// Last, so it is still on screen when the user goes looking for the
+	// keys the legacy CLI left behind (SPEC §1.12, §2.0g). A failure to
+	// resolve the home directory only means no notice -- never an error.
+	if home, err := os.UserHomeDir(); err == nil {
+		writeLegacyNotice(out, detectLegacyHome(home), cfgRoot, backend)
+	}
 
 	return nil
+}
+
+// writeDestination announces the resolved config root and the overrides that
+// relocate it, before the first prompt (SPEC §2.0a).
+func writeDestination(w io.Writer, cfgRoot string) {
+	for _, line := range destinationLines(cfgRoot) {
+		fmt.Fprintln(w, line)
+	}
+
+	fmt.Fprintln(w)
+}
+
+// destinationLines is the announcement body. It is separated from rendering
+// so its content -- the part that has to name the right path and the right
+// overrides -- is assertable without a terminal.
+func destinationLines(cfgRoot string) []string {
+	return []string{
+		"Configuration directory:  " + cfgRoot,
+		"Config file to write:     " + aktctx.ConfigPath(cfgRoot),
+		"",
+		"Override the location with --home <dir> or AKT_HOME=<dir>",
+		"(resolution order: --home, AKT_HOME, $XDG_CONFIG_HOME/akt, ~/.config/akt).",
+		"Nothing is written until the prompts below are complete.",
+	}
+}
+
+// writeSummary reports what was written and where the rest of this context's
+// state will live (SPEC §2.0f).
+func writeSummary(w io.Writer, cfgRoot, currentCtx, chainID, backend string) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, ansiBold+"Setup complete"+ansiReset)
+	fmt.Fprintln(w)
+
+	for _, line := range summaryLines(cfgRoot, currentCtx, chainID, backend) {
+		fmt.Fprintln(w, line)
+	}
+
+	fmt.Fprintln(w)
+}
+
+// summaryLines renders the closing summary as plain text. Labels match
+// `akt context show` so the two describe the same thing the same way.
+//
+// No generated context gets a default-account, so the summary ends with the
+// step that makes the configuration usable rather than leaving the user to
+// discover the gap on their first command.
+func summaryLines(cfgRoot, currentCtx, chainID, backend string) []string {
+	active := currentCtx
+	if chainID != "" {
+		active = fmt.Sprintf("%s (%s)", currentCtx, chainID)
+	}
+
+	kv := func(label, value string) string {
+		return fmt.Sprintf("  %-16s %s", label, value)
+	}
+
+	return []string{
+		kv("Config", aktctx.ConfigPath(cfgRoot)),
+		kv("Active Context", active),
+		kv("Context Dir", aktctx.ContextDir(cfgRoot, currentCtx)+pendingSuffix),
+		kv("Store", aktctx.StoreDir(cfgRoot, currentCtx)+pendingSuffix),
+		kv("Action Log", aktctx.ActionLogPath(cfgRoot, currentCtx)+pendingSuffix),
+		kv("Keyring", keyringLocation(cfgRoot, backend)),
+		"",
+		"No account is configured yet. Next:",
+		"  akt context keys add <name>              create a new account",
+		"  akt context keys add <name> --recover    import an existing mnemonic",
+		"  akt context show                         review this context",
+	}
+}
+
+// keyringLocation describes where the chosen backend keeps its keys. The os
+// backend uses no directory at all, so naming one would send the user looking
+// in the wrong place.
+func keyringLocation(cfgRoot, backend string) string {
+	if backend == "os" {
+		return fmt.Sprintf("system keyring, service %q", aktctx.KeyringServiceName)
+	}
+
+	return aktctx.KeyringDir(cfgRoot, aktctx.Keyring{Name: defaultKeyringName}) + pendingSuffix
+}
+
+// chainIDOf returns the chain ID of the named network, or "" if it is absent.
+func chainIDOf(networks []aktctx.Network, name string) string {
+	for _, n := range networks {
+		if n.Name == name {
+			return n.ChainID
+		}
+	}
+
+	return ""
 }
 
 // ANSI escape helpers.
@@ -238,7 +351,7 @@ func multiSelect(networks []aktctx.Network) []aktctx.Network {
 		b.WriteString("\r\n")
 		b.WriteString(ansiDim + "  q quit" + ansiReset + "\r\n")
 
-		os.Stdout.WriteString(b.String())
+		os.Stderr.WriteString(b.String())
 	}
 
 	// Total rendered lines: header(1) + blank(1) + select-all(1) + blank(1) + networks(n) + blank(1) + hint(1) = n+6
@@ -246,7 +359,7 @@ func multiSelect(networks []aktctx.Network) []aktctx.Network {
 
 	clearLines := func() {
 		for i := 0; i < renderLines; i++ {
-			os.Stdout.WriteString("\033[A\033[2K")
+			os.Stderr.WriteString("\033[A\033[2K")
 		}
 	}
 
@@ -273,7 +386,7 @@ func multiSelect(networks []aktctx.Network) []aktctx.Network {
 				}
 				render()
 			case '\r', '\n':
-				os.Stdout.WriteString("\r\n")
+				os.Stderr.WriteString("\r\n")
 				_ = term.Restore(int(os.Stdin.Fd()), oldState)
 
 				var result []aktctx.Network
@@ -292,9 +405,9 @@ func multiSelect(networks []aktctx.Network) []aktctx.Network {
 				cursor = (cursor - 1 + totalItems) % totalItems
 				render()
 			case 'q', 3:
-				os.Stdout.WriteString("\r\n")
+				os.Stderr.WriteString("\r\n")
 				_ = term.Restore(int(os.Stdin.Fd()), oldState)
-				fmt.Println("Aborted.")
+				fmt.Fprintln(os.Stderr, "Aborted.")
 				os.Exit(0)
 			}
 		} else if nr == 3 && buf[0] == 27 && buf[1] == 91 {
@@ -327,21 +440,25 @@ func allSelected(checked []bool) bool {
 	return true
 }
 
-// keyringOption describes one selectable keyring backend.
-type keyringOption struct {
-	value       string
-	label       string
-	desc        string
+// selectOption describes one row of a single-select menu.
+type selectOption struct {
+	value string
+	label string
+	desc  string
+
+	// unavailable marks a row this host cannot provide. It is still listed,
+	// so the absence is visible rather than silent, but the cursor skips it
+	// and it can never be chosen.
 	unavailable bool
 }
 
 // selectKeyringBackend presents a single-select menu for keyring backend.
 // Returns the selected backend string (e.g. "os", "file", "test").
 //
-// A backend this host cannot provide is shown but not offered: "os" is an
-// alias for the platform credential store, and choosing it on a machine
-// without one used to end with keys in an encrypted file while the context
-// went on reporting "os" (SPEC §1.5, §3.9.1).
+// "os" is offered only where a platform credential store actually answers.
+// Offering it on a host without one is how a headless server ended up with
+// keys in an encrypted file while the context went on reporting "os"
+// (SPEC §1.5, §3.9.1).
 func selectKeyringBackend() string {
 	systemKeyring := aktkeyring.SystemKeyringAvailable()
 
@@ -350,70 +467,204 @@ func selectKeyringBackend() string {
 		osDesc = "System keyring — unavailable on this host"
 	}
 
-	options := []keyringOption{
+	return singleSelect("Select keyring backend", []selectOption{
 		{value: "os", label: "os", desc: osDesc, unavailable: !systemKeyring},
 		{value: "file", label: "file", desc: "File-based encrypted keyring"},
 		{value: "test", label: "test", desc: "Unencrypted test keyring (development only)"},
+	}, 0)
+}
+
+// selectActiveContext asks which of the newly created contexts becomes
+// current-context (SPEC §2.0d).
+//
+// The wizard used to prefer mainnet silently, so the shortest path through
+// setup produced a configuration whose next transaction spent real AKT. The
+// cursor now starts on a test network; mainnet is one keystroke away but is
+// never what pressing enter selects.
+func selectActiveContext(networks []aktctx.Network) string {
+	if len(networks) == 0 {
+		return ""
 	}
 
-	// Start on the first backend that actually works here.
-	cursor := 0
-	for cursor < len(options) && options[cursor].unavailable {
-		cursor++
+	preferred := pickInitialContext(networks)
+
+	options := make([]selectOption, 0, len(networks))
+	initial := 0
+
+	for i, n := range networks {
+		if n.Name == preferred {
+			initial = i
+		}
+
+		options = append(options, selectOption{
+			value: n.Name,
+			label: n.Name,
+			desc:  strings.TrimSpace(fmt.Sprintf("%-14s %s", n.ChainID, networkRisk(n.Name))),
+		})
+	}
+
+	return singleSelect("Select the active context", options, initial)
+}
+
+// pickInitialContext returns the network that the active-context prompt
+// starts on: the safest of the selected networks.
+//
+// Preference runs safest-first -- sandbox, then testnet, then any other
+// non-mainnet network -- and falls back to the first selection only when
+// every option is mainnet. Selection lives here, rather than inside the
+// raw-mode prompt, because this is the part that decides whether a mistake
+// costs money and so is the part that has to be testable.
+func pickInitialContext(networks []aktctx.Network) string {
+	if len(networks) == 0 {
+		return ""
+	}
+
+	for _, want := range []string{"sandbox", "testnet", "test"} {
+		for _, n := range networks {
+			if isMainnetName(n.Name) {
+				continue
+			}
+
+			if strings.Contains(strings.ToLower(n.Name), want) {
+				return n.Name
+			}
+		}
+	}
+
+	// No recognizable test network was selected. Anything that is not
+	// mainnet is still the safer place to start.
+	for _, n := range networks {
+		if !isMainnetName(n.Name) {
+			return n.Name
+		}
+	}
+
+	return networks[0].Name
+}
+
+// isMainnetName reports whether a network name identifies the live network.
+func isMainnetName(name string) bool {
+	return strings.Contains(strings.ToLower(name), "mainnet")
+}
+
+// networkRisk states, in plain language, what transacting on a network costs.
+// That distinction is the entire reason the prompt exists, so it belongs on
+// the row rather than in a footnote.
+func networkRisk(name string) string {
+	lower := strings.ToLower(name)
+
+	switch {
+	case isMainnetName(lower):
+		return "live network - transactions spend real AKT"
+	case strings.Contains(lower, "sandbox"),
+		strings.Contains(lower, "testnet"),
+		strings.Contains(lower, "test"):
+		return "test network - tokens have no value"
+	default:
+		return ""
+	}
+}
+
+// renderSingleSelect draws a single-select menu with cursor on row `cursor`.
+// It is a pure function so the frame the user actually sees can be asserted
+// without a terminal; singleSelect only decides when to draw it.
+func renderSingleSelect(title string, options []selectOption, cursor int) string {
+	g := glyphs.G()
+
+	labelWidth := 10
+	for _, opt := range options {
+		if n := len(opt.label); n > labelWidth {
+			labelWidth = n
+		}
+	}
+
+	var b strings.Builder
+
+	b.WriteString(ansiBold + title + ansiReset + ansiDim + "  ↑↓ move  enter confirm" + ansiReset + "\r\n")
+	b.WriteString("\r\n")
+
+	for i, opt := range options {
+		icon := ansiDim + g.CheckboxOff + ansiReset
+		nameStyle := ansiDim
+		prefix := "  "
+		rowStart := ""
+		rowEnd := ""
+
+		if opt.unavailable {
+			// Listed so the absence is visible, never highlighted as a
+			// choice: the cursor cannot rest here.
+			b.WriteString(fmt.Sprintf("  %s%s %s  %s%s %s%s\r\n",
+				prefix, ansiDim+g.CheckboxOff, ansiReset+ansiDim,
+				fmt.Sprintf("%-*s", labelWidth, opt.label),
+				ansiDim, opt.desc, ansiReset))
+
+			continue
+		}
+
+		if i == cursor {
+			icon = ansiGreen + g.CheckboxOn + ansiReset
+			nameStyle = ansiReset
+			prefix = ansiYellow + g.Cursor + " " + ansiReset
+			rowStart = ansiBgSel
+			rowEnd = ansiReset
+		}
+
+		b.WriteString(fmt.Sprintf("  %s%s %s  %s%s%s %s%s%s\r\n",
+			rowStart, prefix, icon,
+			nameStyle, fmt.Sprintf("%-*s", labelWidth, opt.label), ansiReset,
+			ansiDim, opt.desc+ansiReset, rowEnd))
+	}
+
+	b.WriteString("\r\n")
+
+	return b.String()
+}
+
+// singleSelect presents a single-select menu and returns the chosen value.
+// initial positions the cursor.
+//
+// When stdin cannot be put in raw mode (a pipe, a CI runner) the initial
+// option is returned rather than blocking on a read that will never be
+// answered -- so every caller's documented default is also its fallback.
+func singleSelect(title string, options []selectOption, initial int) string {
+	if len(options) == 0 {
+		return ""
+	}
+
+	if initial < 0 || initial >= len(options) {
+		initial = 0
+	}
+
+	cursor := initial
+
+	// Never start on a row this host cannot provide.
+	for i := 0; i < len(options) && options[cursor].unavailable; i++ {
+		cursor = (cursor + 1) % len(options)
+	}
+
+	if options[cursor].unavailable {
+		// Every option is unavailable; there is nothing to choose.
+		return ""
 	}
 
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
 		// Non-TTY fallback (SPEC §3.9.3): the default option, which is the
-		// first selectable one -- never a backend this host cannot provide.
+		// first selectable one — never a row this host cannot provide.
 		return options[cursor].value
 	}
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
 	render := func() {
-		g := glyphs.G()
-		var b strings.Builder
-
-		b.WriteString(ansiBold + "Select keyring backend" + ansiReset + ansiDim + "  ↑↓ move  enter confirm" + ansiReset + "\r\n")
-		b.WriteString("\r\n")
-
-		for i, opt := range options {
-			icon := ansiDim + g.CheckboxOff + ansiReset
-			nameStyle := ansiDim
-			prefix := "  "
-			rowStart := ""
-			rowEnd := ""
-			if opt.unavailable {
-				// Listed so the absence is visible, never highlighted as a
-				// choice: the cursor cannot rest here.
-				b.WriteString(fmt.Sprintf("  %s%s %s  %-10s %s%s\r\n",
-					prefix, ansiDim+g.CheckboxOff, ansiReset+ansiDim, opt.label,
-					opt.desc, ansiReset))
-				continue
-			}
-			if i == cursor {
-				icon = ansiGreen + g.CheckboxOn + ansiReset
-				nameStyle = ansiReset
-				prefix = ansiYellow + g.Cursor + " " + ansiReset
-				rowStart = ansiBgSel
-				rowEnd = ansiReset
-			}
-
-			b.WriteString(fmt.Sprintf("  %s%s %s  %s%-10s %s%s%s\r\n",
-				rowStart, prefix, icon, nameStyle, opt.label+ansiReset,
-				ansiDim, opt.desc+ansiReset, rowEnd))
-		}
-
-		b.WriteString("\r\n")
-		os.Stdout.WriteString(b.String())
+		os.Stderr.WriteString(renderSingleSelect(title, options, cursor))
 	}
 
-	// header(1) + blank(1) + options(3) + blank(1) = 6
+	// header(1) + blank(1) + options(n) + blank(1)
 	renderLines := len(options) + 3
 
 	clearLines := func() {
 		for i := 0; i < renderLines; i++ {
-			os.Stdout.WriteString("\033[A\033[2K")
+			os.Stderr.WriteString("\033[A\033[2K")
 		}
 	}
 
@@ -422,8 +673,8 @@ func selectKeyringBackend() string {
 	buf := make([]byte, 3)
 	totalItems := len(options)
 
-	// step advances the cursor past any backend this host cannot provide, so
-	// an unavailable row can never be selected.
+	// step advances the cursor past any row this host cannot provide, so an
+	// unavailable option can never be selected.
 	step := func(delta int) {
 		for i := 0; i < totalItems; i++ {
 			cursor = (cursor + delta + totalItems) % totalItems
@@ -442,7 +693,7 @@ func selectKeyringBackend() string {
 		if nr == 1 {
 			switch buf[0] {
 			case '\r', '\n':
-				os.Stdout.WriteString("\r\n")
+				os.Stderr.WriteString("\r\n")
 				_ = term.Restore(int(os.Stdin.Fd()), oldState)
 				return options[cursor].value
 			case 'j':
@@ -454,9 +705,9 @@ func selectKeyringBackend() string {
 				step(-1)
 				render()
 			case 'q', 3:
-				os.Stdout.WriteString("\r\n")
+				os.Stderr.WriteString("\r\n")
 				_ = term.Restore(int(os.Stdin.Fd()), oldState)
-				fmt.Println("Aborted.")
+				fmt.Fprintln(os.Stderr, "Aborted.")
 				os.Exit(0)
 			}
 		} else if nr == 3 && buf[0] == 27 && buf[1] == 91 {

--- a/internal/bootstrap/console.go
+++ b/internal/bootstrap/console.go
@@ -22,22 +22,25 @@ func consoleOnboarding(ctxName string) (key string, routeDeployments bool) {
 		return "", false
 	}
 
-	fmt.Println(ansiBold + "Akash Console (optional)" + ansiReset)
-	fmt.Println(ansiDim + "A Console API key enables managed deployments, USD billing, and the" + ansiReset)
-	fmt.Println(ansiDim + "akt console commands. Keys: console.akash.network > Settings > API Keys." + ansiReset)
-	fmt.Println()
+	// Prompt and progress rendering is stderr-only (SPEC §3.9.2, §10.1.1).
+	out := os.Stderr
+
+	fmt.Fprintln(out, ansiBold+"Akash Console (optional)"+ansiReset)
+	fmt.Fprintln(out, ansiDim+"A Console API key enables managed deployments, USD billing, and the"+ansiReset)
+	fmt.Fprintln(out, ansiDim+"akt console commands. Keys: console.akash.network > Settings > API Keys."+ansiReset)
+	fmt.Fprintln(out)
 
 	if !promptYesNo(fmt.Sprintf("Configure a Console API key for context %q?", ctxName), false) {
-		fmt.Println(ansiDim + "Skipped. You can add one later with: akt console login" + ansiReset)
-		fmt.Println()
+		fmt.Fprintln(out, ansiDim+"Skipped. You can add one later with: akt console login"+ansiReset)
+		fmt.Fprintln(out)
 
 		return "", false
 	}
 
 	key = promptSecret("Console API key: ")
 	if key == "" {
-		fmt.Println(ansiYellow + "No key entered; skipping Console setup." + ansiReset)
-		fmt.Println()
+		fmt.Fprintln(out, ansiYellow+"No key entered; skipping Console setup."+ansiReset)
+		fmt.Fprintln(out)
 
 		return "", false
 	}
@@ -45,7 +48,7 @@ func consoleOnboarding(ctxName string) (key string, routeDeployments bool) {
 	validateConsoleKey(key)
 
 	routeDeployments = promptYesNo("Route deployments through Console for this context (managed wallet, USD)?", false)
-	fmt.Println()
+	fmt.Fprintln(out)
 
 	return key, routeDeployments
 }
@@ -58,11 +61,11 @@ func validateConsoleKey(key string) {
 
 	user, err := console.New("", key).GetUser(ctx)
 	if err != nil {
-		fmt.Printf(ansiYellow+"Could not validate the key (%v); storing anyway. Verify later with: akt console whoami"+ansiReset+"\n", err)
+		fmt.Fprintf(os.Stderr, ansiYellow+"Could not validate the key (%v); storing anyway. Verify later with: akt console whoami"+ansiReset+"\n", err)
 		return
 	}
 
-	fmt.Printf(ansiGreen+"Authenticated as %s"+ansiReset+"\n", user.Username)
+	fmt.Fprintf(os.Stderr, ansiGreen+"Authenticated as %s"+ansiReset+"\n", user.Username)
 }
 
 // promptYesNo asks a yes/no question on stdin. Empty input selects def.
@@ -72,7 +75,7 @@ func promptYesNo(question string, def bool) bool {
 		suffix = " [Y/n]: "
 	}
 
-	fmt.Print(question + suffix)
+	fmt.Fprint(os.Stderr, question+suffix)
 
 	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
@@ -97,10 +100,11 @@ func parseYesNo(input string, def bool) bool {
 
 // promptSecret reads a line without echoing it to the terminal.
 func promptSecret(prompt string) string {
-	fmt.Print(prompt)
+	fmt.Fprint(os.Stderr, prompt)
 
 	data, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println()
+
+	fmt.Fprintln(os.Stderr)
 
 	if err != nil {
 		return ""

--- a/internal/bootstrap/firstrun_test.go
+++ b/internal/bootstrap/firstrun_test.go
@@ -1,0 +1,501 @@
+package bootstrap
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	aktctx "pkg.akt.dev/akt/internal/context"
+	"pkg.akt.dev/akt/internal/glyphs"
+)
+
+func networks(names ...string) []aktctx.Network {
+	out := make([]aktctx.Network, 0, len(names))
+	for _, n := range names {
+		out = append(out, aktctx.Network{Name: n, ChainID: n + "-1"})
+	}
+
+	return out
+}
+
+// TestPickInitialContextPrefersATestNetwork is the money test: the wizard's
+// active-context cursor decides whether "press enter three times" produces a
+// configuration whose next transaction spends real AKT. Mainnet must never be
+// the resting position while any safer network was selected.
+func TestPickInitialContextPrefersATestNetwork(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []aktctx.Network
+		want string
+	}{
+		{"sandbox wins over everything", networks("mainnet", "testnet", "sandbox"), "sandbox"},
+		{"sandbox wins regardless of order", networks("sandbox", "mainnet"), "sandbox"},
+		{"testnet when no sandbox", networks("mainnet", "testnet"), "testnet"},
+		{"suffixed names still match", networks("mainnet", "testnet-02", "sandbox-2"), "sandbox-2"},
+		{"any non-mainnet beats mainnet", networks("mainnet", "edgenet"), "edgenet"},
+		{"mainnet only", networks("mainnet"), "mainnet"},
+		{"single test network", networks("sandbox"), "sandbox"},
+		{"empty", nil, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := pickInitialContext(c.in); got != c.want {
+				t.Errorf("pickInitialContext(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestPickInitialContextNeverReturnsMainnetWhenAnythingElseExists states the
+// property directly, so a future rewrite of the preference list cannot quietly
+// reintroduce the old mainnet-first behavior.
+func TestPickInitialContextNeverReturnsMainnetWhenAnythingElseExists(t *testing.T) {
+	sets := [][]aktctx.Network{
+		networks("mainnet", "sandbox"),
+		networks("mainnet", "testnet"),
+		networks("mainnet", "somethingelse"),
+		networks("akashnet-mainnet", "sandbox"),
+	}
+
+	for _, set := range sets {
+		if got := pickInitialContext(set); isMainnetName(got) {
+			t.Errorf("pickInitialContext(%v) = %q, a mainnet, with a safer option available", set, got)
+		}
+	}
+}
+
+// TestSelectActiveContextFallsBackToTheSafeChoice covers the arm taken when
+// raw mode is unavailable (a pipe, a CI runner): the prompt cannot render, so
+// the value returned must still be the one the cursor would have started on.
+func TestSelectActiveContextFallsBackToTheSafeChoice(t *testing.T) {
+	restoreNonTTYStdin(t)
+
+	if got := selectActiveContext(networks("mainnet", "testnet", "sandbox")); got != "sandbox" {
+		t.Errorf("selectActiveContext fallback = %q, want sandbox", got)
+	}
+
+	if got := selectActiveContext(nil); got != "" {
+		t.Errorf("selectActiveContext(nil) = %q, want empty", got)
+	}
+}
+
+// restoreNonTTYStdin points os.Stdin at a pipe so term.MakeRaw fails
+// deterministically, whatever the test runner attached.
+func restoreNonTTYStdin(t *testing.T) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	prev := os.Stdin
+	os.Stdin = r
+
+	t.Cleanup(func() {
+		os.Stdin = prev
+		_ = w.Close()
+		_ = r.Close()
+	})
+}
+
+// TestActiveContextPromptRestsOnTheSafeRow asserts the frame the user
+// actually sees: the cursor glyph and the checked box sit on the test
+// network, and the mainnet row says out loud what selecting it costs.
+func TestActiveContextPromptRestsOnTheSafeRow(t *testing.T) {
+	nets := []aktctx.Network{
+		{Name: "mainnet", ChainID: "akashnet-2"},
+		{Name: "testnet", ChainID: "testnet-02"},
+		{Name: "sandbox", ChainID: "sandbox-2"},
+	}
+
+	options := make([]selectOption, 0, len(nets))
+	initial := 0
+
+	preferred := pickInitialContext(nets)
+	for i, n := range nets {
+		if n.Name == preferred {
+			initial = i
+		}
+
+		options = append(options, selectOption{value: n.Name, label: n.Name, desc: networkRisk(n.Name)})
+	}
+
+	frame := renderSingleSelect("Select the active context", options, initial)
+
+	rows := strings.Split(frame, "\r\n")
+
+	var mainnetRow, sandboxRow string
+
+	for _, row := range rows {
+		switch {
+		case strings.Contains(row, "mainnet"):
+			mainnetRow = row
+		case strings.Contains(row, "sandbox"):
+			sandboxRow = row
+		}
+	}
+
+	if !strings.Contains(sandboxRow, glyphs.G().Cursor) {
+		t.Errorf("cursor is not on the sandbox row:\n%q", sandboxRow)
+	}
+
+	if strings.Contains(mainnetRow, glyphs.G().Cursor) {
+		t.Errorf("cursor rests on the mainnet row:\n%q", mainnetRow)
+	}
+
+	if !strings.Contains(mainnetRow, "spend real AKT") {
+		t.Errorf("mainnet row does not state its cost:\n%q", mainnetRow)
+	}
+}
+
+func TestNetworkRisk(t *testing.T) {
+	cases := map[string]string{
+		"mainnet":    "live network - transactions spend real AKT",
+		"sandbox-2":  "test network - tokens have no value",
+		"testnet-02": "test network - tokens have no value",
+		"unknown":    "",
+	}
+
+	for name, want := range cases {
+		if got := networkRisk(name); got != want {
+			t.Errorf("networkRisk(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestDestinationLinesNameTheRootAndItsOverrides covers the announcement that
+// runs before the first prompt. A user who Ctrl-Cs mid-wizard, or who has
+// AKT_HOME set by another tool, learns the destination only from these lines.
+func TestDestinationLinesNameTheRootAndItsOverrides(t *testing.T) {
+	root := "/tmp/example/akt-home"
+	body := strings.Join(destinationLines(root), "\n")
+
+	for _, want := range []string{
+		root,
+		aktctx.ConfigPath(root),
+		"--home",
+		"AKT_HOME",
+		"XDG_CONFIG_HOME",
+		"Nothing is written",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("destination announcement omits %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestSummaryLinesNameEveryLocation covers the closing summary. Before this,
+// the only path the wizard ever printed was config.yaml, so the store, action
+// log, and keyring were left for the user to guess at.
+func TestSummaryLinesNameEveryLocation(t *testing.T) {
+	root := "/tmp/example/akt-home"
+	body := strings.Join(summaryLines(root, "sandbox", "sandbox-2", "file"), "\n")
+
+	for _, want := range []string{
+		aktctx.ConfigPath(root),
+		"sandbox (sandbox-2)",
+		aktctx.ContextDir(root, "sandbox"),
+		aktctx.StoreDir(root, "sandbox"),
+		aktctx.ActionLogPath(root, "sandbox"),
+		aktctx.KeyringDir(root, aktctx.Keyring{Name: defaultKeyringName}),
+		// No context is given a default-account, so the summary has to say
+		// what to do about it.
+		"akt context keys add <name>",
+		"--recover",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("summary omits %q:\n%s", want, body)
+		}
+	}
+
+	// SaveConfig creates only the config root. Presenting the rest as
+	// existing directories would send the user looking for them.
+	for _, dir := range []string{
+		aktctx.ContextDir(root, "sandbox"),
+		aktctx.StoreDir(root, "sandbox"),
+	} {
+		if !strings.Contains(body, dir+pendingSuffix) {
+			t.Errorf("summary presents %q as already created:\n%s", dir, body)
+		}
+	}
+}
+
+// TestKeyringLocationMatchesTheBackend covers the one summary line whose
+// answer is not a path: the os backend stores nothing on disk, so naming a
+// directory for it would be wrong.
+func TestKeyringLocationMatchesTheBackend(t *testing.T) {
+	root := "/tmp/example/akt-home"
+
+	osLine := keyringLocation(root, "os")
+	if !strings.Contains(osLine, aktctx.KeyringServiceName) {
+		t.Errorf("os keyring location = %q, want the service name", osLine)
+	}
+
+	if strings.Contains(osLine, root) {
+		t.Errorf("os keyring location = %q, must not name a directory", osLine)
+	}
+
+	for _, backend := range []string{"file", "test"} {
+		line := keyringLocation(root, backend)
+		if !strings.Contains(line, aktctx.KeyringDir(root, aktctx.Keyring{Name: defaultKeyringName})) {
+			t.Errorf("%s keyring location = %q, want the keyring directory", backend, line)
+		}
+	}
+}
+
+func TestChainIDOf(t *testing.T) {
+	nets := networks("mainnet", "sandbox")
+
+	if got := chainIDOf(nets, "sandbox"); got != "sandbox-1" {
+		t.Errorf("chainIDOf = %q, want sandbox-1", got)
+	}
+
+	if got := chainIDOf(nets, "absent"); got != "" {
+		t.Errorf("chainIDOf(absent) = %q, want empty", got)
+	}
+}
+
+// --- Legacy home detection ---
+
+// writeLegacyFixture builds a fake home directory and returns it.
+func writeLegacyFixture(t *testing.T, certs []string, keyringFile, keyringTest bool) string {
+	t.Helper()
+
+	home := t.TempDir()
+	legacy := filepath.Join(home, legacyDirName)
+
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatalf("mkdir legacy home: %v", err)
+	}
+
+	for _, name := range certs {
+		if err := os.WriteFile(filepath.Join(legacy, name), []byte("-----BEGIN CERTIFICATE-----\n"), 0o600); err != nil {
+			t.Fatalf("write cert fixture: %v", err)
+		}
+	}
+
+	if keyringFile {
+		if err := os.MkdirAll(filepath.Join(legacy, legacyKeyringFileDir), 0o700); err != nil {
+			t.Fatalf("mkdir keyring-file: %v", err)
+		}
+	}
+
+	if keyringTest {
+		if err := os.MkdirAll(filepath.Join(legacy, legacyKeyringTestDir), 0o700); err != nil {
+			t.Fatalf("mkdir keyring-test: %v", err)
+		}
+	}
+
+	return home
+}
+
+func TestDetectLegacyHome(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		l := detectLegacyHome(t.TempDir())
+		if l.Exists || l.Found() {
+			t.Errorf("empty home reported a legacy install: %+v", l)
+		}
+	})
+
+	t.Run("empty home directory is not a finding", func(t *testing.T) {
+		// A bare ~/.akash with nothing recoverable in it must stay silent:
+		// the notice is entirely about keys and certificates.
+		l := detectLegacyHome(writeLegacyFixture(t, nil, false, false))
+		if !l.Exists {
+			t.Fatal("existing ~/.akash must be detected")
+		}
+
+		if l.Found() {
+			t.Errorf("empty ~/.akash must not produce a notice: %+v", l)
+		}
+	})
+
+	t.Run("certificates only", func(t *testing.T) {
+		l := detectLegacyHome(writeLegacyFixture(t, []string{"akash1abc.pem", "akash1def.pem"}, false, false))
+		if !l.Found() {
+			t.Fatalf("certs must be a finding: %+v", l)
+		}
+
+		sort.Strings(l.Certs)
+		if len(l.Certs) != 2 || l.Certs[0] != "akash1abc.pem" || l.Certs[1] != "akash1def.pem" {
+			t.Errorf("certs = %v", l.Certs)
+		}
+
+		if l.KeyringFile || l.KeyringTest {
+			t.Errorf("no keyring directories exist, got %+v", l)
+		}
+	})
+
+	t.Run("keyrings only", func(t *testing.T) {
+		l := detectLegacyHome(writeLegacyFixture(t, nil, true, true))
+		if !l.Found() || !l.KeyringFile || !l.KeyringTest {
+			t.Errorf("keyring directories must be a finding: %+v", l)
+		}
+
+		if len(l.Certs) != 0 {
+			t.Errorf("certs = %v, want none", l.Certs)
+		}
+	})
+
+	t.Run("no home directory", func(t *testing.T) {
+		if l := detectLegacyHome(""); l.Exists || l.Found() {
+			t.Errorf("empty home dir must yield nothing, got %+v", l)
+		}
+	})
+
+	t.Run("a file named .akash is not a home", func(t *testing.T) {
+		home := t.TempDir()
+		if err := os.WriteFile(filepath.Join(home, legacyDirName), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		if l := detectLegacyHome(home); l.Exists {
+			t.Errorf("a regular file must not count as a legacy home: %+v", l)
+		}
+	})
+}
+
+// TestDetectLegacyHomeNeverMutates is the promise the notice itself makes.
+// Detection is os.Stat and a filename glob; anything more — reading a PEM,
+// opening a keyring, "helpfully" moving a file — would make the printed
+// assurance a lie.
+func TestDetectLegacyHomeNeverMutates(t *testing.T) {
+	home := writeLegacyFixture(t, []string{"akash1abc.pem"}, true, true)
+
+	before := snapshotTree(t, home)
+
+	l := detectLegacyHome(home)
+	if !l.Found() {
+		t.Fatal("fixture must be detected")
+	}
+
+	// Rendering the notice must be read-only too.
+	if lines := legacyNoticeLines(l, "/tmp/akt-home", "os"); len(lines) == 0 {
+		t.Fatal("a found legacy home must produce a notice")
+	}
+
+	after := snapshotTree(t, home)
+
+	if before != after {
+		t.Errorf("legacy home was modified.\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+// snapshotTree renders a stable description of every entry under root: path,
+// mode, size, modification time, and a content hash for regular files.
+func snapshotTree(t *testing.T, root string) string {
+	t.Helper()
+
+	var b strings.Builder
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		sum := ""
+		if info.Mode().IsRegular() {
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+
+			h := sha256.Sum256(data)
+			sum = hex.EncodeToString(h[:])
+		}
+
+		fmt.Fprintf(&b, "%s mode=%s size=%d mtime=%d sha=%s\n",
+			rel, info.Mode(), info.Size(), info.ModTime().UnixNano(), sum)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+
+	return b.String()
+}
+
+// TestLegacyNoticeSaysWhatDoesNotCarryOverAndHow covers the notice body. Each
+// assertion is a fact the user cannot get anywhere else: that akt does not read
+// the legacy home, that the account is recoverable, that the published
+// certificate survives, and which remedy costs a transaction.
+func TestLegacyNoticeSaysWhatDoesNotCarryOverAndHow(t *testing.T) {
+	home := writeLegacyFixture(t, []string{"akash1abc.pem"}, true, false)
+	l := detectLegacyHome(home)
+
+	cfgRoot := "/tmp/example/akt-home"
+	body := strings.Join(legacyNoticeLines(l, cfgRoot, "os"), "\n")
+
+	for _, want := range []string{
+		l.Path,
+		"Nothing in it is carried over automatically",
+		"there is no import",
+		"never reads, modifies, or deletes",
+		filepath.Join(l.Path, "akash1abc.pem"),
+		filepath.Join(l.Path, legacyKeyringFileDir),
+		// The mismatch, named on both sides.
+		`"akash"`,
+		`"akt"`,
+		aktctx.KeyringDir(cfgRoot, aktctx.Keyring{Name: defaultKeyringName}),
+		cfgRoot,
+		// Recovery, verbatim and runnable.
+		"akt context keys add <name> --recover",
+		"akt query cert list <address>",
+		"akt tx cert generate client",
+		"akt tx cert publish client",
+		// The free path and the paid path, distinguished.
+		"no re-publish, no transaction",
+		"broadcasts a transaction and pays a fee",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("legacy notice omits %q:\n%s", want, body)
+		}
+	}
+
+	// A keyring directory that does not exist must not be listed.
+	if strings.Contains(body, filepath.Join(l.Path, legacyKeyringTestDir)) {
+		t.Errorf("notice lists a keyring-test directory that does not exist:\n%s", body)
+	}
+}
+
+// TestLegacyNoticeSilentWithoutAFinding keeps the wizard quiet for the common
+// case: no legacy install, or a stray empty directory.
+func TestLegacyNoticeSilentWithoutAFinding(t *testing.T) {
+	cases := map[string]legacyHome{
+		"absent":     detectLegacyHome(t.TempDir()),
+		"empty home": detectLegacyHome(writeLegacyFixture(t, nil, false, false)),
+	}
+
+	for name, l := range cases {
+		if lines := legacyNoticeLines(l, "/tmp/akt-home", "os"); len(lines) != 0 {
+			t.Errorf("%s produced a notice:\n%s", name, strings.Join(lines, "\n"))
+		}
+
+		var b strings.Builder
+
+		writeLegacyNotice(&b, l, "/tmp/akt-home", "os")
+
+		if b.Len() != 0 {
+			t.Errorf("%s wrote output: %q", name, b.String())
+		}
+	}
+}

--- a/internal/bootstrap/legacy.go
+++ b/internal/bootstrap/legacy.go
@@ -1,0 +1,184 @@
+package bootstrap
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	aktctx "pkg.akt.dev/akt/internal/context"
+)
+
+const (
+	// legacyDirName is the home directory of the legacy akash and
+	// provider-services CLIs, relative to the user's home directory.
+	legacyDirName = ".akash"
+
+	// legacyKeyringFileDir and legacyKeyringTestDir are the legacy CLI's
+	// file- and test-backend keyring directories inside that home.
+	legacyKeyringFileDir = "keyring-file"
+	legacyKeyringTestDir = "keyring-test"
+)
+
+// legacyHome describes what the first-run wizard found in the legacy akash
+// CLI home (SPEC §1.12).
+//
+// Detection is read-only and bounded to os.Stat and a filename glob. akt
+// never reads, moves, modifies, or deletes anything under the legacy home,
+// and never opens a legacy keyring — the notice built from this struct says
+// so, so the code must not contradict it.
+type legacyHome struct {
+	// Path is the directory that was probed, set whether or not it exists.
+	Path string
+
+	// Exists reports whether Path is a directory.
+	Exists bool
+
+	// Certs holds the base names of the *.pem files directly inside Path.
+	// Only names are collected; no PEM file is ever opened.
+	Certs []string
+
+	// KeyringFile and KeyringTest report the presence of the legacy
+	// file- and test-backend keyring directories.
+	KeyringFile bool
+	KeyringTest bool
+}
+
+// Found reports whether the legacy home holds anything worth telling the user
+// about. A bare or unrelated ~/.akash does not qualify: the notice is entirely
+// about keys and certificates, so printing it with nothing to carry over would
+// be noise.
+func (l legacyHome) Found() bool {
+	return l.Exists && (len(l.Certs) > 0 || l.KeyringFile || l.KeyringTest)
+}
+
+// detectLegacyHome probes homeDir for a legacy akash CLI home. An empty
+// homeDir, or one that cannot be probed, yields a zero result rather than an
+// error: a first run must never fail because of what is or is not in an
+// unrelated directory.
+func detectLegacyHome(homeDir string) legacyHome {
+	l := legacyHome{}
+
+	if homeDir == "" {
+		return l
+	}
+
+	l.Path = filepath.Join(homeDir, legacyDirName)
+
+	if !isDir(l.Path) {
+		return l
+	}
+
+	l.Exists = true
+
+	// Filenames only. Reading a PEM would be unnecessary — the notice tells
+	// the user where to copy it, not what is in it — and would break the
+	// promise the notice itself makes.
+	if matches, err := filepath.Glob(filepath.Join(l.Path, "*.pem")); err == nil {
+		for _, m := range matches {
+			l.Certs = append(l.Certs, filepath.Base(m))
+		}
+	}
+
+	l.KeyringFile = isDir(filepath.Join(l.Path, legacyKeyringFileDir))
+	l.KeyringTest = isDir(filepath.Join(l.Path, legacyKeyringTestDir))
+
+	return l
+}
+
+// isDir reports whether path exists and is a directory.
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+
+	return err == nil && info.IsDir()
+}
+
+// legacyNoticeLines renders the legacy-home notice (SPEC §1.12) as plain
+// text. It returns nil when there is nothing to report.
+//
+// The notice is deliberately not an importer. It states what was found, why
+// none of it is visible to akt, and the exact commands that reproduce the
+// account and the certificate — including which of them costs a transaction.
+func legacyNoticeLines(l legacyHome, cfgRoot, backend string) []string {
+	if !l.Found() {
+		return nil
+	}
+
+	kr := aktctx.Keyring{Name: defaultKeyringName}
+
+	lines := []string{
+		"An existing Akash CLI home was found at " + l.Path,
+		"Nothing in it is carried over automatically, and there is no import",
+		"command. akt never reads, modifies, or deletes anything inside it.",
+		"",
+		"Found:",
+	}
+
+	for _, name := range l.Certs {
+		lines = append(lines, "  "+filepath.Join(l.Path, name)+"  (client certificate)")
+	}
+
+	if l.KeyringFile {
+		lines = append(lines, "  "+filepath.Join(l.Path, legacyKeyringFileDir)+"  (file keyring)")
+	}
+
+	if l.KeyringTest {
+		lines = append(lines, "  "+filepath.Join(l.Path, legacyKeyringTestDir)+"  (test keyring)")
+	}
+
+	lines = append(lines,
+		"",
+		"Why none of it is visible to akt:",
+		"  os keyring    the legacy CLI stores entries under the system keyring",
+		fmt.Sprintf("                service %q; akt uses %q",
+			aktctx.LegacyKeyringServiceName, aktctx.KeyringServiceName),
+		"  file keyring  akt keeps keyrings in "+aktctx.KeyringDir(cfgRoot, kr),
+		"  certificates  akt looks for <address>.pem in "+cfgRoot,
+		"",
+		"Recovering your account (same address, same on-chain identity):",
+		"  akt context keys add <name> --recover",
+		"",
+		"Your published certificate is still valid. It is on-chain state, not a",
+		"local file. Confirm it with:",
+		"  akt query cert list <address>",
+		"",
+		"Only the local half is in the wrong place. Once the key is in akt's",
+		"keyring, copy it across:",
+		"  cp "+filepath.Join(l.Path, "<address>.pem")+" "+filepath.Join(cfgRoot, "<address>.pem"),
+		"",
+		"The PEM password is derived from a keyring signature over the address, so",
+		"the copy works as-is: no re-publish, no transaction. Regenerating instead",
+		"broadcasts a transaction and pays a fee:",
+		"  akt tx cert generate client",
+		"  akt tx cert publish client",
+	)
+
+	if backend == "os" {
+		lines = append(lines,
+			"",
+			"You chose the os keyring backend, so a recovered key is written to the",
+			fmt.Sprintf("system keyring under service %q. The legacy %q entries are left",
+				aktctx.KeyringServiceName, aktctx.LegacyKeyringServiceName),
+			"untouched.")
+	}
+
+	return lines
+}
+
+// writeLegacyNotice prints the legacy-home notice to w. It writes nothing
+// when there is nothing to report.
+func writeLegacyNotice(w io.Writer, l legacyHome, cfgRoot, backend string) {
+	lines := legacyNoticeLines(l, cfgRoot, backend)
+	if len(lines) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w, ansiBold+"Existing Akash CLI configuration"+ansiReset)
+	fmt.Fprintln(w)
+
+	for _, line := range lines {
+		fmt.Fprintln(w, line)
+	}
+
+	fmt.Fprintln(w)
+}

--- a/internal/bootstrap/networks_test.go
+++ b/internal/bootstrap/networks_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	aktctx "pkg.akt.dev/akt/internal/context"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
 )
 
 // stubTransport answers requests from a URL-suffix -> response table without
@@ -288,7 +289,13 @@ func TestAllSelected(t *testing.T) {
 // failure arms of the two wizard selectors. When stdin is not a terminal (a
 // pipe, a CI runner) raw mode cannot be entered, and the selectors must return
 // a safe default instead of blocking on a read that will never be answered:
-// every network selected, and the recommended "os" keyring backend.
+// every network selected, and the first keyring backend this host can actually
+// provide.
+//
+// The keyring default is host-dependent on purpose. "os" is an alias for the
+// platform credential store, and a headless machine has none — writing "os"
+// into the config there produced a context that claimed the system keyring
+// while the SDK quietly used an encrypted file (SPEC §1.5, §3.9.3).
 func TestInteractiveSelectorsFallBackWithoutATerminal(t *testing.T) {
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -313,7 +320,39 @@ func TestInteractiveSelectorsFallBackWithoutATerminal(t *testing.T) {
 		t.Errorf("multiSelect fallback = %+v, want every network", got)
 	}
 
-	if backend := selectKeyringBackend(); backend != "os" {
-		t.Errorf("keyring backend fallback = %q, want os", backend)
+	want := "file"
+	if aktkeyring.SystemKeyringAvailable() {
+		want = "os"
+	}
+
+	if backend := selectKeyringBackend(); backend != want {
+		t.Errorf("keyring backend fallback = %q, want %q", backend, want)
+	}
+}
+
+// TestKeyringBackendFallbackIsAlwaysUsable is the property the previous test
+// asserts per host, stated directly: whatever the wizard picks without a
+// terminal, opening it must succeed. A backend that resolves to nothing is
+// exactly the silent substitution this guards against.
+func TestKeyringBackendFallbackIsAlwaysUsable(t *testing.T) {
+	root := t.TempDir()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer func() {
+		_ = w.Close()
+		_ = r.Close()
+	}()
+
+	prev := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = prev }()
+
+	backend := selectKeyringBackend()
+
+	if _, ok := aktkeyring.EffectiveBackend(root, aktctx.Keyring{Name: "default", Backend: backend}); !ok {
+		t.Errorf("wizard selected backend %q, which this host cannot provide", backend)
 	}
 }

--- a/internal/cli/chain/cctx.go
+++ b/internal/cli/chain/cctx.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -82,6 +83,51 @@ func GetClientQueryContext(cmd *cobra.Command) (sdkclient.Context, error) {
 func GetClientTxContext(cmd *cobra.Command) (sdkclient.Context, error) {
 	ctx := GetClientContextFromCmd(cmd)
 	return ReadTxCommandFlags(ctx, cmd.Flags())
+}
+
+// resolveDefaultAccountAddress resolves the configured query account only at
+// the point where an omitted owner filter needs it. Query initialization keeps
+// named accounts unresolved so unrelated reads never unlock the keyring.
+func resolveDefaultAccountAddress(cctx sdkclient.Context) (string, error) {
+	if addr := cctx.GetFromAddress(); !addr.Empty() {
+		return addr.String(), nil
+	}
+
+	from := strings.TrimSpace(cctx.From)
+	if from == "" {
+		return "", nil
+	}
+
+	if addr, err := sdk.AccAddressFromBech32(from); err == nil {
+		return addr.String(), nil
+	}
+
+	if cctx.Keyring == nil {
+		return "", fmt.Errorf("resolve default account %q: keyring is unavailable", from)
+	}
+
+	addr, _, _, err := sdkclient.GetFromFields(cctx, cctx.Keyring, from)
+	if err != nil {
+		return "", fmt.Errorf("resolve default account %q: %w", from, err)
+	}
+
+	return addr.String(), nil
+}
+
+// defaultOwnerForQueryArg resolves the default account only for numeric
+// shorthand such as 12345[/1]. Explicit addresses, state keywords, and invalid
+// input can all be parsed without touching the keyring.
+func defaultOwnerForQueryArg(cctx sdkclient.Context, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", nil
+	}
+
+	first := strings.SplitN(args[0], "/", 2)[0]
+	if _, err := strconv.ParseUint(first, 10, 64); err == nil {
+		return resolveDefaultAccountAddress(cctx)
+	}
+
+	return "", nil
 }
 
 // ReadQueryCommandFlags returns an updated Context with fields set based on flags

--- a/internal/cli/chain/cctx.go
+++ b/internal/cli/chain/cctx.go
@@ -233,17 +233,15 @@ func ReadPersistentCommandFlags(cctx sdkclient.Context, flagSet *pflag.FlagSet) 
 		cctx = cctx.WithChainID(chainID)
 	}
 
-	if cctx.Keyring == nil || flagSet.Changed(cflags.FlagKeyringBackend) {
-		keyringBackend, _ := flagSet.GetString(cflags.FlagKeyringBackend)
-		if keyringBackend != "" {
-			kr, err := sdkclient.NewKeyringFromBackend(cctx, keyringBackend)
-			if err != nil {
-				return cctx, err
-			}
-
-			cctx = cctx.WithKeyring(kr)
-		}
-	}
+	// --keyring-backend is deliberately NOT turned into a keyring here.
+	//
+	// It is an akt global flag (SPEC §3.1), applied to the keyring
+	// configuration the root command hands to internal/keyring before any
+	// leaf runs -- which is also where an "os" backend is checked against the
+	// platform's credential stores. Rebuilding a keyring from the raw flag
+	// value would bypass that check and, because this runs from the root's
+	// own pre-run on every command, would open a key store for commands that
+	// declare no local identity at all (SPEC §1.7).
 
 	nodeChanged := flagSet.Lookup(cflags.FlagNode) != nil && flagSet.Changed(cflags.FlagNode)
 	if cctx.Client == nil || nodeChanged {

--- a/internal/cli/chain/cert_query.go
+++ b/internal/cli/chain/cert_query.go
@@ -48,7 +48,6 @@ akt query cert list revoked`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			cl := MustLightClientFromContext(ctx)
-			defaultOwner := cl.ClientContext().GetFromAddress().String()
 
 			pageReq, err := ReadPageRequest(cmd.Flags())
 			if err != nil {
@@ -84,6 +83,10 @@ akt query cert list revoked`,
 			}
 
 			if params.Filter.Owner == "" {
+				defaultOwner, err := resolveDefaultAccountAddress(cl.ClientContext())
+				if err != nil {
+					return err
+				}
 				if defaultOwner == "" {
 					return requireOwnerScope("certificate filter")
 				}

--- a/internal/cli/chain/default_account_test.go
+++ b/internal/cli/chain/default_account_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"testing"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/stretchr/testify/require"
+
+	aktcodec "pkg.akt.dev/akt/internal/codec"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
+)
+
+type keyLookupCounter struct {
+	sdkkeyring.Keyring
+	lookups int
+}
+
+func (k *keyLookupCounter) Key(uid string) (*sdkkeyring.Record, error) {
+	k.lookups++
+	return k.Keyring.Key(uid)
+}
+
+func TestDefaultOwnerResolutionTouchesKeyringOnlyForShorthand(t *testing.T) {
+	kr := aktkeyring.NewInMemory(aktcodec.MakeEncodingConfig().Codec)
+	record, _, err := kr.NewMnemonic(
+		"alice",
+		sdkkeyring.English,
+		"m/44'/118'/0'/0/0",
+		"",
+		aktkeyring.DefaultAlgo(),
+	)
+	require.NoError(t, err)
+	address, err := record.GetAddress()
+	require.NoError(t, err)
+
+	counted := &keyLookupCounter{Keyring: kr}
+	cctx := sdkclient.Context{}.
+		WithFrom("alice").
+		WithKeyring(counted)
+
+	owner, err := defaultOwnerForQueryArg(cctx, []string{address.String()})
+	require.NoError(t, err)
+	require.Empty(t, owner)
+	require.Zero(t, counted.lookups, "an explicit owner must not access the keyring")
+
+	owner, err = defaultOwnerForQueryArg(cctx, []string{"not-an-id"})
+	require.NoError(t, err)
+	require.Empty(t, owner)
+	require.Zero(t, counted.lookups, "invalid input must not access the keyring")
+
+	owner, err = defaultOwnerForQueryArg(cctx, []string{"12345"})
+	require.NoError(t, err)
+	require.Equal(t, address.String(), owner)
+	require.Equal(t, 1, counted.lookups, "numeric shorthand must resolve the named default account")
+}

--- a/internal/cli/chain/deployment_query.go
+++ b/internal/cli/chain/deployment_query.go
@@ -61,7 +61,10 @@ the command fails if the deployment is in a different one.`,
 				return err
 			}
 
-			defaultOwner := cl.ClientContext().GetFromAddress().String()
+			defaultOwner, err := defaultOwnerForQueryArg(cl.ClientContext(), args)
+			if err != nil {
+				return err
+			}
 
 			if len(args) > 0 {
 				af, err := cflags.DepFiltersFromArg(args[0], defaultOwner)
@@ -94,6 +97,12 @@ the command fails if the deployment is in a different one.`,
 
 			// Default owner fallback when no arg and no --owner flag.
 			if dfilters.Owner == "" {
+				if defaultOwner == "" {
+					defaultOwner, err = resolveDefaultAccountAddress(cl.ClientContext())
+					if err != nil {
+						return err
+					}
+				}
 				if defaultOwner == "" {
 					return requireOwnerScope("deployment filter")
 				}
@@ -170,7 +179,10 @@ func GetQueryDeploymentGroupCmd() *cobra.Command {
 				gseq  uint32
 			)
 
-			defaultOwner := cl.ClientContext().GetFromAddress().String()
+			defaultOwner, err := defaultOwnerForQueryArg(cl.ClientContext(), args)
+			if err != nil {
+				return err
+			}
 
 			if len(args) == 1 {
 				parsed, fullySpecified, err := cflags.GroupIDFromArg(args[0], defaultOwner)

--- a/internal/cli/chain/escrow_query.go
+++ b/internal/cli/chain/escrow_query.go
@@ -268,8 +268,11 @@ akt query escrow blocks-remaining akash1owner.../12345`,
 
 			// Positional [owner/]dseq; owner defaults to the context
 			// default account (SPEC §3.8).
-			defaultOwner := cl.ClientContext().GetFromAddress().String()
-			id, err := cflags.DeploymentIDFromArgs(args, id, defaultOwner)
+			defaultOwner, err := defaultOwnerForQueryArg(cl.ClientContext(), args)
+			if err != nil {
+				return err
+			}
+			id, err = cflags.DeploymentIDFromArgs(args, id, defaultOwner)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/chain/flags/flags.go
+++ b/internal/cli/chain/flags/flags.go
@@ -391,10 +391,17 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive(FlagUnordered, FlagSequence)
 	cmd.MarkFlagsRequiredTogether(FlagUnordered, TimeoutDuration)
 
-	AddKeyringFlags(f)
+	// --keyring-backend and --keyring-dir are deliberately NOT registered
+	// here. They are global (SPEC §3.1), registered once on the root command
+	// so key management, queries, and transactions all read the same value.
+	// A transaction-local copy shadowed the global one, which kept the
+	// documented AKT_KEYRING_BACKEND/AKT_KEYRING_DIR variables from ever
+	// reaching a tx invocation, and its non-empty "os" default stood ready to
+	// override the context's persisted backend.
 }
 
-// AddKeyringFlags sets common keyring flags
+// AddKeyringFlags sets common keyring flags on a standalone command tree that
+// does not inherit akt's global flags (SPEC §3.1).
 func AddKeyringFlags(flags *pflag.FlagSet) {
 	flags.String(FlagKeyringDir, "", "The client Keyring directory; if omitted, the default 'home' directory will be used")
 	flags.String(FlagKeyringBackend, DefaultKeyringBackend, "Select keyring's backend (os|file|kwallet|pass|test|memory)")

--- a/internal/cli/chain/keys.go
+++ b/internal/cli/chain/keys.go
@@ -9,6 +9,16 @@ import (
 
 // KeysCmds registers a sub-tree of commands to interact with
 // local private key storage.
+//
+// NOTE: this tree is NOT registered on the akt root command -- `akt context
+// keys` (internal/cli/keys) is the key-management surface, and it takes its
+// keyring from the context system rather than from flags. KeysCmds is kept as
+// a clean copy of the upstream subtree for reference and for the commands
+// below that other trees reuse; it therefore registers its own keyring flags,
+// which the root's global --keyring-backend/--keyring-dir (SPEC §3.1) would
+// otherwise provide. Wiring it up would give akt two key-management trees with
+// different resolution rules, so it stays unregistered until there is a reason
+// to expose it.
 func KeysCmds() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "keys",

--- a/internal/cli/chain/market_query.go
+++ b/internal/cli/chain/market_query.go
@@ -64,7 +64,10 @@ rather than printing it.`,
 				return err
 			}
 
-			defaultOwner := cl.ClientContext().GetFromAddress().String()
+			defaultOwner, err := defaultOwnerForQueryArg(cl.ClientContext(), args)
+			if err != nil {
+				return err
+			}
 
 			if len(args) > 0 {
 				af, err := cflags.OrderFiltersFromArg(args[0], defaultOwner)
@@ -103,6 +106,12 @@ rather than printing it.`,
 
 			// Default owner fallback when no arg and no --owner flag.
 			if ofilters.Owner == "" {
+				if defaultOwner == "" {
+					defaultOwner, err = resolveDefaultAccountAddress(cl.ClientContext())
+					if err != nil {
+						return err
+					}
+				}
 				if defaultOwner == "" {
 					return requireOwnerScope("order filter")
 				}
@@ -192,12 +201,19 @@ than printing it.`,
 				return err
 			}
 
-			defaultOwner := cl.ClientContext().GetFromAddress().String()
 			byProvider, _ := cmd.Flags().GetString("by")
 
 			isByProvider, err := parseByPerspective(byProvider)
 			if err != nil {
 				return err
+			}
+
+			var defaultOwner string
+			if !isByProvider {
+				defaultOwner, err = defaultOwnerForQueryArg(cl.ClientContext(), args)
+				if err != nil {
+					return err
+				}
 			}
 
 			if len(args) > 0 {
@@ -244,6 +260,12 @@ than printing it.`,
 					return requireProviderScope("bid filter")
 				}
 			} else if bfilters.Owner == "" {
+				if defaultOwner == "" {
+					defaultOwner, err = resolveDefaultAccountAddress(cl.ClientContext())
+					if err != nil {
+						return err
+					}
+				}
 				if defaultOwner == "" {
 					return requireOwnerScope("bid filter")
 				}
@@ -335,12 +357,19 @@ rather than printing it.`,
 				return err
 			}
 
-			defaultOwner := cl.ClientContext().GetFromAddress().String()
 			byProvider, _ := cmd.Flags().GetString("by")
 
 			isByProvider, err := parseByPerspective(byProvider)
 			if err != nil {
 				return err
+			}
+
+			var defaultOwner string
+			if !isByProvider {
+				defaultOwner, err = defaultOwnerForQueryArg(cl.ClientContext(), args)
+				if err != nil {
+					return err
+				}
 			}
 
 			if len(args) > 0 {
@@ -387,6 +416,12 @@ rather than printing it.`,
 					return requireProviderScope("lease filter")
 				}
 			} else if lfilters.Owner == "" {
+				if defaultOwner == "" {
+					defaultOwner, err = resolveDefaultAccountAddress(cl.ClientContext())
+					if err != nil {
+						return err
+					}
+				}
 				if defaultOwner == "" {
 					return requireOwnerScope("lease filter")
 				}

--- a/internal/cli/context/commands.go
+++ b/internal/cli/context/commands.go
@@ -18,6 +18,7 @@ import (
 	clinetwork "pkg.akt.dev/akt/internal/cli/network"
 	"pkg.akt.dev/akt/internal/cliutil"
 	aktctx "pkg.akt.dev/akt/internal/context"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
 	"pkg.akt.dev/akt/internal/output"
 	"pkg.akt.dev/akt/internal/output/pretty"
 )
@@ -41,6 +42,7 @@ func Commands(mgr func() *aktctx.Manager, getKeyring func() (sdkkeyring.Keyring,
 		renameCmd(mgr),
 		logCmd(mgr),
 		clinetwork.Commands(mgr),
+		keyringCommands(mgr),
 		clikeys.Commands(getKeyring),
 	)
 
@@ -260,11 +262,16 @@ func currentCmd(mgr func() *aktctx.Manager) *cobra.Command {
 				return err
 			}
 
+			// Which credential store actually serves the configured backend
+			// on this host (SPEC §1.5). Inspection only -- showing a context
+			// never opens a keyring.
+			effective, available := aktkeyring.EffectiveBackend(m.Root(), rc.Keyring)
+
 			if f := output.FormatFromCmd(cmd); f != output.FormatTable {
-				return output.Fprint(cmd.OutOrStdout(), f, newContextDetails(rc))
+				return output.Fprint(cmd.OutOrStdout(), f, newContextDetails(rc, effective, available))
 			}
 
-			_, err = fmt.Fprint(output.TerminalAwareWriter(cmd.OutOrStdout()), pretty.RenderContextShow(*rc))
+			_, err = fmt.Fprint(output.TerminalAwareWriter(cmd.OutOrStdout()), pretty.RenderContextShow(*rc, effective))
 			return err
 		},
 	}
@@ -281,6 +288,8 @@ type contextDetails struct {
 	Name                    string                  `json:"name"                       yaml:"name"`
 	Network                 aktctx.Network          `json:"network"                    yaml:"network"`
 	Keyring                 aktctx.Keyring          `json:"keyring"                    yaml:"keyring"`
+	KeyringBackendEffective string                  `json:"keyring_backend_effective"  yaml:"keyring_backend_effective"`
+	KeyringBackendAvailable bool                    `json:"keyring_backend_available"  yaml:"keyring_backend_available"`
 	AuthMethod              string                  `json:"auth_method"                yaml:"auth_method"`
 	ConsoleAPIURL           string                  `json:"console_api_url"            yaml:"console_api_url"`
 	ConsoleAPIKeyConfigured bool                    `json:"console_api_key_configured" yaml:"console_api_key_configured"`
@@ -296,12 +305,14 @@ type contextDetails struct {
 	Capabilities            contextCapabilities     `json:"capabilities"               yaml:"capabilities"`
 }
 
-func newContextDetails(rc *aktctx.Context) contextDetails {
+func newContextDetails(rc *aktctx.Context, effectiveKeyringBackend string, keyringBackendAvailable bool) contextDetails {
 	set := capability.Resolve(rc)
 	return contextDetails{
 		Name:                    rc.Name,
 		Network:                 rc.Network,
 		Keyring:                 rc.Keyring,
+		KeyringBackendEffective: effectiveKeyringBackend,
+		KeyringBackendAvailable: keyringBackendAvailable,
 		AuthMethod:              rc.AuthMethod,
 		ConsoleAPIURL:           rc.ConsoleAPIURL,
 		ConsoleAPIKeyConfigured: rc.ConsoleAPIKey != "",

--- a/internal/cli/context/keyring.go
+++ b/internal/cli/context/keyring.go
@@ -1,0 +1,246 @@
+package context
+
+import (
+	"fmt"
+	"strings"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/spf13/cobra"
+
+	aktctx "pkg.akt.dev/akt/internal/context"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
+	"pkg.akt.dev/akt/internal/output"
+)
+
+// keyringCommands returns the "context keyring" command tree: management of
+// the keyring definitions themselves (SPEC §2.2.2), as opposed to the keys
+// they hold (§2.2.3). Without it the only way to change a context's key
+// storage after first run was to hand-edit config.yaml -- which is also the
+// remedy a host with no system credential store needs (§1.5).
+func keyringCommands(mgr func() *aktctx.Manager) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keyring",
+		RunE:  sdkclient.ValidateCmd,
+		Short: "Manage keyring definitions",
+		Long: `Keyrings are shared key storage referenced by name from a context.
+
+The backend selects where keys are kept. "os" is an alias for the platform
+credential store -- Keychain on macOS, Credential Manager on Windows, Secret
+Service or KWallet on Linux -- and akt refuses to open it on a host that has
+none rather than quietly storing keys somewhere else.`,
+	}
+
+	cmd.AddCommand(
+		keyringCreateCmd(mgr),
+		keyringListCmd(mgr),
+		keyringSetCmd(mgr),
+	)
+
+	return cmd
+}
+
+func keyringCreateCmd(mgr func() *aktctx.Manager) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "create <name> <backend>",
+		Short:             "Create a keyring definition",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: completeKeyringArgs(mgr),
+		Example: `  # A file-backed keyring for a headless server
+  akt context keyring create headless file
+
+  # Keep the store outside the akt home
+  akt context keyring create secure file --dir /mnt/secure/keys`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name, backend := args[0], args[1]
+			if err := aktkeyring.ValidateBackend(backend); err != nil {
+				return err
+			}
+
+			m := mgr()
+			dir, _ := cmd.Flags().GetString("dir")
+
+			if err := m.CreateKeyring(aktctx.Keyring{Name: name, Backend: backend, Dir: dir}); err != nil {
+				return err
+			}
+
+			recordContextAction(m.Root(), activeContextFromCmd(cmd, m), "keyring-create", map[string]string{
+				"keyring": name,
+				"backend": backend,
+			})
+
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "Created keyring %q (backend: %s)\n", name, backend)
+			return err
+		},
+	}
+
+	cmd.Flags().String("dir", "", "Keyring directory (default: <home>/keyrings/<name>/)")
+
+	return cmd
+}
+
+func keyringListCmd(mgr func() *aktctx.Manager) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List keyring definitions",
+		Args:    cobra.NoArgs,
+		Example: `  akt context keyring list`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			m := mgr()
+			keyrings := m.ListKeyrings()
+
+			if len(keyrings) == 0 {
+				_, err := fmt.Fprintln(cmd.OutOrStdout(),
+					"No keyrings configured. Create one with: akt context keyring create default file")
+				return err
+			}
+
+			type keyringRow struct {
+				Name      string   `json:"name"      yaml:"name"`
+				Backend   string   `json:"backend"   yaml:"backend"`
+				Effective string   `json:"effective" yaml:"effective"`
+				Available bool     `json:"available" yaml:"available"`
+				Dir       string   `json:"dir"       yaml:"dir"`
+				UsedBy    []string `json:"used_by"   yaml:"used-by"`
+			}
+
+			columns := []output.Column{
+				{Header: "NAME"},
+				{Header: "BACKEND"},
+				{Header: "EFFECTIVE"},
+				{Header: "DIR"},
+				{Header: "USED BY"},
+			}
+
+			rows := make([][]string, 0, len(keyrings))
+			data := make([]keyringRow, 0, len(keyrings))
+
+			for _, kr := range keyrings {
+				backend := kr.Backend
+				if backend == "" {
+					backend = aktctx.DefaultKeyring().Backend
+				}
+
+				// Report what this host actually provides, never the
+				// configured value dressed up as a fact (SPEC §1.5).
+				effective, available := aktkeyring.EffectiveBackend(m.Root(), kr)
+				display := effective
+				if !available {
+					display = "unavailable"
+				}
+
+				users := m.KeyringUsers(kr.Name)
+				usedBy := "(none)"
+				if len(users) > 0 {
+					usedBy = strings.Join(users, ", ")
+				}
+
+				rows = append(rows, []string{
+					kr.Name, backend, display, aktctx.KeyringDir(m.Root(), kr), usedBy,
+				})
+				data = append(data, keyringRow{
+					Name:      kr.Name,
+					Backend:   backend,
+					Effective: effective,
+					Available: available,
+					Dir:       aktctx.KeyringDir(m.Root(), kr),
+					UsedBy:    users,
+				})
+			}
+
+			return output.PrintData(cmd, columns, rows, data)
+		},
+	}
+}
+
+func keyringSetCmd(mgr func() *aktctx.Manager) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "set <name> <backend>",
+		Short:             "Change a keyring's backend",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: completeKeyringArgs(mgr),
+		Long: `Change where a keyring stores its keys.
+
+Backends do not share storage, so keys added under the previous backend stay
+where they are; re-add or import them under the new backend.`,
+		Example: `  # Persist the remedy for a host with no system credential store
+  akt context keyring set default file
+
+  # Move the store as well
+  akt context keyring set default file --dir /mnt/secure/keys`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name, backend := args[0], args[1]
+			if err := aktkeyring.ValidateBackend(backend); err != nil {
+				return err
+			}
+
+			m := mgr()
+
+			previous := ""
+			if existing := m.GetKeyring(name); existing != nil {
+				previous = existing.Backend
+			}
+
+			dirChanged := cmd.Flags().Changed("dir")
+			dir, _ := cmd.Flags().GetString("dir")
+
+			if err := m.UpdateKeyring(name, func(kr *aktctx.Keyring) error {
+				kr.Backend = backend
+				if dirChanged {
+					kr.Dir = dir
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			recordContextAction(m.Root(), activeContextFromCmd(cmd, m), "keyring-set", map[string]string{
+				"keyring":  name,
+				"backend":  backend,
+				"previous": previous,
+			})
+
+			out := cmd.OutOrStdout()
+			if _, err := fmt.Fprintf(out, "Keyring %q now uses backend %s\n", name, backend); err != nil {
+				return err
+			}
+
+			if previous != "" && previous != backend {
+				_, err := fmt.Fprintf(out,
+					"Keys stored under the %s backend are not migrated; re-add or import them under %s.\n",
+					previous, backend)
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("dir", "", "Keyring directory (default: <home>/keyrings/<name>/)")
+
+	return cmd
+}
+
+// completeKeyringArgs completes the keyring name first, then the backend.
+func completeKeyringArgs(mgr func() *aktctx.Manager) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 1 {
+			return aktkeyring.Backends(), cobra.ShellCompDirectiveNoFileComp
+		}
+		if len(args) > 1 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		m := mgr()
+		if m == nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		keyrings := m.ListKeyrings()
+		names := make([]string, 0, len(keyrings))
+		for _, kr := range keyrings {
+			names = append(names, kr.Name)
+		}
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/internal/cli/gating_test.go
+++ b/internal/cli/gating_test.go
@@ -186,3 +186,41 @@ func TestRequiresContextExemptsOfflineGroups(t *testing.T) {
 		t.Error("tx must still require a context")
 	}
 }
+
+// TestOfflineGroupsDeclareNoLocalIdentity is the keyring half of the same
+// contract. Exempting a group from needing a *context* is not enough: startup
+// still opened the context's keyring and resolved its named default-account,
+// which prompts for a file passphrase or an OS unlock. `akt sdl validate`
+// asking for a wallet password is the bug this pins (SPEC §1.7, §2.11).
+func TestOfflineGroupsDeclareNoLocalIdentity(t *testing.T) {
+	root := &cobra.Command{Use: "akt"}
+
+	if requiresLocalIdentity(root) {
+		t.Error("the root command prints help and must not open a keyring")
+	}
+
+	for _, group := range []string{"sdl", "monitor", "version", "completion", "context", "store", "console"} {
+		g := &cobra.Command{Use: group}
+		root.AddCommand(g)
+
+		if requiresLocalIdentity(g) {
+			t.Errorf("%s must not open a keyring", group)
+		}
+
+		// Leaves inherit the group's answer -- `akt sdl validate` is the
+		// invocation that actually reported the bug.
+		leaf := &cobra.Command{Use: "validate"}
+		g.AddCommand(leaf)
+		if requiresLocalIdentity(leaf) {
+			t.Errorf("%s validate must not open a keyring", group)
+		}
+	}
+
+	for _, group := range []string{"tx", "query", "provider", "deploy", "mcp"} {
+		g := &cobra.Command{Use: group}
+		root.AddCommand(g)
+		if !requiresLocalIdentity(g) {
+			t.Errorf("%s signs or scopes by account and must resolve the local identity", group)
+		}
+	}
+}

--- a/internal/cli/gating_test.go
+++ b/internal/cli/gating_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 
 	"pkg.akt.dev/akt/internal/capability"
+	aktclient "pkg.akt.dev/akt/internal/client"
 )
 
 func gatedTree() (*cobra.Command, *cobra.Command, *cobra.Command) {
@@ -187,15 +189,13 @@ func TestRequiresContextExemptsOfflineGroups(t *testing.T) {
 	}
 }
 
-// TestOfflineGroupsDeclareNoLocalIdentity is the keyring half of the same
-// contract. Exempting a group from needing a *context* is not enough: startup
-// still opened the context's keyring and resolved its named default-account,
-// which prompts for a file passphrase or an OS unlock. `akt sdl validate`
-// asking for a wallet password is the bug this pins (SPEC §1.7, §2.11).
-func TestOfflineGroupsDeclareNoLocalIdentity(t *testing.T) {
+// TestLocalIdentityModes pins the three-way startup boundary from SPEC §1.7.
+// Public reads may need a default owner later, but that must not make startup
+// open a keyring that the invocation never uses.
+func TestLocalIdentityModes(t *testing.T) {
 	root := &cobra.Command{Use: "akt"}
 
-	if requiresLocalIdentity(root) {
+	if got := localIdentityMode(root); got != aktclient.LocalIdentityNone {
 		t.Error("the root command prints help and must not open a keyring")
 	}
 
@@ -203,7 +203,7 @@ func TestOfflineGroupsDeclareNoLocalIdentity(t *testing.T) {
 		g := &cobra.Command{Use: group}
 		root.AddCommand(g)
 
-		if requiresLocalIdentity(g) {
+		if got := localIdentityMode(g); got != aktclient.LocalIdentityNone {
 			t.Errorf("%s must not open a keyring", group)
 		}
 
@@ -211,16 +211,53 @@ func TestOfflineGroupsDeclareNoLocalIdentity(t *testing.T) {
 		// invocation that actually reported the bug.
 		leaf := &cobra.Command{Use: "validate"}
 		g.AddCommand(leaf)
-		if requiresLocalIdentity(leaf) {
+		if got := localIdentityMode(leaf); got != aktclient.LocalIdentityNone {
 			t.Errorf("%s validate must not open a keyring", group)
 		}
 	}
 
-	for _, group := range []string{"tx", "query", "provider", "deploy", "mcp"} {
+	for _, group := range []string{"query"} {
 		g := &cobra.Command{Use: group}
 		root.AddCommand(g)
-		if !requiresLocalIdentity(g) {
-			t.Errorf("%s signs or scopes by account and must resolve the local identity", group)
+		if got := localIdentityMode(g); got != aktclient.LocalIdentityOnDemand {
+			t.Errorf("%s mode = %v, want on demand", group, got)
 		}
+	}
+
+	mcp := &cobra.Command{Use: "mcp"}
+	mcp.Flags().Bool("enable-writes", false, "")
+	root.AddCommand(mcp)
+	if got := localIdentityMode(mcp); got != aktclient.LocalIdentityOnDemand {
+		t.Errorf("read-only mcp mode = %v, want on demand", got)
+	}
+	require.NoError(t, mcp.Flags().Set("enable-writes", "true"))
+	if got := localIdentityMode(mcp); got != aktclient.LocalIdentityRequired {
+		t.Errorf("write-enabled mcp mode = %v, want required", got)
+	}
+
+	provider := &cobra.Command{Use: "provider"}
+	status := &cobra.Command{Use: "status"}
+	leaseStatus := &cobra.Command{Use: "lease-status"}
+	provider.AddCommand(status, leaseStatus)
+	root.AddCommand(provider)
+	if got := localIdentityMode(status); got != aktclient.LocalIdentityNone {
+		t.Errorf("provider status mode = %v, want none", got)
+	}
+	if got := localIdentityMode(leaseStatus); got != aktclient.LocalIdentityRequired {
+		t.Errorf("provider lease-status mode = %v, want required", got)
+	}
+
+	tx := &cobra.Command{Use: "tx"}
+	send := &cobra.Command{Use: "send"}
+	send.Flags().Bool("generate-only", false, "")
+	send.Flags().Bool("dry-run", false, "")
+	tx.AddCommand(send)
+	root.AddCommand(tx)
+	if got := localIdentityMode(send); got != aktclient.LocalIdentityRequired {
+		t.Errorf("ordinary tx mode = %v, want required", got)
+	}
+	require.NoError(t, send.Flags().Set("generate-only", "true"))
+	if got := localIdentityMode(send); got != aktclient.LocalIdentityOnDemand {
+		t.Errorf("generate-only tx mode = %v, want on demand", got)
 	}
 }

--- a/internal/cli/provider/commands.go
+++ b/internal/cli/provider/commands.go
@@ -21,6 +21,7 @@ import (
 	"pkg.akt.dev/akt/internal/capability"
 	chaincli "pkg.akt.dev/akt/internal/cli/chain"
 	cflags "pkg.akt.dev/akt/internal/cli/chain/flags"
+	aktclient "pkg.akt.dev/akt/internal/client"
 	"pkg.akt.dev/akt/internal/output"
 	aktprovider "pkg.akt.dev/akt/internal/provider"
 )
@@ -689,7 +690,13 @@ func gatewayClientFromCmd(cmd *cobra.Command, providerURL string) (rest.Client, 
 func gatewayAuthenticationFromCmd(cmd *cobra.Command) (sdkclient.Context, sdk.AccAddress, string, error) {
 	cctx := sdkclient.GetClientContextFromCmd(cmd)
 	authType, _ := cmd.Flags().GetString("auth-type")
-	addr := cctx.GetFromAddress()
+	addr, err := aktclient.ResolveAccountAddress(cctx)
+	if err != nil {
+		return sdkclient.Context{}, nil, "", err
+	}
+	if !addr.Empty() {
+		cctx = cctx.WithFromAddress(addr)
+	}
 	if err := aktprovider.ValidateGatewayAuthentication(addr, authType, cctx.Keyring); err != nil {
 		return sdkclient.Context{}, nil, "", err
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -246,7 +246,7 @@ the deployment is created.`,
 				encCfg,
 				v.GetString("context"),
 				v.GetString(cflags.FlagFrom),
-				requiresLocalIdentity(cmd),
+				localIdentityMode(cmd),
 			)
 			if err != nil {
 				return err
@@ -605,12 +605,9 @@ func requiresConfig(cmd *cobra.Command) bool {
 	return true
 }
 
-// requiresLocalIdentity returns true if the command can need the local
-// signing identity -- the context's keyring, and the account its
-// default-account names. It is the third and narrowest of the startup
-// predicates: requiresConfig decides whether to bootstrap, requiresContext
-// decides whether a context is mandatory, and this one decides whether to
-// open a key store.
+// localIdentityMode decides whether startup supplies no keyring, a deferred
+// keyring, or an immediately opened signing identity (SPEC §1.7). It is the
+// third and narrowest startup predicate after requiresConfig/requiresContext.
 //
 // The distinction matters because opening a keyring and resolving a named
 // account are interactive: a file backend prompts for its passphrase and an
@@ -618,47 +615,82 @@ func requiresConfig(cmd *cobra.Command) bool {
 // broke the group's documented promise to run entirely locally (SPEC §2.11),
 // and did the same to `akt monitor` (SPEC §2.6). Commands listed here are
 // defined to work without a signer, so they must not trigger either.
-//
-// Query commands are deliberately absent: an owner-scoped query with no
-// explicit owner falls back to the context's default account, so a named
-// account still has to resolve. Narrowing that to the queries that actually
-// need the address is a separate change (see the lazy resolvers in
-// internal/cli/chain/cctx.go); this predicate is the single place that will
-// record the decision once they land.
-func requiresLocalIdentity(cmd *cobra.Command) bool {
+func localIdentityMode(cmd *cobra.Command) aktclient.LocalIdentityMode {
 	path := cmd.CommandPath()
 
 	switch {
 	// The root command itself only prints help.
 	case path == "akt":
-		return false
+		return aktclient.LocalIdentityNone
 	// SDL authoring is entirely local: parsing, scaffolding, and linting
 	// never touch a network or a credential.
 	case strings.HasPrefix(path, "akt sdl"):
-		return false
+		return aktclient.LocalIdentityNone
 	// Monitoring reads public chain state over RPC.
 	case strings.HasPrefix(path, "akt monitor"):
-		return false
+		return aktclient.LocalIdentityNone
 	// Build metadata and completion scripts come from the binary alone.
 	case strings.HasPrefix(path, "akt version"),
 		strings.HasPrefix(path, "akt completion"):
-		return false
+		return aktclient.LocalIdentityNone
 	// Context, network, and keyring management edits config.yaml. The keys
 	// subgroup does need keys, and gets them from the getKeyring closure at
 	// the point it uses them -- which is also what lets `akt context keys`
 	// fix a context whose configured backend this host cannot open.
 	case strings.HasPrefix(path, "akt context"):
-		return false
+		return aktclient.LocalIdentityNone
 	// The store is a local bbolt database.
 	case strings.HasPrefix(path, "akt store"):
-		return false
+		return aktclient.LocalIdentityNone
 	// The Console rail authenticates with an API key; its contexts may have
 	// no keyring at all.
 	case strings.HasPrefix(path, "akt console"):
+		return aktclient.LocalIdentityNone
+	// Queries may need a named default account, but only when an omitted owner
+	// reaches the command handler.
+	case strings.HasPrefix(path, "akt query"):
+		return aktclient.LocalIdentityOnDemand
+	// Provider status is the gateway's public endpoint. Protected provider
+	// operations still preflight their signing identity before network work.
+	case path == "akt provider status":
+		return aktclient.LocalIdentityNone
+	case strings.HasPrefix(path, "akt provider"):
+		if boolFlag(cmd, cflags.FlagDryRun) {
+			return aktclient.LocalIdentityOnDemand
+		}
+		return aktclient.LocalIdentityRequired
+	// MCP reads defer identity until an owner-defaulting tool is invoked.
+	// Explicitly enabling writes opts a keyring context into eager resolution;
+	// MustResolveAndInit keeps Console-only contexts keyring-free.
+	case strings.HasPrefix(path, "akt mcp"):
+		if boolFlag(cmd, "enable-writes") {
+			return aktclient.LocalIdentityRequired
+		}
+		return aktclient.LocalIdentityOnDemand
+	// Unsigned construction and simulation accept a bech32 signer without a
+	// local key. A signer name resolves through the deferred keyring later.
+	case strings.HasPrefix(path, "akt tx"):
+		if boolFlag(cmd, cflags.FlagGenerateOnly) || boolFlag(cmd, cflags.FlagDryRun) {
+			return aktclient.LocalIdentityOnDemand
+		}
+		return aktclient.LocalIdentityRequired
+	// Workflow dry-runs validate and print a plan without selecting a transport
+	// client or local signer.
+	case boolFlag(cmd, cflags.FlagDryRun):
+		return aktclient.LocalIdentityNone
+	}
+
+	return aktclient.LocalIdentityRequired
+}
+
+func boolFlag(cmd *cobra.Command, name string) bool {
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
 		return false
 	}
 
-	return true
+	value, err := cmd.Flags().GetBool(name)
+	return err == nil && value
 }
 
 // requiresContext returns true if the command needs a fully resolved akt

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -167,6 +167,15 @@ the deployment is created.`,
 				_ = v.BindPFlag(cflags.FlagFrom, fromFlag)
 			}
 
+			// Keyring overrides. The env names are bound explicitly rather
+			// than left to AutomaticEnv, which would look for
+			// AKT_KEYRING-BACKEND and never find the documented
+			// AKT_KEYRING_BACKEND (SPEC §1.9).
+			_ = v.BindPFlag(cflags.FlagKeyringBackend, cmd.Flags().Lookup(cflags.FlagKeyringBackend))
+			_ = v.BindPFlag(cflags.FlagKeyringDir, cmd.Flags().Lookup(cflags.FlagKeyringDir))
+			_ = v.BindEnv(cflags.FlagKeyringBackend, "AKT_KEYRING_BACKEND")
+			_ = v.BindEnv(cflags.FlagKeyringDir, "AKT_KEYRING_DIR")
+
 			// Verbosity validation: -q and -v are mutually exclusive.
 			if v.GetBool("quiet") && v.GetInt("verbose") > 0 {
 				return fmt.Errorf("--quiet and --verbose are mutually exclusive")
@@ -211,12 +220,25 @@ the deployment is created.`,
 				return err
 			}
 
-			// Initialize the keyring manager with all keyring configs.
+			// Initialize the keyring manager with all keyring configs, with
+			// the per-invocation --keyring-backend/--keyring-dir overrides
+			// applied so every keyring this run opens agrees (SPEC §3.1).
+			keyringBackend := v.GetString(cflags.FlagKeyringBackend)
+			if err := aktkeyring.ValidateBackend(keyringBackend); err != nil {
+				return err
+			}
+
 			cfg := mgr.Config()
-			krMgr = aktkeyring.NewManager(cfgRoot, cfg.Keyrings, encCfg.Codec)
+			krMgr = aktkeyring.NewManager(
+				cfgRoot,
+				aktkeyring.ApplyOverrides(cfg.Keyrings, keyringBackend, v.GetString(cflags.FlagKeyringDir)),
+				encCfg.Codec,
+			)
 
 			// 3. If an akt context is active, enrich the SDK client.Context
 			//    with context-specific values (chain-id, RPC, keyring, etc.).
+			//    The keyring is opened only when this command can need the
+			//    local signing identity (SPEC §1.7).
 			resolved, err := aktclient.MustResolveAndInit(
 				cmd,
 				mgr,
@@ -224,6 +246,7 @@ the deployment is created.`,
 				encCfg,
 				v.GetString("context"),
 				v.GetString(cflags.FlagFrom),
+				requiresLocalIdentity(cmd),
 			)
 			if err != nil {
 				return err
@@ -347,6 +370,15 @@ the deployment is created.`,
 	// not captured into Go variables.
 	root.PersistentFlags().String("home", "", "Home directory for config, contexts, and keyrings (default: $AKT_HOME or ~/.config/akt)")
 	root.PersistentFlags().String("context", "", "Active context name (overrides current-context in config)")
+	// Key storage is a property of the invocation, not of signing: listing and
+	// adding keys need the same override a transaction does, and on a host
+	// whose configured backend is unavailable it is the only way in. Empty
+	// defaults so that leaving them unset never shadows the context's stored
+	// keyring (SPEC §3.1).
+	root.PersistentFlags().String(cflags.FlagKeyringBackend, "",
+		"Keyring backend for this invocation: "+strings.Join(aktkeyring.Backends(), "|")+" (default: the context's keyring backend)")
+	root.PersistentFlags().String(cflags.FlagKeyringDir, "",
+		"Keyring directory for this invocation (default: the context's keyring directory)")
 	root.PersistentFlags().VarP(output.NewFormatFlag("pretty"), "output", "o", "Output format: pretty, json, yaml")
 	// Local, not persistent: launching the TUI is only meaningful at the root.
 	// As a persistent flag it was advertised on all ~400 subcommands and
@@ -567,6 +599,62 @@ func requiresConfig(cmd *cobra.Command) bool {
 	// SDL authoring is entirely local (see requiresContext), so demanding
 	// a network fetch before linting a local file would be backwards.
 	case strings.HasPrefix(path, "akt sdl"):
+		return false
+	}
+
+	return true
+}
+
+// requiresLocalIdentity returns true if the command can need the local
+// signing identity -- the context's keyring, and the account its
+// default-account names. It is the third and narrowest of the startup
+// predicates: requiresConfig decides whether to bootstrap, requiresContext
+// decides whether a context is mandatory, and this one decides whether to
+// open a key store.
+//
+// The distinction matters because opening a keyring and resolving a named
+// account are interactive: a file backend prompts for its passphrase and an
+// os backend asks the desktop to unlock. Doing that for `akt sdl validate`
+// broke the group's documented promise to run entirely locally (SPEC §2.11),
+// and did the same to `akt monitor` (SPEC §2.6). Commands listed here are
+// defined to work without a signer, so they must not trigger either.
+//
+// Query commands are deliberately absent: an owner-scoped query with no
+// explicit owner falls back to the context's default account, so a named
+// account still has to resolve. Narrowing that to the queries that actually
+// need the address is a separate change (see the lazy resolvers in
+// internal/cli/chain/cctx.go); this predicate is the single place that will
+// record the decision once they land.
+func requiresLocalIdentity(cmd *cobra.Command) bool {
+	path := cmd.CommandPath()
+
+	switch {
+	// The root command itself only prints help.
+	case path == "akt":
+		return false
+	// SDL authoring is entirely local: parsing, scaffolding, and linting
+	// never touch a network or a credential.
+	case strings.HasPrefix(path, "akt sdl"):
+		return false
+	// Monitoring reads public chain state over RPC.
+	case strings.HasPrefix(path, "akt monitor"):
+		return false
+	// Build metadata and completion scripts come from the binary alone.
+	case strings.HasPrefix(path, "akt version"),
+		strings.HasPrefix(path, "akt completion"):
+		return false
+	// Context, network, and keyring management edits config.yaml. The keys
+	// subgroup does need keys, and gets them from the getKeyring closure at
+	// the point it uses them -- which is also what lets `akt context keys`
+	// fix a context whose configured backend this host cannot open.
+	case strings.HasPrefix(path, "akt context"):
+		return false
+	// The store is a local bbolt database.
+	case strings.HasPrefix(path, "akt store"):
+		return false
+	// The Console rail authenticates with an API key; its contexts may have
+	// no keyring at all.
+	case strings.HasPrefix(path, "akt console"):
 		return false
 	}
 

--- a/internal/client/context.go
+++ b/internal/client/context.go
@@ -31,6 +31,16 @@ func BuildClientContext(
 	enc sdkutil.EncodingConfig,
 	fromOverride string,
 ) sdkclient.Context {
+	return buildClientContext(rc, kr, enc, fromOverride, true)
+}
+
+func buildClientContext(
+	rc *aktctx.Context,
+	kr sdkkeyring.Keyring,
+	enc sdkutil.EncodingConfig,
+	fromOverride string,
+	resolveNamedAccount bool,
+) sdkclient.Context {
 	cctx := sdkclient.Context{}.
 		WithCodec(enc.Codec).
 		WithInterfaceRegistry(enc.InterfaceRegistry).
@@ -43,16 +53,16 @@ func BuildClientContext(
 		WithChainID(rc.Network.ChainID).
 		WithKeyringDir(aktctx.KeyringDir(rc.Root, rc.Keyring))
 
-	// Resolve the invocation signer before downstream tx/query hooks run.
+	// Carry the invocation account before downstream tx/query hooks run.
 	//
 	// WithFrom records the name only; FromName and FromAddress stay empty
-	// until something resolves the name against the keyring. Tx commands do
-	// that themselves, queries never do -- so every query that falls back to
-	// the default account saw no address and reported "no default account
-	// set" on a context that had one configured and displayed. Resolve it
-	// here so both paths agree.
+	// until something resolves the name against the keyring. Commands that
+	// need a signer resolve it here. Query initialization deliberately leaves
+	// a named account unresolved so network-wide and explicitly scoped reads
+	// never unlock the keyring; owner-defaulting query handlers resolve it only
+	// when they actually need its address.
 	//
-	// A name that is not in the keyring is left as the bare From value rather
+	// A name that is not resolved is left as the bare From value rather
 	// than failing: the context is built for every command, including the
 	// keys and context commands someone would use to fix it.
 	from := fromOverride
@@ -62,18 +72,13 @@ func BuildClientContext(
 	if from != "" {
 		cctx = cctx.WithFrom(from)
 
-		resolvedName := false
-		if kr != nil {
+		if addr, err := sdk.AccAddressFromBech32(from); err == nil {
+			cctx = cctx.WithFromAddress(addr)
+		} else if resolveNamedAccount && kr != nil {
 			if rec, err := kr.Key(from); err == nil {
 				if addr, err := rec.GetAddress(); err == nil {
 					cctx = cctx.WithFromName(from).WithFromAddress(addr)
-					resolvedName = true
 				}
-			}
-		}
-		if !resolvedName {
-			if addr, err := sdk.AccAddressFromBech32(from); err == nil {
-				cctx = cctx.WithFromAddress(addr)
 			}
 		}
 	}
@@ -105,7 +110,18 @@ func InitClientContext(
 	enc sdkutil.EncodingConfig,
 	fromOverride string,
 ) error {
-	cctx := BuildClientContext(rc, kr, enc, fromOverride)
+	return initClientContext(cmd, rc, kr, enc, fromOverride, true)
+}
+
+func initClientContext(
+	cmd *cobra.Command,
+	rc *aktctx.Context,
+	kr sdkkeyring.Keyring,
+	enc sdkutil.EncodingConfig,
+	fromOverride string,
+	resolveNamedAccount bool,
+) error {
+	cctx := buildClientContext(rc, kr, enc, fromOverride, resolveNamedAccount)
 
 	// Store address codecs in the context for chain-sdk commands.
 	ctx := cmd.Context()
@@ -169,5 +185,15 @@ func MustResolveAndInit(
 		return false, err
 	}
 
-	return true, InitClientContext(cmd, rc, kr, enc, fromOverride)
+	return true, initClientContext(cmd, rc, kr, enc, fromOverride, !isQueryCommand(cmd))
+}
+
+func isQueryCommand(cmd *cobra.Command) bool {
+	for current := cmd; current != nil; current = current.Parent() {
+		if current.Name() == "query" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/client/context.go
+++ b/internal/client/context.go
@@ -7,7 +7,9 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strings"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -21,6 +23,16 @@ import (
 
 	arpcclient "pkg.akt.dev/go/node/client"
 	"pkg.akt.dev/go/sdkutil"
+)
+
+// LocalIdentityMode controls when command startup may open the selected
+// context's keyring (SPEC §1.7).
+type LocalIdentityMode uint8
+
+const (
+	LocalIdentityNone LocalIdentityMode = iota
+	LocalIdentityOnDemand
+	LocalIdentityRequired
 )
 
 // BuildClientContext constructs a fully populated Cosmos SDK client.Context
@@ -104,6 +116,40 @@ func buildClientContext(
 	return cctx
 }
 
+// ResolveAccountAddress resolves the account carried by cctx. Address-valued
+// accounts are parsed without consulting the keyring; named accounts trigger
+// the first key operation on an on-demand keyring.
+func ResolveAccountAddress(cctx sdkclient.Context) (sdk.AccAddress, error) {
+	if addr := cctx.GetFromAddress(); !addr.Empty() {
+		return addr, nil
+	}
+
+	from := strings.TrimSpace(cctx.From)
+	if from == "" {
+		return nil, nil
+	}
+
+	if addr, err := sdk.AccAddressFromBech32(from); err == nil {
+		return addr, nil
+	}
+
+	if cctx.Keyring == nil {
+		return nil, fmt.Errorf("resolve account %q: keyring is unavailable", from)
+	}
+
+	record, err := cctx.Keyring.Key(from)
+	if err != nil {
+		return nil, fmt.Errorf("resolve account %q: %w", from, err)
+	}
+
+	addr, err := record.GetAddress()
+	if err != nil {
+		return nil, fmt.Errorf("resolve account %q address: %w", from, err)
+	}
+
+	return addr, nil
+}
+
 // InitClientContext initializes the Cosmos SDK client context on a cobra command.
 // This must be called in the root PersistentPreRunE before any chain-sdk CLI
 // commands execute. It stores the client.Context in the cobra context the same
@@ -153,13 +199,9 @@ func initClientContext(
 // keyring, and initializes the SDK client context on the command. Used in
 // the root PersistentPreRunE. Returns true if a context was resolved.
 //
-// needsLocalIdentity is the caller's explicit decision about whether this
-// invocation can need the local signing identity (SPEC §1.7). When it is
-// false the keyring is not opened and a named default account is left
-// unresolved, because both can prompt for a passphrase or an OS unlock that
-// the command has no use for. The root command decides this via
-// requiresLocalIdentity; the client layer must not infer it from command
-// names.
+// identityMode is the caller's explicit decision about when this invocation
+// may open the local signing identity (SPEC §1.7). The client layer does not
+// infer that policy from command names.
 func MustResolveAndInit(
 	cmd *cobra.Command,
 	mgr *aktctx.Manager,
@@ -167,7 +209,7 @@ func MustResolveAndInit(
 	enc sdkutil.EncodingConfig,
 	contextOverride string,
 	fromOverride string,
-	needsLocalIdentity bool,
+	identityMode LocalIdentityMode,
 ) (bool, error) {
 	ctxName := contextOverride
 	if ctxName == "" {
@@ -189,31 +231,35 @@ func MustResolveAndInit(
 		return false, err
 	}
 
+	// Console contexts never use a local wallet. Even a command that can write
+	// selects the managed rail and must not turn that capability into a local
+	// keyring requirement.
+	if rc.AuthMethod == aktctx.AuthMethodConsoleAPI {
+		identityMode = LocalIdentityNone
+	}
+
 	// A nil keyring is a deliberate, complete answer for commands that declare
-	// no local identity: BuildClientContext leaves a named account unresolved
-	// and still parses an address-valued default.
+	// no local identity. On-demand commands receive a proxy that opens the
+	// backend only when a key operation is actually requested.
 	var kr sdkkeyring.Keyring
-	if needsLocalIdentity {
+	resolveNamedAccount := false
+	if identityMode != LocalIdentityNone {
 		krName := rc.Keyring.Name
 		if krName == "" {
 			krName = "default"
 		}
 
-		kr, err = krMgr.Get(krName)
-		if err != nil {
-			return false, err
+		switch identityMode {
+		case LocalIdentityOnDemand:
+			kr = krMgr.Deferred(krName)
+		case LocalIdentityRequired:
+			kr, err = krMgr.Get(krName)
+			if err != nil {
+				return false, err
+			}
+			resolveNamedAccount = true
 		}
 	}
 
-	return true, initClientContext(cmd, rc, kr, enc, fromOverride, !isQueryCommand(cmd))
-}
-
-func isQueryCommand(cmd *cobra.Command) bool {
-	for current := cmd; current != nil; current = current.Parent() {
-		if current.Name() == "query" {
-			return true
-		}
-	}
-
-	return false
+	return true, initClientContext(cmd, rc, kr, enc, fromOverride, resolveNamedAccount)
 }

--- a/internal/client/context.go
+++ b/internal/client/context.go
@@ -65,6 +65,11 @@ func buildClientContext(
 	// A name that is not resolved is left as the bare From value rather
 	// than failing: the context is built for every command, including the
 	// keys and context commands someone would use to fix it.
+	//
+	// kr is nil for commands that declare no local identity (SPEC §1.7). A
+	// named account then stays unresolved -- resolving it would open the
+	// keyring and prompt -- while an address-valued default still resolves,
+	// because parsing bech32 costs nothing.
 	from := fromOverride
 	if from == "" {
 		from = rc.DefaultAccount
@@ -147,6 +152,14 @@ func initClientContext(
 // MustResolveAndInit is a convenience that resolves the context, gets the
 // keyring, and initializes the SDK client context on the command. Used in
 // the root PersistentPreRunE. Returns true if a context was resolved.
+//
+// needsLocalIdentity is the caller's explicit decision about whether this
+// invocation can need the local signing identity (SPEC §1.7). When it is
+// false the keyring is not opened and a named default account is left
+// unresolved, because both can prompt for a passphrase or an OS unlock that
+// the command has no use for. The root command decides this via
+// requiresLocalIdentity; the client layer must not infer it from command
+// names.
 func MustResolveAndInit(
 	cmd *cobra.Command,
 	mgr *aktctx.Manager,
@@ -154,6 +167,7 @@ func MustResolveAndInit(
 	enc sdkutil.EncodingConfig,
 	contextOverride string,
 	fromOverride string,
+	needsLocalIdentity bool,
 ) (bool, error) {
 	ctxName := contextOverride
 	if ctxName == "" {
@@ -175,14 +189,20 @@ func MustResolveAndInit(
 		return false, err
 	}
 
-	krName := rc.Keyring.Name
-	if krName == "" {
-		krName = "default"
-	}
+	// A nil keyring is a deliberate, complete answer for commands that declare
+	// no local identity: BuildClientContext leaves a named account unresolved
+	// and still parses an address-valued default.
+	var kr sdkkeyring.Keyring
+	if needsLocalIdentity {
+		krName := rc.Keyring.Name
+		if krName == "" {
+			krName = "default"
+		}
 
-	kr, err := krMgr.Get(krName)
-	if err != nil {
-		return false, err
+		kr, err = krMgr.Get(krName)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	return true, initClientContext(cmd, rc, kr, enc, fromOverride, !isQueryCommand(cmd))

--- a/internal/client/context_test.go
+++ b/internal/client/context_test.go
@@ -75,7 +75,7 @@ func TestProviderListDoesNotReadNamedDefaultAccount(t *testing.T) {
 	queryCmd.AddCommand(providerCmd)
 	providerCmd.AddCommand(listCmd)
 
-	resolved, err := MustResolveAndInit(listCmd, mgr, keyrings, enc, "", "")
+	resolved, err := MustResolveAndInit(listCmd, mgr, keyrings, enc, "", "", LocalIdentityOnDemand)
 	require.NoError(t, err)
 	require.True(t, resolved)
 	require.Zero(t, promptInput.reads, "provider list must not access the keyring")

--- a/internal/client/context_test.go
+++ b/internal/client/context_test.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	aktcodec "pkg.akt.dev/akt/internal/codec"
+	aktctx "pkg.akt.dev/akt/internal/context"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
+)
+
+type countingReader struct {
+	io.Reader
+	reads int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	r.reads++
+	return r.Reader.Read(p)
+}
+
+func TestProviderListDoesNotReadNamedDefaultAccount(t *testing.T) {
+	root := t.TempDir()
+	enc := aktcodec.MakeEncodingConfig()
+
+	mgr, err := aktctx.NewManager(root)
+	require.NoError(t, err)
+	require.NoError(t, mgr.CreateNetwork(aktctx.Network{
+		Name:    "mainnet",
+		ChainID: "akashnet-2",
+		Endpoints: aktctx.Endpoints{
+			RPC: []string{"https://rpc.example.test"},
+		},
+	}))
+	require.NoError(t, mgr.CreateKeyring(aktctx.Keyring{
+		Name:    "locked",
+		Backend: sdkkeyring.BackendFile,
+	}))
+	require.NoError(t, mgr.CreateContext(aktctx.Context{
+		Name:           "locked",
+		Network:        aktctx.Network{Name: "mainnet"},
+		Keyring:        aktctx.Keyring{Name: "locked"},
+		DefaultAccount: "alice",
+	}))
+	require.NoError(t, mgr.UseContext("locked"))
+
+	keyringConfig := []aktctx.Keyring{{Name: "locked", Backend: sdkkeyring.BackendFile}}
+	setupManager := aktkeyring.NewManager(root, keyringConfig, enc.Codec)
+	setupManager.SetInput(strings.NewReader("testpass123\ntestpass123\n"))
+	setupKeyring, err := setupManager.Get("locked")
+	require.NoError(t, err)
+	_, _, err = setupKeyring.NewMnemonic(
+		"alice",
+		sdkkeyring.English,
+		"m/44'/118'/0'/0/0",
+		"",
+		aktkeyring.DefaultAlgo(),
+	)
+	require.NoError(t, err)
+
+	promptInput := &countingReader{Reader: strings.NewReader("testpass123\n")}
+	keyrings := aktkeyring.NewManager(root, keyringConfig, enc.Codec)
+	keyrings.SetInput(promptInput)
+
+	rootCmd := &cobra.Command{Use: "akt"}
+	queryCmd := &cobra.Command{Use: "query"}
+	providerCmd := &cobra.Command{Use: "provider"}
+	listCmd := &cobra.Command{Use: "list"}
+	rootCmd.AddCommand(queryCmd)
+	queryCmd.AddCommand(providerCmd)
+	providerCmd.AddCommand(listCmd)
+
+	resolved, err := MustResolveAndInit(listCmd, mgr, keyrings, enc, "", "")
+	require.NoError(t, err)
+	require.True(t, resolved)
+	require.Zero(t, promptInput.reads, "provider list must not access the keyring")
+}

--- a/internal/client/local_identity_test.go
+++ b/internal/client/local_identity_test.go
@@ -100,7 +100,7 @@ func TestOfflineCommandsDoNotOpenTheKeyring(t *testing.T) {
 
 			leaf := commandTree(path...)
 
-			resolved, err := MustResolveAndInit(leaf, mgr, keyrings, enc, "", "", false)
+			resolved, err := MustResolveAndInit(leaf, mgr, keyrings, enc, "", "", LocalIdentityNone)
 			require.NoError(t, err)
 			require.True(t, resolved)
 			require.Zero(t, input.reads, "an offline command must not read the keyring passphrase prompt")
@@ -120,13 +120,70 @@ func TestSignerCommandsStillResolveTheDefaultAccount(t *testing.T) {
 
 	leaf := commandTree("tx", "bank", "send")
 
-	resolved, err := MustResolveAndInit(leaf, mgr, keyrings, enc, "", "", true)
+	resolved, err := MustResolveAndInit(leaf, mgr, keyrings, enc, "", "", LocalIdentityRequired)
 	require.NoError(t, err)
 	require.True(t, resolved)
 
 	cctx := sdkclient.GetClientContextFromCmd(leaf)
 	require.Equal(t, "alice", cctx.FromName)
 	require.False(t, cctx.GetFromAddress().Empty())
+}
+
+func TestOnDemandIdentityOpensOnlyWhenAKeyIsUsed(t *testing.T) {
+	mgr, keyringConfig, root := lockedContext(t)
+	enc := aktcodec.MakeEncodingConfig()
+
+	input := &promptCountingReader{Reader: strings.NewReader("testpass123\n")}
+	keyrings := aktkeyring.NewManager(root, keyringConfig, enc.Codec)
+	keyrings.SetInput(input)
+
+	leaf := commandTree("query", "provider", "list")
+	resolved, err := MustResolveAndInit(
+		leaf,
+		mgr,
+		keyrings,
+		enc,
+		"",
+		"",
+		LocalIdentityOnDemand,
+	)
+	require.NoError(t, err)
+	require.True(t, resolved)
+	require.Zero(t, input.reads, "startup must not open the deferred keyring")
+
+	cctx := sdkclient.GetClientContextFromCmd(leaf)
+	require.NotNil(t, cctx.Keyring)
+	_, err = cctx.Keyring.Key("alice")
+	require.NoError(t, err)
+	require.Positive(t, input.reads, "the first key operation must open the keyring")
+}
+
+func TestConsoleContextNeverOpensLocalIdentity(t *testing.T) {
+	mgr, keyringConfig, root := lockedContext(t)
+	require.NoError(t, mgr.UpdateContext("locked", func(ctx *aktctx.Context) error {
+		ctx.AuthMethod = aktctx.AuthMethodConsoleAPI
+		return nil
+	}))
+
+	enc := aktcodec.MakeEncodingConfig()
+	input := &promptCountingReader{Reader: strings.NewReader("testpass123\n")}
+	keyrings := aktkeyring.NewManager(root, keyringConfig, enc.Codec)
+	keyrings.SetInput(input)
+
+	leaf := commandTree("mcp")
+	resolved, err := MustResolveAndInit(
+		leaf,
+		mgr,
+		keyrings,
+		enc,
+		"",
+		"",
+		LocalIdentityRequired,
+	)
+	require.NoError(t, err)
+	require.True(t, resolved)
+	require.Zero(t, input.reads)
+	require.Nil(t, sdkclient.GetClientContextFromCmd(leaf).Keyring)
 }
 
 func commandTree(path ...string) *cobra.Command {

--- a/internal/client/local_identity_test.go
+++ b/internal/client/local_identity_test.go
@@ -1,0 +1,144 @@
+package client
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	aktcodec "pkg.akt.dev/akt/internal/codec"
+	aktctx "pkg.akt.dev/akt/internal/context"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
+)
+
+// promptCountingReader counts reads of the keyring manager's input. The file
+// backend's passphrase prompt is the only thing that reads it, so a non-zero
+// count is a prompt the user would have had to answer.
+type promptCountingReader struct {
+	io.Reader
+	reads int
+}
+
+func (r *promptCountingReader) Read(p []byte) (int, error) {
+	r.reads++
+	return r.Reader.Read(p)
+}
+
+// lockedContext seeds a home whose active context has a file-backed keyring
+// and a *named* default account -- the shape that made offline commands
+// prompt, because resolving the name means unlocking the keyring.
+func lockedContext(t *testing.T) (*aktctx.Manager, []aktctx.Keyring, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	enc := aktcodec.MakeEncodingConfig()
+
+	mgr, err := aktctx.NewManager(root)
+	require.NoError(t, err)
+	require.NoError(t, mgr.CreateNetwork(aktctx.Network{
+		Name:    "mainnet",
+		ChainID: "akashnet-2",
+		Endpoints: aktctx.Endpoints{
+			RPC: []string{"https://rpc.example.test"},
+		},
+	}))
+	require.NoError(t, mgr.CreateKeyring(aktctx.Keyring{
+		Name:    "locked",
+		Backend: sdkkeyring.BackendFile,
+	}))
+	require.NoError(t, mgr.CreateContext(aktctx.Context{
+		Name:           "locked",
+		Network:        aktctx.Network{Name: "mainnet"},
+		Keyring:        aktctx.Keyring{Name: "locked"},
+		DefaultAccount: "alice",
+	}))
+	require.NoError(t, mgr.UseContext("locked"))
+
+	keyringConfig := []aktctx.Keyring{{Name: "locked", Backend: sdkkeyring.BackendFile}}
+
+	setupManager := aktkeyring.NewManager(root, keyringConfig, enc.Codec)
+	setupManager.SetInput(strings.NewReader("testpass123\ntestpass123\n"))
+	setupKeyring, err := setupManager.Get("locked")
+	require.NoError(t, err)
+	_, _, err = setupKeyring.NewMnemonic(
+		"alice",
+		sdkkeyring.English,
+		"m/44'/118'/0'/0/0",
+		"",
+		aktkeyring.DefaultAlgo(),
+	)
+	require.NoError(t, err)
+
+	return mgr, keyringConfig, root
+}
+
+// TestOfflineCommandsDoNotOpenTheKeyring pins the promise that `akt sdl` and
+// `akt monitor` run entirely locally (SPEC §2.11, §2.6). Both used to unlock
+// the context's keyring at startup just to turn a named default-account into
+// an address neither of them uses, so validating a local YAML file asked for a
+// wallet passphrase.
+func TestOfflineCommandsDoNotOpenTheKeyring(t *testing.T) {
+	commands := map[string][]string{
+		"sdl validate":     {"sdl", "validate"},
+		"monitor":          {"monitor"},
+		"monitor provider": {"monitor", "provider"},
+		"version":          {"version"},
+	}
+
+	for name, path := range commands {
+		t.Run(name, func(t *testing.T) {
+			mgr, keyringConfig, root := lockedContext(t)
+			enc := aktcodec.MakeEncodingConfig()
+
+			input := &promptCountingReader{Reader: strings.NewReader("testpass123\n")}
+			keyrings := aktkeyring.NewManager(root, keyringConfig, enc.Codec)
+			keyrings.SetInput(input)
+
+			leaf := commandTree(path...)
+
+			resolved, err := MustResolveAndInit(leaf, mgr, keyrings, enc, "", "", false)
+			require.NoError(t, err)
+			require.True(t, resolved)
+			require.Zero(t, input.reads, "an offline command must not read the keyring passphrase prompt")
+		})
+	}
+}
+
+// TestSignerCommandsStillResolveTheDefaultAccount is the other half of the
+// contract: suppressing keyring access for offline commands must not leave
+// signing commands without an identity.
+func TestSignerCommandsStillResolveTheDefaultAccount(t *testing.T) {
+	mgr, keyringConfig, root := lockedContext(t)
+	enc := aktcodec.MakeEncodingConfig()
+
+	keyrings := aktkeyring.NewManager(root, keyringConfig, enc.Codec)
+	keyrings.SetInput(strings.NewReader("testpass123\ntestpass123\ntestpass123\n"))
+
+	leaf := commandTree("tx", "bank", "send")
+
+	resolved, err := MustResolveAndInit(leaf, mgr, keyrings, enc, "", "", true)
+	require.NoError(t, err)
+	require.True(t, resolved)
+
+	cctx := sdkclient.GetClientContextFromCmd(leaf)
+	require.Equal(t, "alice", cctx.FromName)
+	require.False(t, cctx.GetFromAddress().Empty())
+}
+
+func commandTree(path ...string) *cobra.Command {
+	root := &cobra.Command{Use: "akt"}
+
+	parent := root
+	var leaf *cobra.Command
+	for _, name := range path {
+		leaf = &cobra.Command{Use: name}
+		parent.AddCommand(leaf)
+		parent = leaf
+	}
+
+	return leaf
+}

--- a/internal/context/config.go
+++ b/internal/context/config.go
@@ -73,6 +73,19 @@ func ContextWorkflowsDir(root, name string) string {
 	return filepath.Join(root, "contexts", name, "workflows")
 }
 
+const (
+	// KeyringServiceName is the service name akt registers with the OS
+	// keyring backend (Keychain on macOS, libsecret on Linux). The service
+	// name is the lookup key, which is why akt cannot see entries written
+	// by the legacy CLI and vice versa (SPEC §1.12).
+	KeyringServiceName = "akt"
+
+	// LegacyKeyringServiceName is the service name used by the legacy
+	// akash / provider-services CLIs. It exists so the first-run wizard can
+	// explain the mismatch; akt never opens a keyring under this name.
+	LegacyKeyringServiceName = "akash"
+)
+
 // KeyringDir returns the directory for a named keyring.
 func KeyringDir(root string, kr Keyring) string {
 	if kr.Dir != "" {

--- a/internal/context/manager.go
+++ b/internal/context/manager.go
@@ -558,6 +558,44 @@ func (m *Manager) CreateKeyring(kr Keyring) error {
 	return m.save()
 }
 
+// UpdateKeyring mutates an existing keyring definition in place. Without it
+// the only way to change where a context stores its keys after first run was
+// to hand-edit config.yaml (SPEC §2.2.2).
+func (m *Manager) UpdateKeyring(name string, apply func(*Keyring) error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	kr := m.getKeyring(name)
+	if kr == nil {
+		return fmt.Errorf("keyring %q not found", name)
+	}
+
+	if err := apply(kr); err != nil {
+		return err
+	}
+
+	return m.save()
+}
+
+// KeyringUsers returns the names of contexts referencing the named keyring.
+func (m *Manager) KeyringUsers(name string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var users []string
+	for _, ctx := range m.cfg.Contexts {
+		krName := ctx.Keyring.Name
+		if krName == "" {
+			krName = "default"
+		}
+		if krName == name {
+			users = append(users, ctx.Name)
+		}
+	}
+
+	return users
+}
+
 // ---------------------------------------------------------------------------
 // Resolution (compose a full effective context from config + env + flags)
 // ---------------------------------------------------------------------------

--- a/internal/keyring/backend.go
+++ b/internal/keyring/backend.go
@@ -1,0 +1,201 @@
+package keyring
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	krbackend "github.com/99designs/keyring"
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	aktctx "pkg.akt.dev/akt/internal/context"
+)
+
+// Backends returns every keyring backend akt accepts, in the order they are
+// offered to users (SPEC §1.5).
+func Backends() []string {
+	return []string{
+		sdkkeyring.BackendOS,
+		sdkkeyring.BackendFile,
+		sdkkeyring.BackendTest,
+		sdkkeyring.BackendKWallet,
+		sdkkeyring.BackendPass,
+		sdkkeyring.BackendMemory,
+	}
+}
+
+// ValidateBackend reports whether backend names a keyring akt can open. An
+// empty value means "unset" and is accepted: callers treat it as "inherit the
+// configured backend".
+func ValidateBackend(backend string) error {
+	if backend == "" {
+		return nil
+	}
+
+	for _, known := range Backends() {
+		if backend == known {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unknown keyring backend %q; valid backends: %s", backend, strings.Join(Backends(), ", "))
+}
+
+// UnavailableBackendError reports a configured keyring backend that this host
+// cannot provide. It is deliberately fatal rather than a fallback: substituting
+// a different credential store would move the user's keys without telling them
+// (SPEC §1.5).
+type UnavailableBackendError struct {
+	// Keyring is the configured keyring name, e.g. "default".
+	Keyring string
+	// Backend is the configured backend, e.g. "os".
+	Backend string
+	// Expected lists the platform stores that could have served Backend.
+	Expected []string
+}
+
+func (e *UnavailableBackendError) Error() string {
+	expected := "none on this platform"
+	if len(e.Expected) > 0 {
+		expected = strings.Join(e.Expected, " or ")
+	}
+
+	return fmt.Sprintf(
+		"keyring %q is configured with backend %q, but this host provides no system credential store (looked for %s)\n"+
+			"akt will not silently store keys somewhere else; select a backend this host has:\n"+
+			"  akt --keyring-backend file ...            (this invocation only)\n"+
+			"  akt context keyring set %s file           (persist the change)",
+		e.Keyring, e.Backend, expected, e.Keyring)
+}
+
+// EffectiveBackend reports the concrete credential store that serves kr's
+// configured backend on this host, and whether the host can provide it at all.
+//
+// Only "os" is an alias: every other backend is pinned by the SDK to exactly
+// one store, so it is its own effective backend. Resolution is inspection only
+// — it never reads a key, unlocks a store, or prompts.
+func EffectiveBackend(root string, kr aktctx.Keyring) (string, bool) {
+	backend := kr.Backend
+	if backend == "" {
+		backend = sdkkeyring.BackendOS
+	}
+
+	if backend != sdkkeyring.BackendOS {
+		return backend, true
+	}
+
+	effective := resolveSystemBackend(appName, aktctx.KeyringDir(root, kr))
+	if effective == "" {
+		return "", false
+	}
+
+	return effective, true
+}
+
+// SystemKeyringAvailable reports whether this host provides a credential store
+// that can serve the "os" backend (SPEC §1.5). Offering "os" where this is
+// false hands the user a backend that silently becomes something else.
+func SystemKeyringAvailable() bool {
+	// The directory only matters to the file backend, which this probe never
+	// allows, so an empty one is complete.
+	return resolveSystemBackend(appName, "") != ""
+}
+
+// SystemBackendNames names the credential stores that can serve the "os"
+// backend on this platform, whether or not they are present.
+func SystemBackendNames() []string {
+	expected := systemBackends()
+
+	names := make([]string, 0, len(expected))
+	for _, backend := range expected {
+		names = append(names, string(backend))
+	}
+
+	return names
+}
+
+// systemBackends returns the credential stores that may serve "os" on this
+// platform, in the order github.com/99designs/keyring itself considers them.
+func systemBackends() []krbackend.BackendType {
+	switch runtime.GOOS {
+	case "darwin":
+		return []krbackend.BackendType{krbackend.KeychainBackend}
+	case "windows":
+		return []krbackend.BackendType{krbackend.WinCredBackend}
+	case "linux":
+		return []krbackend.BackendType{krbackend.SecretServiceBackend, krbackend.KWalletBackend}
+	}
+
+	return nil
+}
+
+// resolveSystemBackend returns the system credential store that the "os"
+// backend resolves to, or "" when this host has none.
+//
+// The check is a pinned open of each candidate rather than a registration
+// lookup: github.com/99designs/keyring registers the kernel keyring
+// unconditionally on Linux and only fails when its opener runs, and a
+// registered Secret Service can still fail to connect. Because the library
+// orders every OS-specific backend ahead of "pass" and "file", a pinned open
+// that succeeds is also proof that the SDK's unpinned open would land on the
+// same store — which is what lets akt promise that "os" never becomes a file
+// keyring behind the user's back (DESIGN §3.1.2.1).
+func resolveSystemBackend(serviceName, dir string) string {
+	registered := make(map[krbackend.BackendType]bool)
+	for _, backend := range krbackend.AvailableBackends() {
+		registered[backend] = true
+	}
+
+	for _, backend := range systemBackends() {
+		if !registered[backend] {
+			continue
+		}
+
+		cfg := systemKeyringConfig(serviceName, dir)
+		cfg.AllowedBackends = []krbackend.BackendType{backend}
+
+		if _, err := krbackend.Open(cfg); err != nil {
+			continue
+		}
+
+		return string(backend)
+	}
+
+	return ""
+}
+
+// systemKeyringConfig mirrors the Cosmos SDK's own "os" backend config so the
+// probe and the real open agree. FilePasswordFunc is deliberately absent: the
+// file backend is never an allowed backend here, and leaving the prompt
+// unwired makes that structural rather than incidental.
+func systemKeyringConfig(serviceName, dir string) krbackend.Config {
+	return krbackend.Config{
+		ServiceName:              serviceName,
+		FileDir:                  dir,
+		KeychainTrustApplication: true,
+	}
+}
+
+// ApplyOverrides returns keyring configurations with the per-invocation
+// --keyring-backend / --keyring-dir overrides (SPEC §3.1) applied. Empty
+// overrides leave the persisted configuration untouched, so an unset flag can
+// never shadow a context's stored backend.
+func ApplyOverrides(keyrings []aktctx.Keyring, backend, dir string) []aktctx.Keyring {
+	if backend == "" && dir == "" {
+		return keyrings
+	}
+
+	out := make([]aktctx.Keyring, len(keyrings))
+	copy(out, keyrings)
+
+	for i := range out {
+		if backend != "" {
+			out[i].Backend = backend
+		}
+		if dir != "" {
+			out[i].Dir = dir
+		}
+	}
+
+	return out
+}

--- a/internal/keyring/backend_test.go
+++ b/internal/keyring/backend_test.go
@@ -1,0 +1,177 @@
+package keyring_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	aktcodec "pkg.akt.dev/akt/internal/codec"
+	aktctx "pkg.akt.dev/akt/internal/context"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
+)
+
+// TestEffectiveBackendPinsNonAliasBackends: every backend except "os" is
+// pinned by the SDK to exactly one store, so it is its own effective backend
+// on every host.
+func TestEffectiveBackendPinsNonAliasBackends(t *testing.T) {
+	root := t.TempDir()
+
+	for _, backend := range []string{
+		sdkkeyring.BackendFile,
+		sdkkeyring.BackendTest,
+		sdkkeyring.BackendKWallet,
+		sdkkeyring.BackendPass,
+		sdkkeyring.BackendMemory,
+	} {
+		effective, ok := aktkeyring.EffectiveBackend(root, aktctx.Keyring{Name: "default", Backend: backend})
+		if !ok {
+			t.Errorf("backend %q reported unavailable", backend)
+		}
+		if effective != backend {
+			t.Errorf("backend %q resolved to %q, want itself", backend, effective)
+		}
+	}
+}
+
+// TestEffectiveBackendResolvesOSToASystemStore: "os" must never report itself.
+// It is an alias, and echoing it back is exactly how a headless host ended up
+// claiming the system keyring while the SDK used an encrypted file.
+func TestEffectiveBackendResolvesOSToASystemStore(t *testing.T) {
+	root := t.TempDir()
+
+	effective, ok := aktkeyring.EffectiveBackend(root, aktctx.Keyring{Name: "default", Backend: sdkkeyring.BackendOS})
+
+	if !ok {
+		if effective != "" {
+			t.Errorf("an unavailable backend must resolve to no store, got %q", effective)
+		}
+		return
+	}
+
+	if effective == sdkkeyring.BackendOS {
+		t.Error(`"os" resolved to itself; it must name the concrete platform store`)
+	}
+
+	system := aktkeyring.SystemBackendNames()
+	for _, name := range system {
+		if effective == name {
+			return
+		}
+	}
+
+	t.Errorf("os resolved to %q, which is not one of this platform's system stores %v", effective, system)
+}
+
+// TestEmptyBackendMeansOS pins the documented default (SPEC §1.5): an omitted
+// backend is "os", not "whatever opens".
+func TestEmptyBackendMeansOS(t *testing.T) {
+	root := t.TempDir()
+
+	empty, emptyOK := aktkeyring.EffectiveBackend(root, aktctx.Keyring{Name: "default"})
+	explicit, explicitOK := aktkeyring.EffectiveBackend(root, aktctx.Keyring{Name: "default", Backend: sdkkeyring.BackendOS})
+
+	if empty != explicit || emptyOK != explicitOK {
+		t.Errorf("empty backend resolved to (%q, %v), want the same as os (%q, %v)",
+			empty, emptyOK, explicit, explicitOK)
+	}
+}
+
+// TestUnavailableSystemKeyringFailsWithARemedy: when the host has no system
+// credential store, opening an "os" keyring must fail rather than silently
+// land on the file backend, and the error must name the way out.
+func TestUnavailableSystemKeyringFailsWithARemedy(t *testing.T) {
+	if aktkeyring.SystemKeyringAvailable() {
+		t.Skip("this host provides a system credential store")
+	}
+
+	root := t.TempDir()
+	cdc := aktcodec.MakeEncodingConfig().Codec
+
+	mgr := aktkeyring.NewManager(root, []aktctx.Keyring{{Name: "default", Backend: sdkkeyring.BackendOS}}, cdc)
+	mgr.SetInput(strings.NewReader(""))
+
+	_, err := mgr.Get("default")
+	if err == nil {
+		t.Fatal("expected an error opening os on a host with no system credential store")
+	}
+
+	var unavailable *aktkeyring.UnavailableBackendError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected UnavailableBackendError, got %T: %v", err, err)
+	}
+
+	for _, want := range []string{"--keyring-backend file", "akt context keyring set"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must name the remedy %q, got:\n%s", want, err)
+		}
+	}
+}
+
+// TestUnavailableBackendErrorNamesBothRemedies runs on every host: the
+// message is the entire user-facing value of failing instead of substituting,
+// so it must always name the per-invocation flag and the persistent command.
+func TestUnavailableBackendErrorNamesBothRemedies(t *testing.T) {
+	err := &aktkeyring.UnavailableBackendError{
+		Keyring:  "default",
+		Backend:  sdkkeyring.BackendOS,
+		Expected: []string{"secret-service", "kwallet"},
+	}
+
+	for _, want := range []string{
+		`keyring "default"`,
+		`backend "os"`,
+		"secret-service or kwallet",
+		"--keyring-backend file",
+		"akt context keyring set default file",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must contain %q, got:\n%s", want, err)
+		}
+	}
+}
+
+func TestValidateBackendRejectsUnknownValues(t *testing.T) {
+	if err := aktkeyring.ValidateBackend(""); err != nil {
+		t.Errorf("an unset backend must be accepted as inherit: %v", err)
+	}
+
+	for _, backend := range aktkeyring.Backends() {
+		if err := aktkeyring.ValidateBackend(backend); err != nil {
+			t.Errorf("advertised backend %q rejected: %v", backend, err)
+		}
+	}
+
+	if err := aktkeyring.ValidateBackend("keychain"); err == nil {
+		t.Error("expected an error for a store name that is not a configurable backend")
+	}
+}
+
+func TestApplyOverridesLeavesUnsetValuesAlone(t *testing.T) {
+	configured := []aktctx.Keyring{
+		{Name: "default", Backend: sdkkeyring.BackendOS, Dir: "/configured"},
+		{Name: "other", Backend: sdkkeyring.BackendTest},
+	}
+
+	unchanged := aktkeyring.ApplyOverrides(configured, "", "")
+	if unchanged[0].Backend != sdkkeyring.BackendOS || unchanged[0].Dir != "/configured" {
+		t.Errorf("unset overrides must not touch the stored config, got %+v", unchanged[0])
+	}
+
+	overridden := aktkeyring.ApplyOverrides(configured, sdkkeyring.BackendFile, "")
+	for _, kr := range overridden {
+		if kr.Backend != sdkkeyring.BackendFile {
+			t.Errorf("keyring %q kept backend %q, want the override", kr.Name, kr.Backend)
+		}
+	}
+	if overridden[0].Dir != "/configured" {
+		t.Errorf("an unset --keyring-dir must not clear the configured dir, got %q", overridden[0].Dir)
+	}
+
+	// The input slice must survive: the manager is built from the config the
+	// context manager still owns.
+	if configured[0].Backend != sdkkeyring.BackendOS {
+		t.Error("ApplyOverrides mutated its input")
+	}
+}

--- a/internal/keyring/deferred.go
+++ b/internal/keyring/deferred.go
@@ -1,0 +1,251 @@
+package keyring
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+)
+
+// DeferredLoader opens the configured keyring when an operation first needs
+// key material. The returned keyring or error is cached for the process.
+type DeferredLoader func() (sdkkeyring.Keyring, error)
+
+// deferredKeyring implements the Cosmos SDK Keyring interface without opening
+// its backend during client-context construction. Backend is metadata and is
+// therefore the only method that does not resolve the wrapped keyring.
+type deferredKeyring struct {
+	backend string
+	loader  DeferredLoader
+	once    sync.Once
+	keyring sdkkeyring.Keyring
+	err     error
+}
+
+// NewDeferred returns a keyring proxy that invokes loader on its first key
+// operation. It is used by public reads that may need a named default account
+// later but must not prompt merely because the context has one configured.
+func NewDeferred(backend string, loader DeferredLoader) sdkkeyring.Keyring {
+	return &deferredKeyring{backend: backend, loader: loader}
+}
+
+func (d *deferredKeyring) resolve() (sdkkeyring.Keyring, error) {
+	d.once.Do(func() {
+		d.keyring, d.err = d.loader()
+		if d.keyring == nil && d.err == nil {
+			d.err = errors.New("deferred keyring loader returned no keyring")
+		}
+	})
+
+	return d.keyring, d.err
+}
+
+func (d *deferredKeyring) Backend() string {
+	return d.backend
+}
+
+func (d *deferredKeyring) List() ([]*sdkkeyring.Record, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return kr.List()
+}
+
+func (d *deferredKeyring) SupportedAlgorithms() (sdkkeyring.SigningAlgoList, sdkkeyring.SigningAlgoList) {
+	// Manager opens SDK keyrings without custom algorithm options, so these
+	// lists are backend-independent metadata and need not resolve the store.
+	algorithms := sdkkeyring.SigningAlgoList{hd.Secp256k1}
+	return algorithms, algorithms
+}
+
+func (d *deferredKeyring) Key(uid string) (*sdkkeyring.Record, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return kr.Key(uid)
+}
+
+func (d *deferredKeyring) KeyByAddress(address sdk.Address) (*sdkkeyring.Record, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return kr.KeyByAddress(address)
+}
+
+func (d *deferredKeyring) Delete(uid string) error {
+	kr, err := d.resolve()
+	if err != nil {
+		return err
+	}
+	return kr.Delete(uid)
+}
+
+func (d *deferredKeyring) DeleteByAddress(address sdk.Address) error {
+	kr, err := d.resolve()
+	if err != nil {
+		return err
+	}
+	return kr.DeleteByAddress(address)
+}
+
+func (d *deferredKeyring) Rename(from, to string) error {
+	kr, err := d.resolve()
+	if err != nil {
+		return err
+	}
+	return kr.Rename(from, to)
+}
+
+func (d *deferredKeyring) NewMnemonic(
+	uid string,
+	language sdkkeyring.Language,
+	hdPath string,
+	bip39Passphrase string,
+	algo sdkkeyring.SignatureAlgo,
+) (*sdkkeyring.Record, string, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, "", err
+	}
+	return kr.NewMnemonic(uid, language, hdPath, bip39Passphrase, algo)
+}
+
+func (d *deferredKeyring) NewAccount(
+	uid string,
+	mnemonic string,
+	bip39Passphrase string,
+	hdPath string,
+	algo sdkkeyring.SignatureAlgo,
+) (*sdkkeyring.Record, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return kr.NewAccount(uid, mnemonic, bip39Passphrase, hdPath, algo)
+}
+
+func (d *deferredKeyring) SaveLedgerKey(
+	uid string,
+	algo sdkkeyring.SignatureAlgo,
+	hrp string,
+	coinType uint32,
+	account uint32,
+	index uint32,
+) (*sdkkeyring.Record, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return kr.SaveLedgerKey(uid, algo, hrp, coinType, account, index)
+}
+
+func (d *deferredKeyring) SaveOfflineKey(uid string, pubkey cryptotypes.PubKey) (*sdkkeyring.Record, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return kr.SaveOfflineKey(uid, pubkey)
+}
+
+func (d *deferredKeyring) SaveMultisig(uid string, pubkey cryptotypes.PubKey) (*sdkkeyring.Record, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return kr.SaveMultisig(uid, pubkey)
+}
+
+func (d *deferredKeyring) Sign(
+	uid string,
+	msg []byte,
+	signMode signing.SignMode,
+) ([]byte, cryptotypes.PubKey, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, nil, err
+	}
+	return kr.Sign(uid, msg, signMode)
+}
+
+func (d *deferredKeyring) SignByAddress(
+	address sdk.Address,
+	msg []byte,
+	signMode signing.SignMode,
+) ([]byte, cryptotypes.PubKey, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, nil, err
+	}
+	return kr.SignByAddress(address, msg, signMode)
+}
+
+func (d *deferredKeyring) ImportPrivKey(uid, armor, passphrase string) error {
+	kr, err := d.resolve()
+	if err != nil {
+		return err
+	}
+	return kr.ImportPrivKey(uid, armor, passphrase)
+}
+
+func (d *deferredKeyring) ImportPrivKeyHex(uid, privKey, algo string) error {
+	kr, err := d.resolve()
+	if err != nil {
+		return err
+	}
+	return kr.ImportPrivKeyHex(uid, privKey, algo)
+}
+
+func (d *deferredKeyring) ImportPubKey(uid, armor string) error {
+	kr, err := d.resolve()
+	if err != nil {
+		return err
+	}
+	return kr.ImportPubKey(uid, armor)
+}
+
+func (d *deferredKeyring) ExportPubKeyArmor(uid string) (string, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return "", err
+	}
+	return kr.ExportPubKeyArmor(uid)
+}
+
+func (d *deferredKeyring) ExportPubKeyArmorByAddress(address sdk.Address) (string, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return "", err
+	}
+	return kr.ExportPubKeyArmorByAddress(address)
+}
+
+func (d *deferredKeyring) ExportPrivKeyArmor(uid, passphrase string) (string, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return "", err
+	}
+	return kr.ExportPrivKeyArmor(uid, passphrase)
+}
+
+func (d *deferredKeyring) ExportPrivKeyArmorByAddress(address sdk.Address, passphrase string) (string, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return "", err
+	}
+	return kr.ExportPrivKeyArmorByAddress(address, passphrase)
+}
+
+func (d *deferredKeyring) MigrateAll() ([]*sdkkeyring.Record, error) {
+	kr, err := d.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return kr.MigrateAll()
+}

--- a/internal/keyring/deferred_test.go
+++ b/internal/keyring/deferred_test.go
@@ -1,0 +1,32 @@
+package keyring
+
+import (
+	"testing"
+
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/stretchr/testify/require"
+
+	aktcodec "pkg.akt.dev/akt/internal/codec"
+)
+
+func TestDeferredKeyringDoesNotLoadForBackendInspection(t *testing.T) {
+	loads := 0
+	deferred := NewDeferred(sdkkeyring.BackendOS, func() (sdkkeyring.Keyring, error) {
+		loads++
+		return NewInMemory(aktcodec.MakeEncodingConfig().Codec), nil
+	})
+
+	require.Equal(t, sdkkeyring.BackendOS, deferred.Backend())
+	supported, ledger := deferred.SupportedAlgorithms()
+	require.NotEmpty(t, supported)
+	require.NotEmpty(t, ledger)
+	require.Zero(t, loads)
+
+	_, err := deferred.List()
+	require.NoError(t, err)
+	require.Equal(t, 1, loads)
+
+	_, err = deferred.List()
+	require.NoError(t, err)
+	require.Equal(t, 1, loads, "the loaded keyring must be cached")
+}

--- a/internal/keyring/manager.go
+++ b/internal/keyring/manager.go
@@ -95,6 +95,23 @@ func (m *Manager) Get(name string) (sdkkeyring.Keyring, error) {
 	return kr, nil
 }
 
+// Deferred returns a proxy that opens the named keyring on its first key
+// operation. Inspecting Backend does not open the configured store.
+func (m *Manager) Deferred(name string) sdkkeyring.Keyring {
+	m.mu.Lock()
+	cfg := m.configs[name]
+	m.mu.Unlock()
+
+	backend := cfg.Backend
+	if backend == "" {
+		backend = sdkkeyring.BackendOS
+	}
+
+	return NewDeferred(backend, func() (sdkkeyring.Keyring, error) {
+		return m.Get(name)
+	})
+}
+
 // Reload updates the keyring configurations (e.g., after config live-reload).
 // Cached keyrings whose config changed are evicted.
 func (m *Manager) Reload(keyrings []aktctx.Keyring) {

--- a/internal/keyring/manager.go
+++ b/internal/keyring/manager.go
@@ -20,7 +20,10 @@ import (
 	aktctx "pkg.akt.dev/akt/internal/context"
 )
 
-const appName = "akt"
+// appName is the service name handed to the SDK keyring. It is defined in
+// internal/context so the first-run wizard can name it when explaining why
+// legacy akash keyring entries are invisible to akt (SPEC §1.12).
+const appName = aktctx.KeyringServiceName
 
 // Manager manages multiple named keyrings. It lazily opens keyrings on
 // first access and caches them for the lifetime of the process.

--- a/internal/keyring/manager.go
+++ b/internal/keyring/manager.go
@@ -8,6 +8,7 @@
 package keyring
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -76,6 +77,13 @@ func (m *Manager) Get(name string) (sdkkeyring.Keyring, error) {
 
 	kr, err := m.open(cfg)
 	if err != nil {
+		// An unavailable backend already names the keyring and its remedy;
+		// prefixing it again buries the remedy behind a second "open keyring".
+		var unavailable *UnavailableBackendError
+		if errors.As(err, &unavailable) {
+			return nil, err
+		}
+
 		return nil, fmt.Errorf("open keyring %q: %w", name, err)
 	}
 
@@ -127,7 +135,30 @@ func (m *Manager) open(cfg aktctx.Keyring) (sdkkeyring.Keyring, error) {
 		backend = sdkkeyring.BackendOS
 	}
 
+	if err := ValidateBackend(backend); err != nil {
+		return nil, err
+	}
+
 	dir := aktctx.KeyringDir(m.root, cfg)
+
+	// "os" is an alias for the platform credential store, and the SDK opens it
+	// without pinning the backend list -- so on a host without one it silently
+	// lands on pass or file while the config keeps claiming "os". Refuse
+	// instead, and name the remedy (SPEC §1.5).
+	if backend == sdkkeyring.BackendOS {
+		if _, ok := EffectiveBackend(m.root, cfg); !ok {
+			name := cfg.Name
+			if name == "" {
+				name = "default"
+			}
+
+			return nil, &UnavailableBackendError{
+				Keyring:  name,
+				Backend:  backend,
+				Expected: SystemBackendNames(),
+			}
+		}
+	}
 
 	// Ensure keyring directory exists for file-based backends.
 	if backend == sdkkeyring.BackendFile || backend == sdkkeyring.BackendTest {
@@ -137,6 +168,20 @@ func (m *Manager) open(cfg aktctx.Keyring) (sdkkeyring.Keyring, error) {
 	}
 
 	return sdkkeyring.New(appName, backend, dir, m.input, m.cdc)
+}
+
+// EffectiveBackend reports the concrete credential store that serves the named
+// keyring on this host (SPEC §1.5), and whether the host can provide it.
+func (m *Manager) EffectiveBackend(name string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cfg, ok := m.configs[name]
+	if !ok {
+		return "", false
+	}
+
+	return EffectiveBackend(m.root, cfg)
 }
 
 // NewInMemory creates an in-memory keyring for dry-run / testing use.

--- a/internal/keyring/manager_test.go
+++ b/internal/keyring/manager_test.go
@@ -34,6 +34,17 @@ func TestGetTestKeyring(t *testing.T) {
 	if kr.Backend() != sdkkeyring.BackendTest {
 		t.Errorf("backend = %q, want %q", kr.Backend(), sdkkeyring.BackendTest)
 	}
+
+	// kr.Backend() only echoes what was asked for -- it would report "os" on a
+	// host where the SDK had silently opened a file keyring instead. Assert
+	// the store this host actually provides as well (SPEC §1.5).
+	effective, available := mgr.EffectiveBackend("default")
+	if !available {
+		t.Fatal("the test backend must be available on every host")
+	}
+	if effective != sdkkeyring.BackendTest {
+		t.Errorf("effective backend = %q, want %q", effective, sdkkeyring.BackendTest)
+	}
 }
 
 func TestGetCached(t *testing.T) {
@@ -104,6 +115,10 @@ func TestGetByName(t *testing.T) {
 
 	if kr.Backend() != sdkkeyring.BackendTest {
 		t.Errorf("backend = %q, want %q", kr.Backend(), sdkkeyring.BackendTest)
+	}
+
+	if effective, available := mgr.EffectiveBackend("mykr"); !available || effective != sdkkeyring.BackendTest {
+		t.Errorf("effective backend = (%q, %v), want (%q, true)", effective, available, sdkkeyring.BackendTest)
 	}
 }
 
@@ -225,6 +240,33 @@ func TestInMemoryKeyring(t *testing.T) {
 
 	if kr.Backend() != sdkkeyring.BackendMemory {
 		t.Errorf("backend = %q, want %q", kr.Backend(), sdkkeyring.BackendMemory)
+	}
+}
+
+// TestReloadAppliesOverriddenBackend covers the per-invocation
+// --keyring-backend override reaching the manager: a context configured for
+// "os" must open the overridden store, which is what makes `akt context keys`
+// usable on a host that cannot provide the configured one.
+func TestReloadAppliesOverriddenBackend(t *testing.T) {
+	root := t.TempDir()
+	cdc := aktcodec.MakeEncodingConfig().Codec
+
+	configured := []aktctx.Keyring{{Name: "default", Backend: sdkkeyring.BackendOS}}
+
+	mgr := aktkeyring.NewManager(root, aktkeyring.ApplyOverrides(configured, sdkkeyring.BackendTest, ""), cdc)
+	mgr.SetInput(strings.NewReader(""))
+
+	kr, err := mgr.Get("default")
+	if err != nil {
+		t.Fatalf("Get with an overridden backend: %v", err)
+	}
+
+	if kr.Backend() != sdkkeyring.BackendTest {
+		t.Errorf("backend = %q, want the override %q", kr.Backend(), sdkkeyring.BackendTest)
+	}
+
+	if effective, available := mgr.EffectiveBackend("default"); !available || effective != sdkkeyring.BackendTest {
+		t.Errorf("effective backend = (%q, %v), want (%q, true)", effective, available, sdkkeyring.BackendTest)
 	}
 }
 

--- a/internal/mcp/marshal/owner.go
+++ b/internal/mcp/marshal/owner.go
@@ -1,0 +1,25 @@
+package marshal
+
+import (
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+
+	aktclient "pkg.akt.dev/akt/internal/client"
+)
+
+// AddressOrDefault returns explicit unchanged, or resolves the account carried
+// by cctx. A named account opens an on-demand keyring only on this fallback.
+func AddressOrDefault(cctx sdkclient.Context, explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+
+	addr, err := aktclient.ResolveAccountAddress(cctx)
+	if err != nil {
+		return "", err
+	}
+	if addr.Empty() {
+		return "", nil
+	}
+
+	return addr.String(), nil
+}

--- a/internal/mcp/marshal/owner_test.go
+++ b/internal/mcp/marshal/owner_test.go
@@ -1,0 +1,44 @@
+package marshal
+
+import (
+	"testing"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/stretchr/testify/require"
+
+	aktcodec "pkg.akt.dev/akt/internal/codec"
+	aktkeyring "pkg.akt.dev/akt/internal/keyring"
+)
+
+func TestAddressOrDefaultDefersNamedAccountLookup(t *testing.T) {
+	kr := aktkeyring.NewInMemory(aktcodec.MakeEncodingConfig().Codec)
+	record, _, err := kr.NewMnemonic(
+		"alice",
+		sdkkeyring.English,
+		"m/44'/118'/0'/0/0",
+		"",
+		aktkeyring.DefaultAlgo(),
+	)
+	require.NoError(t, err)
+	address, err := record.GetAddress()
+	require.NoError(t, err)
+
+	loads := 0
+	deferred := aktkeyring.NewDeferred(kr.Backend(), func() (sdkkeyring.Keyring, error) {
+		loads++
+		return kr, nil
+	})
+	cctx := sdkclient.Context{}.WithFrom("alice").WithKeyring(deferred)
+
+	explicit := "akash1explicit"
+	got, err := AddressOrDefault(cctx, explicit)
+	require.NoError(t, err)
+	require.Equal(t, explicit, got)
+	require.Zero(t, loads)
+
+	got, err = AddressOrDefault(cctx, "")
+	require.NoError(t, err)
+	require.Equal(t, address.String(), got)
+	require.Equal(t, 1, loads)
+}

--- a/internal/mcp/tools/bank/tools.go
+++ b/internal/mcp/tools/bank/tools.go
@@ -30,13 +30,12 @@ func ToolAccountBalance() mcp.Tool {
 // HandleAccountBalance returns the handler for the account_balance tool.
 func HandleAccountBalance(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		addr := marshal.OptionalString(req, "address")
+		addr, err := marshal.AddressOrDefault(cl.ClientContext(), marshal.OptionalString(req, "address"))
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve account address: %v", err), nil
+		}
 		if addr == "" {
-			fromAddr := cl.ClientContext().GetFromAddress()
-			if fromAddr == nil {
-				return marshal.ErrResult("no address provided and no key configured"), nil
-			}
-			addr = fromAddr.String()
+			return marshal.ErrResult("no address provided and no default account configured"), nil
 		}
 
 		denom := marshal.OptionalString(req, "denom")

--- a/internal/mcp/tools/cert/tools.go
+++ b/internal/mcp/tools/cert/tools.go
@@ -30,11 +30,9 @@ func ToolListCertificates() mcp.Tool {
 // HandleListCertificates returns the handler for listing certificates.
 func HandleListCertificates(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		owner := marshal.OptionalString(req, "owner")
-		if owner == "" {
-			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
-				owner = addr.String()
-			}
+		owner, err := marshal.AddressOrDefault(cl.ClientContext(), marshal.OptionalString(req, "owner"))
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve owner address: %v", err), nil
 		}
 
 		if owner == "" {

--- a/internal/mcp/tools/deployment/tools.go
+++ b/internal/mcp/tools/deployment/tools.go
@@ -32,11 +32,9 @@ func ToolListDeployments() mcp.Tool {
 // HandleListDeployments returns the handler for listing deployments.
 func HandleListDeployments(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		owner := marshal.OptionalString(req, "owner")
-		if owner == "" {
-			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
-				owner = addr.String()
-			}
+		owner, err := marshal.AddressOrDefault(cl.ClientContext(), marshal.OptionalString(req, "owner"))
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve owner address: %v", err), nil
 		}
 
 		if owner == "" {
@@ -77,11 +75,9 @@ func ToolGetDeployment() mcp.Tool {
 // HandleGetDeployment returns the handler for getting a deployment.
 func HandleGetDeployment(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		owner := marshal.OptionalString(req, "owner")
-		if owner == "" {
-			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
-				owner = addr.String()
-			}
+		owner, err := marshal.AddressOrDefault(cl.ClientContext(), marshal.OptionalString(req, "owner"))
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve owner address: %v", err), nil
 		}
 		if owner == "" {
 			return marshal.ErrResult("owner address is required"), nil
@@ -129,11 +125,9 @@ func ToolGetGroup() mcp.Tool {
 // HandleGetGroup returns the handler for getting a deployment group.
 func HandleGetGroup(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		owner := marshal.OptionalString(req, "owner")
-		if owner == "" {
-			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
-				owner = addr.String()
-			}
+		owner, err := marshal.AddressOrDefault(cl.ClientContext(), marshal.OptionalString(req, "owner"))
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve owner address: %v", err), nil
 		}
 		if owner == "" {
 			return marshal.ErrResult("owner address is required"), nil
@@ -184,9 +178,17 @@ func HandleCloseDeployment(cl v1beta3.Client) mcpserver.ToolHandlerFunc {
 			return marshal.ErrResultf("%v", err), nil
 		}
 
+		owner, err := marshal.AddressOrDefault(cl.ClientContext(), "")
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve owner address: %v", err), nil
+		}
+		if owner == "" {
+			return marshal.ErrResult("owner address is required: configure a default account"), nil
+		}
+
 		msg := &dtypes.MsgCloseDeployment{
 			ID: dv1.DeploymentID{
-				Owner: cl.ClientContext().GetFromAddress().String(),
+				Owner: owner,
 				DSeq:  dseq,
 			},
 		}

--- a/internal/mcp/tools/market/tools.go
+++ b/internal/mcp/tools/market/tools.go
@@ -34,11 +34,9 @@ func ToolListOrders() mcp.Tool {
 // HandleListOrders returns the handler for listing orders.
 func HandleListOrders(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		owner := marshal.OptionalString(req, "owner")
-		if owner == "" {
-			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
-				owner = addr.String()
-			}
+		owner, err := marshal.AddressOrDefault(cl.ClientContext(), marshal.OptionalString(req, "owner"))
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve owner address: %v", err), nil
 		}
 
 		if owner == "" {
@@ -143,11 +141,9 @@ func ToolListBids() mcp.Tool {
 // HandleListBids returns the handler for listing bids.
 func HandleListBids(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		owner := marshal.OptionalString(req, "owner")
-		if owner == "" {
-			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
-				owner = addr.String()
-			}
+		owner, err := marshal.AddressOrDefault(cl.ClientContext(), marshal.OptionalString(req, "owner"))
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve owner address: %v", err), nil
 		}
 
 		if owner == "" {
@@ -272,11 +268,9 @@ func ToolListLeases() mcp.Tool {
 // HandleListLeases returns the handler for listing leases.
 func HandleListLeases(cl v1beta3.LightClient) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		owner := marshal.OptionalString(req, "owner")
-		if owner == "" {
-			if addr := cl.ClientContext().GetFromAddress(); !addr.Empty() {
-				owner = addr.String()
-			}
+		owner, err := marshal.AddressOrDefault(cl.ClientContext(), marshal.OptionalString(req, "owner"))
+		if err != nil {
+			return marshal.ErrResultf("failed to resolve owner address: %v", err), nil
 		}
 
 		if owner == "" {

--- a/internal/mcp/tools/provider/tools.go
+++ b/internal/mcp/tools/provider/tools.go
@@ -13,6 +13,7 @@ import (
 	ptypes "pkg.akt.dev/go/node/provider/v1beta4"
 	rest "pkg.akt.dev/go/provider/client"
 
+	aktclient "pkg.akt.dev/akt/internal/client"
 	"pkg.akt.dev/akt/internal/mcp/marshal"
 	aktprovider "pkg.akt.dev/akt/internal/provider"
 )
@@ -316,6 +317,10 @@ func gatewayClient(
 	authType string,
 ) (rest.Client, error) {
 	cctx := cl.ClientContext()
-	addr := cctx.GetFromAddress()
+	addr, err := aktclient.ResolveAccountAddress(cctx)
+	if err != nil {
+		return nil, err
+	}
+	cctx = cctx.WithFromAddress(addr)
 	return aktprovider.NewGatewayClient(ctx, cctx, addr, providerURL, authType, cctx.Keyring)
 }

--- a/internal/output/pretty/context.go
+++ b/internal/output/pretty/context.go
@@ -11,7 +11,13 @@ import (
 
 // RenderContextShow renders a full context detail view as a string.
 // Used by both CLI "akt context show" and TUI context detail views.
-func RenderContextShow(rc aktctx.Context) string {
+//
+// effectiveKeyringBackend is the concrete credential store that serves the
+// context's configured backend on this host, or "" when the host cannot
+// provide it (SPEC §1.5). It is passed in rather than resolved here so the
+// renderer stays a pure formatter -- and so this view can never be the reason
+// a key store is opened.
+func RenderContextShow(rc aktctx.Context, effectiveKeyringBackend string) string {
 	var buf strings.Builder
 	w := &buf
 
@@ -66,7 +72,24 @@ func RenderContextShow(rc aktctx.Context) string {
 		}
 	}
 
-	KV(w, "Keyring", fmt.Sprintf("%s (backend: %s)", rc.Keyring.Name, rc.Keyring.Backend))
+	// An omitted backend means "os", the same normalization the keyring
+	// manager applies before opening.
+	configuredBackend := rc.Keyring.Backend
+	if configuredBackend == "" {
+		configuredBackend = aktctx.DefaultKeyring().Backend
+	}
+
+	KV(w, "Keyring", fmt.Sprintf("%s (backend: %s)", rc.Keyring.Name, configuredBackend))
+
+	// "os" is an alias for a platform store, so the configured value alone is
+	// not an answer to "where are my keys?". Report the concrete store, and
+	// say so plainly when this host has none.
+	switch {
+	case effectiveKeyringBackend == "":
+		SubKV(w, "Effective", Dim("unavailable — this host has no "+configuredBackend+" credential store"))
+	case effectiveKeyringBackend != configuredBackend:
+		SubKV(w, "Effective", effectiveKeyringBackend)
+	}
 
 	if rc.DefaultAccount != "" {
 		KV(w, "Default Account", rc.DefaultAccount)

--- a/internal/output/pretty/context_test.go
+++ b/internal/output/pretty/context_test.go
@@ -1,6 +1,7 @@
 package pretty
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/x/exp/golden"
@@ -11,8 +12,12 @@ import (
 func TestRenderContextShow(t *testing.T) {
 	tests := map[string]struct {
 		ctx aktctx.Context
+		// effective is the credential store that serves ctx.Keyring.Backend
+		// on the host; "" means the host cannot provide it (SPEC §1.5).
+		effective string
 	}{
 		"Full": {
+			effective: "keychain",
 			ctx: aktctx.Context{
 				Name: "production",
 				Network: aktctx.Network{
@@ -40,6 +45,7 @@ func TestRenderContextShow(t *testing.T) {
 			},
 		},
 		"Minimal": {
+			effective: "test",
 			ctx: aktctx.Context{
 				Name: "local",
 				Network: aktctx.Network{
@@ -65,7 +71,28 @@ func TestRenderContextShow(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			golden.RequireEqual(t, RenderContextShow(tc.ctx))
+			golden.RequireEqual(t, RenderContextShow(tc.ctx, tc.effective))
 		})
+	}
+}
+
+// TestRenderContextShowReportsUnavailableKeyring pins the honest form of the
+// keyring line: a configured backend the host cannot provide is reported as
+// unavailable, never echoed back as if it were in use (SPEC §1.5).
+func TestRenderContextShowReportsUnavailableKeyring(t *testing.T) {
+	rc := aktctx.Context{
+		Name:    "headless",
+		Network: aktctx.Network{Name: "mainnet", ChainID: "akashnet-2"},
+		Keyring: aktctx.Keyring{Name: "default", Backend: "os"},
+		Root:    "/home/user/.akt",
+	}
+
+	out := RenderContextShow(rc, "")
+
+	if !strings.Contains(out, "unavailable") {
+		t.Errorf("expected the keyring line to report unavailability, got:\n%s", out)
+	}
+	if strings.Contains(out, "Effective:     os") {
+		t.Errorf("an unavailable backend must not be reported as effective, got:\n%s", out)
 	}
 }

--- a/internal/output/pretty/testdata/TestRenderContextShow/Full.golden
+++ b/internal/output/pretty/testdata/TestRenderContextShow/Full.golden
@@ -11,6 +11,7 @@
 
   [38;2;113;113;122mAuth Method:[m         keyring
   [38;2;113;113;122mKeyring:[m             default (backend: os)
+      [38;2;113;113;122mEffective:[m       keychain
   [38;2;113;113;122mDefault Account:[m     deployer
   [38;2;113;113;122mGas:[m                 auto
   [38;2;113;113;122mFees:[m                5000uakt


### PR DESCRIPTION
## Summary

- defer keyring backend access until a command actually needs key material
- keep public queries, provider status, MCP startup, SDL/store/monitor commands,
  workflow dry-runs, and address-only transaction construction non-interactive
- resolve named default accounts on demand for owner-scoped queries and MCP tools
- refuse unavailable `os` backends instead of silently falling back to file/pass
- expose consistent global keyring overrides and persistent keyring management
- make first-run network selection explicit, default its cursor to a test network,
  show every resolved path, and explain legacy Akash key/certificate migration
- keep Console-only contexts usable without any local account or keyring

## Reproduction

The reported failure was a network-wide command prompting for a wallet it did
not use:

```console
$ akt q provider list
Enter keyring passphrase (attempt 1/3):
```

Strict backend validation exposed the same root problem more broadly: on a
headless context configured for `os`, public queries, `provider status`, MCP
startup, workflow dry-runs, and unsigned transaction construction all failed
before reaching their handlers.

The client-context boundary now has three explicit modes: no identity, deferred
identity, and required identity. A deferred keyring opens once, at the first
real key operation, while explicit addresses never touch it.

## Validation

- `GOWORK=off CGO_ENABLED=0 go build -tags
  "osusergo,netgo,nolink_libwasmvm" -o .cache/bin/akt ./cmd/akt`
- `GOWORK=off CGO_ENABLED=0 go test -tags
  "osusergo,netgo,nolink_libwasmvm" ./... -count=1`
- `GOWORK=off CGO_ENABLED=0 go vet -tags
  "osusergo,netgo,nolink_libwasmvm" ./internal/... ./cmd/...`
- `gofmt -l internal cmd e2e` (empty)
- `git diff --check`
- headless smoke: `provider status` reached the supplied gateway, workflow
  dry-run exited 0, address-only offline generation emitted unsigned tx JSON,
  and MCP started then exited cleanly on EOF without opening the unavailable
  configured OS keyring
