### PR TITLE
fix(provider): resolve gateways from active deployment leases

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,42 @@
 
 ### Fixed
 
+- **Provider commands demanded a provider `akt` had already chosen, and
+  suggested a shortcut that did not work**: every lease-scoped `akt provider`
+  command now resolves the provider from the deployment's active lease on
+  chain, exactly as `akt console status <dseq>` already does, so `akt provider
+  lease-status 12345` needs no `--provider` for a deployment `akt` set up
+  itself. `--provider` remains an optional override for choosing between
+  several active leases, and never became a required flag. Ambiguity is refused
+  rather than guessed: the error distinguishes a deployment with no leases,
+  with no *active* lease (listing the states that exist), and with several
+  active leases (listing every provider address in full), and points at `akt
+  query market lease <dseq>`. The resolved lease also supplies `gseq`/`oseq`
+  unless they were named explicitly, so a lease on a re-ordered group is
+  reachable. `send-manifest` without `--provider` now delivers to every
+  provider with an active lease, the behavior the spec had documented but never
+  implemented. The guard order was inverted so a command missing everything
+  reports the missing deployment sequence instead of blaming the provider, and
+  the eight lease commands no longer advertise a positional provider argument
+  that none of them accepts — on four of them that positional slot is the
+  `dseq`, so following the old hint produced a second, more confusing parse
+  error.
+
+- **The documented provider lookup command did not exist**: `akt query
+  provider <address>` — the form printed in README.md, SPEC §3.8.5, and
+  DESIGN §7.1 — failed with `unknown command "akash1..." for "provider"`
+  because the group carried no positional argument. The provider query is now
+  positional-primary like `query deployment` and `query market lease`: an
+  address returns that provider, no argument lists them all, and the `list` and
+  `get` subcommands keep working unchanged.
+
+- **Provider spec documented flags that did not exist**: `--from` was listed on
+  every lease command but registered nowhere in the provider tree (the owner
+  comes from the context's `default-account`), and `migrate-hostnames` /
+  `migrate-endpoints` documented a `--destination-dseq` that has no
+  counterpart in the gateway API, which addresses the destination lease alone.
+  SPEC §2.4 now matches the command surface.
+
 - **Strict keyring validation blocked commands that never used a key**: the
   startup identity boundary now distinguishes no access, deferred access, and
   required access. Public queries, provider status, MCP startup, workflow

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -365,6 +365,8 @@ A `console-api` context has no wallet, yet the operations users reach for most a
 
 **Why this shape**: Akash Console fronts provider gateways with a server-side `provider-proxy` websocket relay. `akt` is a native client that can reach the gateway directly, so it deliberately does **not** reimplement that relay. Step 4 hands off to the same provider client and the same streaming code paths that back `akt provider lease-status`, `lease-logs`, `lease-events`, and `lease-shell` — one implementation of log streaming, event streaming, and PTY handling, exercised by both rails. The Console-minted JWT simply substitutes for the wallet-signed JWT a keyring context would present, so `akt console status|logs|events|shell` and their `akt provider` counterparts cannot drift apart.
 
+Step 1 — resolving the deployment to its active lease, and from that lease to a provider — is a **rail-independent** identification, not a Console feature. The keyring rail performs the same resolution against the chain's market module (`internal/cli/provider`): the leases owned by the context's default account for the given `dseq` are queried, and the single active one supplies the provider address plus its `gseq`/`oseq`. `akt console status 12345` and `akt provider lease-status 12345` therefore address the same deployment with the same arguments, and `--provider` exists only to disambiguate a multi-provider deployment or to override the resolution. Making a user restate a provider that `akt` itself selected during `akt deploy` would be per-rail behavior leaking into the command layer, which the transport rule forbids.
+
 The shared gateway boundary also normalizes protocol details that providers do
 not implement uniformly. It resolves a provider address to the on-chain host
 URI unless the user supplies an explicit URL override, verifies a lease before
@@ -1050,7 +1052,7 @@ never handle.
 | `akash query market orders`             | `akt query market order [filter]`            | Filter: `[owner/]dseq[/gseq/oseq]`                        |
 | `akash query market bids`               | `akt query market bid [filter]`              | Filter: `[owner/]dseq[/…/provider]`; `--by provider` reverses hierarchy |
 | `akash query market leases`             | `akt query market lease [filter]`            | Filter: `[owner/]dseq[/…/provider]`; `--by provider` reverses hierarchy |
-| `akash query provider list`/`get`       | `akt query provider [address]`               | Optional positional arg (unchanged)                        |
+| `akash query provider list`/`get`       | `akt query provider [address]`               | Address → one provider; no arg → list. `list`/`get` remain as aliases |
 | `akash query cert list`                 | `akt query cert [owner]`                     | Filter by owner; no arg → default account                  |
 | `akash query audit list`/`get`          | `akt query audit [owner]`                    | Filter by owner; no arg → list all                         |
 | `akash query escrow accounts`           | `akt query escrow [filter]`                  | Filter: `[owner[/dseq]]`                                   |
@@ -1071,14 +1073,14 @@ never handle.
 | Current (`provider-services`)         | New (`akt`)                      | Notes              |
 | ------------------------------------- | -------------------------------- | ------------------ |
 | `provider-services status`            | `akt provider status`            | Identical behavior |
-| `provider-services lease-status`      | `akt provider lease-status`      | Identical behavior |
-| `provider-services lease-logs`        | `akt provider lease-logs`        | Identical behavior |
-| `provider-services lease-events`      | `akt provider lease-events`      | Identical behavior |
-| `provider-services lease-shell`       | `akt provider lease-shell`       | Identical behavior |
-| `provider-services send-manifest`     | `akt provider send-manifest`     | Identical behavior |
-| `provider-services get-manifest`      | `akt provider get-manifest`      | Identical behavior |
-| `provider-services migrate-hostnames` | `akt provider migrate-hostnames` | Identical behavior |
-| `provider-services migrate-endpoints` | `akt provider migrate-endpoints` | Identical behavior |
+| `provider-services lease-status`      | `akt provider lease-status`      | `--provider` optional: resolved from the deployment's active lease |
+| `provider-services lease-logs`        | `akt provider lease-logs`        | `--provider` optional: resolved from the deployment's active lease |
+| `provider-services lease-events`      | `akt provider lease-events`      | `--provider` optional: resolved from the deployment's active lease |
+| `provider-services lease-shell`       | `akt provider lease-shell`       | `--provider` optional: resolved from the deployment's active lease |
+| `provider-services send-manifest`     | `akt provider send-manifest`     | `--provider` optional: defaults to every provider with an active lease |
+| `provider-services get-manifest`      | `akt provider get-manifest`      | `--provider` optional: resolved from the deployment's active lease |
+| `provider-services migrate-hostnames` | `akt provider migrate-hostnames` | `--provider` optional: resolved from the destination deployment's active lease |
+| `provider-services migrate-endpoints` | `akt provider migrate-endpoints` | `--provider` optional: resolved from the destination deployment's active lease |
 
 
 ### 7.3 Commands NOT Migrated

--- a/SPEC.md
+++ b/SPEC.md
@@ -694,7 +694,7 @@ akt
 │   │   ├── bid [filter] [state]         # [owner/]dseq[/gseq/oseq[/prov]] [state]; --by; --state — **disabled pending feedback** (positional only, 2026-07)
 │   │   ├── lease [filter] [state]       # [owner/]dseq[/gseq/oseq[/prov]] [state]; --by; --state — **disabled pending feedback** (positional only, 2026-07)
 │   │   └── params
-│   ├── provider [address]               # List or get (address → single)
+│   ├── provider [address]               # List or get (address → single); `list`/`get` remain as aliases
 │   ├── cert [owner] [state]             # Owner or default account, plus [state]; --owner/--state flags — **disabled pending feedback** (positional only, 2026-07)
 │   ├── audit [owner]                    # Owner or default account; --auditor flag
 │   ├── escrow [filter]                  # [owner[/dseq]]; --state flag
@@ -1699,6 +1699,43 @@ Provider status remains public; lease status, service status, and manifest
 submission use the shared authenticated gateway boundary with JWT or mTLS as
 configured.
 
+**Provider resolution for lease-scoped commands.** `--provider` names the
+gateway explicitly and always wins. When it is omitted, `akt` resolves the
+provider from the deployment's leases on chain: it queries the leases owned by
+the selected context's `default-account` for the given deployment sequence and
+uses the provider of the deployment's single active lease. This is the same
+identification `akt console status <dseq>` already performs on the Console rail,
+so a deployment `akt` created is addressed identically on both rails. The
+resolved lease also supplies `gseq`/`oseq` unless they were given explicitly.
+
+Resolution is refused rather than guessed when it is ambiguous or impossible,
+and the error names the actual cause:
+
+- the deployment has no leases at all;
+- it has leases but none active (their states are listed);
+- more than one lease is active (every active provider is listed and
+  `--provider` is required to choose).
+
+Each of those errors points at `akt query market lease <dseq>` for the full
+record. `--provider` is never a cobra-required flag (§3.8): the deployment
+sequence is the primary value and the provider is an optional override.
+
+`--provider-url` overrides the gateway URL, not the provider identity: the
+lease path sent to the gateway still needs a provider address, so without
+`--provider` the lease is read from chain even when a URL is supplied. Because
+one URL cannot address several gateways, combining `--provider-url` with a
+`send-manifest` fan-out over multiple active leases is refused.
+
+Because the provider is resolved *from* the deployment sequence, the sequence is
+validated first. A lease command invoked with neither a `dseq` nor a
+`--provider` reports the missing deployment sequence, not the missing provider,
+and never suggests a positional provider on a command whose positional slot is
+the `dseq`.
+
+The lease owner is always the selected context's `default-account`. The provider
+group has no `--from` flag; select a different account with `akt context use`,
+`--context`, or the context's `default-account` setting.
+
 #### `akt provider lease-status [dseq]`
 
 Query lease deployment status from the provider gateway. The positional `dseq` supplies the deployment sequence. The `--dseq` flag is **disabled pending feedback** (positional only, 2026-07).
@@ -1706,10 +1743,9 @@ Query lease deployment status from the provider gateway. The positional `dseq` s
 | Flag          | Type   | Default         | Description         |
 | ------------- | ------ | --------------- | ------------------- |
 | `--dseq`      | uint64 | required unless positional `dseq` given | Deployment sequence — **disabled pending feedback** (positional only, 2026-07) |
-| `--gseq`      | uint32 | `1`             | Group sequence      |
-| `--oseq`      | uint32 | `1`             | Order sequence      |
-| `--provider`  | string | required        | Provider address    |
-| `--from`      | string | context default | Owner account       |
+| `--gseq`      | uint32 | active lease    | Group sequence      |
+| `--oseq`      | uint32 | active lease    | Order sequence      |
+| `--provider`  | string | active lease    | Provider address; resolved from the deployment's active lease when omitted |
 | `--auth-type` | string | context default | Auth type           |
 
 #### `akt provider lease-logs [dseq]`
@@ -1719,10 +1755,9 @@ Stream container logs from a lease. The positional `dseq` supplies the deploymen
 | Flag          | Type   | Default         | Description               |
 | ------------- | ------ | --------------- | ------------------------- |
 | `--dseq`      | uint64 | required unless positional `dseq` given | Deployment sequence — **disabled pending feedback** (positional only, 2026-07) |
-| `--gseq`      | uint32 | `1`             | Group sequence            |
-| `--oseq`      | uint32 | `1`             | Order sequence            |
-| `--provider`  | string | required        | Provider address          |
-| `--from`      | string | context default | Owner account             |
+| `--gseq`      | uint32 | active lease    | Group sequence            |
+| `--oseq`      | uint32 | active lease    | Order sequence            |
+| `--provider`  | string | active lease    | Provider address; resolved from the deployment's active lease when omitted |
 | `--service`   | string | `""`            | Filter by service name    |
 | `--follow`    | bool   | `false`         | Stream logs continuously  |
 | `--tail`      | int64  | `-1`            | Lines from end (-1 = all) |
@@ -1746,10 +1781,9 @@ Open an interactive shell into a running container.
 | Flag          | Type   | Default         | Description         |
 | ------------- | ------ | --------------- | ------------------- |
 | `--dseq`      | uint64 | required        | Deployment sequence |
-| `--gseq`      | uint32 | `1`             | Group sequence      |
-| `--oseq`      | uint32 | `1`             | Order sequence      |
-| `--provider`  | string | required        | Provider address    |
-| `--from`      | string | context default | Owner account       |
+| `--gseq`      | uint32 | active lease    | Group sequence      |
+| `--oseq`      | uint32 | active lease    | Order sequence      |
+| `--provider`  | string | active lease    | Provider address; resolved from the deployment's active lease when omitted |
 | `--service`   | string | required        | Service name        |
 | `--tty`       | bool   | `true`          | Allocate a TTY      |
 | `--stdin`     | bool   | `false`         | Force stdin attachment for an explicit terminal command |
@@ -1776,30 +1810,39 @@ Send an SDL manifest to provider(s) for an existing lease.
 | Flag          | Type   | Default         | Description                                                   |
 | ------------- | ------ | --------------- | ------------------------------------------------------------- |
 | `--dseq`      | uint64 | required        | Deployment sequence                                           |
-| `--from`      | string | context default | Owner account                                                 |
 | `--provider`  | string | `""`            | Specific provider (default: all providers with active leases) |
 | `--auth-type` | string | context default | Auth type                                                     |
 
+Unlike the other lease-scoped commands, `send-manifest` fans out: with no
+`--provider` it submits the manifest to **every** provider holding an active
+lease for the deployment, which is the same delivery the `update` workflow's
+manifest step performs (§2.3). Every provider is attempted even when an earlier
+one rejects the manifest, each accepted submission is reported by full provider
+address, and the command fails unless all of them accepted. A deployment with a
+single active lease therefore needs no `--provider` at all.
+
 #### `akt provider get-manifest [dseq]`
 
-Retrieve the current manifest from a provider. The positional `dseq` supplies the deployment sequence. The `--dseq` flag is **disabled pending feedback** (positional only, 2026-07).
+Retrieve the current manifest from a provider. The positional `dseq` supplies the deployment sequence. The `--dseq` flag is **disabled pending feedback** (positional only, 2026-07). `--provider` is resolved from the deployment's active lease when omitted.
 
 #### `akt provider migrate-hostnames`
 
-Migrate hostnames from one deployment to another on the same provider.
+Migrate hostnames onto a deployment from whichever deployment currently holds
+them on the same provider. The gateway addresses the **destination** lease only,
+so there is no source flag.
 
-| Flag                 | Type     | Default         | Description                |
-| -------------------- | -------- | --------------- | -------------------------- |
-| `--dseq`             | uint64   | required        | Source deployment sequence |
-| `--destination-dseq` | uint64   | required        | Target deployment sequence |
-| `--from`             | string   | context default | Owner account              |
-| `--provider`         | string   | required        | Provider address           |
-| `--hostnames`        | []string | required        | Hostnames to migrate       |
-| `--auth-type`        | string   | context default | Auth type                  |
+| Flag                 | Type     | Default         | Description                            |
+| -------------------- | -------- | --------------- | -------------------------------------- |
+| `--dseq`             | uint64   | required        | Destination deployment sequence        |
+| `--gseq`             | uint32   | active lease    | Destination group sequence             |
+| `--provider`         | string   | active lease    | Provider address; resolved from the destination deployment's active lease when omitted |
+| `--hostnames`        | []string | required        | Hostnames to migrate                   |
+| `--auth-type`        | string   | context default | Auth type                              |
 
 #### `akt provider migrate-endpoints`
 
-Same pattern as `migrate-hostnames` but for IP endpoints.
+Same pattern as `migrate-hostnames`, with `--endpoints` naming the IP endpoints
+to migrate.
 
 **Provider gateway output and stream contract:** provider status, lease
 status, and manifest reads emit JSON by default; `--output json` and
@@ -2826,6 +2869,8 @@ akt query market lease --by provider akash1prov.../12345/1/1/akash1owner...  # G
 ```bash
 akt query cert                                 # List certs for default account
 akt query cert akash1abc...                    # List certs for that owner
+akt query provider                             # List every provider on the network
+akt query provider akash1prov...               # Get one provider (the `get` subcommand remains an alias)
 akt query escrow 12345                         # List escrow accounts for dseq 12345 (owner from context)
 akt query escrow akash1abc.../12345            # Specific escrow account
 ```

--- a/e2e/offline_test.go
+++ b/e2e/offline_test.go
@@ -599,6 +599,91 @@ func TestTxDeploymentClosePositionalArgsOffline(t *testing.T) {
 	}
 }
 
+// TestQueryProviderPositionalArgOffline pins the positional-primary form
+// documented in README.md, SPEC §3.8.5, and DESIGN §7.1. The group used to
+// carry no positional at all, so the documented `akt query provider
+// akash1prov...` failed with `unknown command "akash1..." for "provider"`.
+// The `list`/`get` subcommands must keep working alongside it.
+func TestQueryProviderPositionalArgOffline(t *testing.T) {
+	home := setupContextHome(t)
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"positional address", []string{"query", "provider", testMnemonicAddr, "--node", unreachableNode}},
+		{"no argument lists", []string{"query", "provider", "--node", unreachableNode}},
+		{"get subcommand", []string{"query", "provider", "get", testMnemonicAddr, "--node", unreachableNode}},
+		{"list subcommand", []string{"query", "provider", "list", "--node", unreachableNode}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runAkt(t, home, tc.args...)
+			combined := stdout + stderr
+
+			if exitCode == 0 {
+				t.Fatalf("expected non-zero exit against unreachable node, got 0:\n%s", combined)
+			}
+			if strings.Contains(combined, "unknown command") || strings.Contains(combined, "accepts at most") {
+				t.Fatalf("the documented form was rejected by cobra args validation:\n%s", combined)
+			}
+			if !strings.Contains(combined, "127.0.0.1") {
+				t.Fatalf("expected a connection-stage error mentioning the node address, got:\n%s", combined)
+			}
+		})
+	}
+}
+
+// TestProviderLeaseCommandsBlameTheMissingDSeqOffline pins the honest guard
+// order on the provider gateway commands. Every one of them used to report
+// `provider address is required (positional argument or --provider flag)` for
+// any missing input — false advice, since none takes a positional provider and
+// four of them use that slot for the dseq. The deployment sequence is what the
+// provider is now resolved from, so it must be reported first and with the
+// form the command actually accepts.
+func TestProviderLeaseCommandsBlameTheMissingDSeqOffline(t *testing.T) {
+	home := setupContextHome(t)
+
+	cases := []struct {
+		name   string
+		args   []string
+		remedy string
+	}{
+		{"lease-status", []string{"provider", "lease-status"}, "positional argument"},
+		{"lease-logs", []string{"provider", "lease-logs"}, "positional argument"},
+		{"lease-events", []string{"provider", "lease-events"}, "positional argument"},
+		{"get-manifest", []string{"provider", "get-manifest"}, "positional argument"},
+		{"lease-shell", []string{"provider", "lease-shell", "--", "/bin/sh"}, "--dseq"},
+		{"send-manifest", []string{"provider", "send-manifest", "does-not-exist.yaml"}, "--dseq"},
+		{"migrate-hostnames", []string{"provider", "migrate-hostnames", "--hostnames", "a.example.com"}, "--dseq"},
+		{"migrate-endpoints", []string{"provider", "migrate-endpoints", "--endpoints", "ep1"}, "--dseq"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, exitCode := runAkt(t, home, tc.args...)
+			combined := stdout + stderr
+
+			if exitCode == 0 {
+				t.Fatalf("expected non-zero exit for a missing dseq, got 0:\n%s", combined)
+			}
+			if !strings.Contains(combined, "dseq is required") {
+				t.Fatalf("expected the dseq guard error, got:\n%s", combined)
+			}
+			if !strings.Contains(combined, tc.remedy) {
+				t.Fatalf("expected the remedy to offer %q, got:\n%s", tc.remedy, combined)
+			}
+			if strings.Contains(combined, "provider address is required") {
+				t.Fatalf("error still blames the provider:\n%s", combined)
+			}
+			if strings.Contains(combined, "positional argument or --provider") {
+				t.Fatalf("error advertises a positional provider that does not exist:\n%s", combined)
+			}
+		})
+	}
+}
+
 // --- dseq fail-fast guards (2026-07 positional-only trial) ---
 //
 // With --dseq disabled, the positional dseq is the only source for
@@ -816,6 +901,8 @@ func TestAllCommandsHelp(t *testing.T) {
 		{"query", "oracle"},
 		{"query", "params"},
 		{"query", "provider"},
+		{"query", "provider", "get"},
+		{"query", "provider", "list"},
 		{"query", "slashing"},
 		{"query", "staking"},
 		{"query", "tx"},

--- a/internal/cli/chain/provider_query.go
+++ b/internal/cli/chain/provider_query.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	cflags "pkg.akt.dev/akt/internal/cli/chain/flags"
@@ -11,14 +10,39 @@ import (
 	types "pkg.akt.dev/go/node/provider/v1beta4"
 )
 
-// GetQueryProviderCmds returns the transaction commands for the provider module
+// GetQueryProviderCmds returns the query commands for the provider module.
+// Per the positional-primary convention (SPEC §3.8) the group itself is the
+// query: a positional address returns that provider, no argument lists them
+// all. `list` and `get` remain registered so existing scripts keep working.
 func GetQueryProviderCmds() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                        types.ModuleName,
-		Short:                      "Provider query commands",
+		Use:   types.ModuleName + " [address]",
+		Short: "Query providers",
+		Long: `Query providers.
+
+Without arguments, lists every provider on the network.
+
+[address] is a provider's bech32 account address and returns that provider's
+record alone.`,
+		Example: `  # Every provider on the network
+  akt query provider
+
+  # One provider
+  akt query provider akash1prov...`,
+		Args:                       cobra.MaximumNArgs(1),
 		SuggestionsMinimumDistance: 2,
-		RunE:                       sdkclient.ValidateCmd,
+		PersistentPreRunE:          QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return queryProviderList(cmd)
+			}
+
+			return queryProvider(cmd, args[0])
+		},
 	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+	cflags.AddPaginationFlagsToCmd(cmd, "providers")
 
 	cmd.AddCommand(
 		GetQueryProvidersCmd(),
@@ -33,26 +57,10 @@ func GetQueryProvidersCmd() *cobra.Command {
 		Use:               "list",
 		Args:              cobra.NoArgs,
 		Short:             "Query for all providers",
+		Long:              "Query for all providers. Equivalent to `akt query provider` with no argument.",
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			cl := MustLightClientFromContext(ctx)
-
-			pageReq, err := ReadPageRequest(cmd.Flags())
-			if err != nil {
-				return err
-			}
-
-			params := &types.QueryProvidersRequest{
-				Pagination: pageReq,
-			}
-
-			res, err := cl.Query().Provider().Providers(ctx, params)
-			if err != nil {
-				return err
-			}
-
-			return pretty.PrintQueryResult(cmd, cl.ClientContext(), res)
+			return queryProviderList(cmd)
 		},
 	}
 
@@ -66,27 +74,53 @@ func GetQueryProviderCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "get [address]",
 		Short:             "Query provider",
+		Long:              "Query one provider by address. Equivalent to `akt query provider <address>`.",
 		Args:              cobra.ExactArgs(1),
 		PersistentPreRunE: QueryPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			cl := MustLightClientFromContext(ctx)
-
-			owner, err := sdk.AccAddressFromBech32(args[0])
-			if err != nil {
-				return err
-			}
-
-			res, err := cl.Query().Provider().Provider(cmd.Context(), &types.QueryProviderRequest{Owner: owner.String()})
-			if err != nil {
-				return err
-			}
-
-			return pretty.PrintQueryResult(cmd, cl.ClientContext(), &res.Provider)
+			return queryProvider(cmd, args[0])
 		},
 	}
 
 	cflags.AddQueryFlagsToCmd(cmd)
 
 	return cmd
+}
+
+// queryProviderList prints every provider on the network.
+func queryProviderList(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	cl := MustLightClientFromContext(ctx)
+
+	pageReq, err := ReadPageRequest(cmd.Flags())
+	if err != nil {
+		return err
+	}
+
+	res, err := cl.Query().Provider().Providers(ctx, &types.QueryProvidersRequest{
+		Pagination: pageReq,
+	})
+	if err != nil {
+		return err
+	}
+
+	return pretty.PrintQueryResult(cmd, cl.ClientContext(), res)
+}
+
+// queryProvider prints one provider's record.
+func queryProvider(cmd *cobra.Command, address string) error {
+	ctx := cmd.Context()
+	cl := MustLightClientFromContext(ctx)
+
+	owner, err := sdk.AccAddressFromBech32(address)
+	if err != nil {
+		return err
+	}
+
+	res, err := cl.Query().Provider().Provider(ctx, &types.QueryProviderRequest{Owner: owner.String()})
+	if err != nil {
+		return err
+	}
+
+	return pretty.PrintQueryResult(cmd, cl.ClientContext(), &res.Provider)
 }

--- a/internal/cli/provider/commands.go
+++ b/internal/cli/provider/commands.go
@@ -4,6 +4,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,18 +14,22 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	mtypes "pkg.akt.dev/go/node/market/v1"
+	manifest "pkg.akt.dev/go/manifest/v2beta3"
 	ptypes "pkg.akt.dev/go/node/provider/v1beta4"
 	rest "pkg.akt.dev/go/provider/client"
 	"pkg.akt.dev/go/sdl"
 
 	"pkg.akt.dev/akt/internal/capability"
 	chaincli "pkg.akt.dev/akt/internal/cli/chain"
-	cflags "pkg.akt.dev/akt/internal/cli/chain/flags"
 	aktclient "pkg.akt.dev/akt/internal/client"
 	"pkg.akt.dev/akt/internal/output"
 	aktprovider "pkg.akt.dev/akt/internal/provider"
 )
+
+// leaseProviderHelp is appended to every lease-scoped command's long help so
+// the auto-resolution documented in SPEC §2.4 is discoverable from --help.
+const leaseProviderHelp = "The provider is resolved from the deployment's active lease on chain, " +
+	"so --provider is only needed to choose between several active leases or to override the lookup."
 
 // Commands returns the `akt provider` command group.
 func Commands() *cobra.Command {
@@ -38,7 +43,7 @@ func Commands() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().String("auth-type", "", "Provider auth type: jwt (default) or mtls")
-	cmd.PersistentFlags().String("provider", "", "Provider address (bech32)")
+	cmd.PersistentFlags().String("provider", "", "Provider address (bech32); default: the deployment's active lease")
 	cmd.PersistentFlags().String("provider-url", "", "Provider gateway URL (e.g. https://provider.example.com:8443)")
 
 	cmd.AddCommand(
@@ -97,24 +102,23 @@ func leaseStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lease-status [dseq]",
 		Short: "Query lease deployment status",
-		Long:  "Query the live status of a lease from a provider, including service status, forwarded ports, and IPs.",
-		Args:  cobra.MaximumNArgs(1),
-		Example: `  # Query lease status (positional dseq)
+		Long: "Query the live status of a lease from a provider, including service status, forwarded " +
+			"ports, and IPs. " + leaseProviderHelp,
+		Args: cobra.MaximumNArgs(1),
+		Example: `  # Query lease status (provider resolved from the active lease)
+  akt provider lease-status 12345
+
+  # Pin the provider when several leases are active
   akt provider lease-status 12345 --provider akash1...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			providerAddr, providerURL, err := resolveAuthenticatedProvider(cmd, nil)
+			lid, providerURL, err := resolveAuthenticatedLease(cmd, args)
 			if err != nil {
 				return err
 			}
 
 			cl, err := gatewayClientFromCmd(cmd, providerURL)
-			if err != nil {
-				return err
-			}
-
-			lid, err := leaseIDFromFlags(cmd, args, providerAddr)
 			if err != nil {
 				return err
 			}
@@ -137,16 +141,20 @@ func leaseLogsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lease-logs [dseq]",
 		Short: "Stream container logs",
-		Long:  "Stream container logs from a lease. Supports filtering by service and following output.",
-		Args:  cobra.MaximumNArgs(1),
-		Example: `  # Stream logs for all services (positional dseq)
-  akt provider lease-logs 12345 --provider akash1...
+		Long: "Stream container logs from a lease. Supports filtering by service and following " +
+			"output. " + leaseProviderHelp,
+		Args: cobra.MaximumNArgs(1),
+		Example: `  # Stream logs for all services (provider resolved from the active lease)
+  akt provider lease-logs 12345
 
   # Follow logs for a specific service
-  akt provider lease-logs 12345 --provider akash1... --service web --follow
+  akt provider lease-logs 12345 --service web --follow
 
   # Show last 100 lines
-  akt provider lease-logs 12345 --provider akash1... --tail 100`,
+  akt provider lease-logs 12345 --tail 100
+
+  # Pin the provider when several leases are active
+  akt provider lease-logs 12345 --provider akash1...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			follow, _ := cmd.Flags().GetBool("follow")
@@ -156,17 +164,12 @@ func leaseLogsCmd() *cobra.Command {
 				return err
 			}
 
-			providerAddr, providerURL, err := resolveAuthenticatedProvider(cmd, nil)
+			lid, providerURL, err := resolveAuthenticatedLease(cmd, args)
 			if err != nil {
 				return err
 			}
 
 			cl, err := gatewayClientFromCmd(cmd, providerURL)
-			if err != nil {
-				return err
-			}
-
-			lid, err := leaseIDFromFlags(cmd, args, providerAddr)
 			if err != nil {
 				return err
 			}
@@ -196,28 +199,26 @@ func leaseEventsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lease-events [dseq]",
 		Short: "Stream Kubernetes events",
-		Long:  "Stream Kubernetes events for a lease from the provider.",
+		Long:  "Stream Kubernetes events for a lease from the provider. " + leaseProviderHelp,
 		Args:  cobra.MaximumNArgs(1),
-		Example: `  # Stream events (positional dseq)
-  akt provider lease-events 12345 --provider akash1...
+		Example: `  # Stream events (provider resolved from the active lease)
+  akt provider lease-events 12345
 
   # Follow events
-  akt provider lease-events 12345 --provider akash1... --follow`,
+  akt provider lease-events 12345 --follow
+
+  # Pin the provider when several leases are active
+  akt provider lease-events 12345 --provider akash1...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			follow, _ := cmd.Flags().GetBool("follow")
 
-			providerAddr, providerURL, err := resolveAuthenticatedProvider(cmd, nil)
+			lid, providerURL, err := resolveAuthenticatedLease(cmd, args)
 			if err != nil {
 				return err
 			}
 
 			cl, err := gatewayClientFromCmd(cmd, providerURL)
-			if err != nil {
-				return err
-			}
-
-			lid, err := leaseIDFromFlags(cmd, args, providerAddr)
 			if err != nil {
 				return err
 			}
@@ -245,19 +246,23 @@ func leaseShellCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lease-shell [-- command...]",
 		Short: "Open interactive shell",
-		Long:  "Open an interactive shell session to a container in a lease. The remote command defaults to /bin/sh.",
-		Args:  cobra.ArbitraryArgs,
+		Long: "Open an interactive shell session to a container in a lease. The remote command " +
+			"defaults to /bin/sh. " + leaseProviderHelp,
+		Args: cobra.ArbitraryArgs,
 		Example: `  # Open the default /bin/sh shell
-  akt provider lease-shell --dseq 12345 --provider akash1... --service web
+  akt provider lease-shell --dseq 12345 --service web
 
   # Open a bash shell
-  akt provider lease-shell --dseq 12345 --provider akash1... --service web -- /bin/bash
+  akt provider lease-shell --dseq 12345 --service web -- /bin/bash
 
   # Run a single command
-  akt provider lease-shell --dseq 12345 --provider akash1... --service web -- ls -la
+  akt provider lease-shell --dseq 12345 --service web -- ls -la
 
   # Capture an explicit command as structured stdout and stderr
-  akt provider lease-shell --dseq 12345 --provider akash1... --service web -o json -- pwd`,
+  akt provider lease-shell --dseq 12345 --service web -o json -- pwd
+
+  # Pin the provider when several leases are active
+  akt provider lease-shell --dseq 12345 --provider akash1... --service web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			shellCtx, cancelShell := context.WithCancel(ctx)
@@ -267,19 +272,14 @@ func leaseShellCmd() *cobra.Command {
 				return err
 			}
 
-			providerAddr, providerURL, err := resolveAuthenticatedProvider(cmd, nil)
+			// lease-shell consumes its positional args as the remote command,
+			// so dseq must come from the --dseq flag here.
+			lid, providerURL, err := resolveAuthenticatedLease(cmd, nil)
 			if err != nil {
 				return err
 			}
 
 			cl, err := gatewayClientFromCmd(cmd, providerURL)
-			if err != nil {
-				return err
-			}
-
-			// lease-shell consumes its positional args as the remote command,
-			// so dseq must come from the --dseq flag here.
-			lid, err := leaseIDFromFlags(cmd, nil, providerAddr)
 			if err != nil {
 				return err
 			}
@@ -321,26 +321,25 @@ func sendManifestCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "send-manifest <sdl-file>",
 		Short: "Send SDL manifest to provider",
-		Long:  "Parse an SDL file and submit the resulting manifest to the provider for a deployment.",
-		Args:  cobra.ExactArgs(1),
-		Example: `  # Send manifest from SDL file
+		Long: "Parse an SDL file and submit the resulting manifest to the deployment's providers. " +
+			"Without --provider the manifest goes to every provider holding an active lease for " +
+			"the deployment; each one is attempted even if an earlier one rejects it.",
+		Args: cobra.ExactArgs(1),
+		Example: `  # Send the manifest to every provider with an active lease
+  akt provider send-manifest deploy.yaml --dseq 12345
+
+  # Send it to one specific provider
   akt provider send-manifest deploy.yaml --dseq 12345 --provider akash1...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			providerAddr, providerURL, err := resolveAuthenticatedProvider(cmd, nil)
+			scope, err := leaseScopeFromCmd(cmd, nil)
 			if err != nil {
 				return err
 			}
 
-			cl, err := gatewayClientFromCmd(cmd, providerURL)
-			if err != nil {
+			if _, _, _, err := gatewayAuthenticationFromCmd(cmd); err != nil {
 				return err
-			}
-
-			dseq, _ := cmd.Flags().GetUint64("dseq")
-			if dseq == 0 {
-				return fmt.Errorf("--dseq is required")
 			}
 
 			sdlManifest, err := sdl.ReadFile(args[0])
@@ -353,14 +352,24 @@ func sendManifestCmd() *cobra.Command {
 				return fmt.Errorf("build manifest from SDL: %w", err)
 			}
 
-			err = cl.SubmitManifest(ctx, dseq, mani)
-			recordProviderAction(ctx, "send-manifest", providerAddr.String(), dseq, err)
+			providers, err := sendManifestTargets(cmd, scope, chainLeaseQuery(cmd))
 			if err != nil {
-				return aktprovider.GatewayError("submit manifest", err)
+				return err
 			}
 
-			fmt.Fprintln(cmd.OutOrStdout(), "Manifest submitted successfully.")
-			return nil
+			var failures []error
+			for _, provider := range providers {
+				err := submitManifest(cmd, provider, scope.DSeq, mani)
+				recordProviderAction(ctx, "send-manifest", provider, scope.DSeq, err)
+				if err != nil {
+					failures = append(failures, fmt.Errorf("provider %s: %w", provider, err))
+					continue
+				}
+
+				fmt.Fprintf(cmd.OutOrStdout(), "Manifest submitted successfully to %s.\n", provider)
+			}
+
+			return errors.Join(failures...)
 		},
 	}
 
@@ -369,28 +378,74 @@ func sendManifestCmd() *cobra.Command {
 	return cmd
 }
 
+// sendManifestTargets resolves the providers a manifest is delivered to: the
+// explicit --provider, or every provider with an active lease for the
+// deployment (SPEC §2.4).
+func sendManifestTargets(cmd *cobra.Command, scope leaseScope, leases leaseQuery) ([]string, error) {
+	if addrStr, _ := cmd.Flags().GetString("provider"); addrStr != "" {
+		addr, err := sdk.AccAddressFromBech32(addrStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid provider address %q: %w", addrStr, err)
+		}
+
+		return []string{addr.String()}, nil
+	}
+
+	providers, err := activeLeaseProviders(cmd.Context(), scope, leases)
+	if err != nil {
+		return nil, err
+	}
+
+	// A single explicit gateway URL cannot stand in for several providers.
+	if providerURL, _ := cmd.Flags().GetString("provider-url"); providerURL != "" && len(providers) > 1 {
+		return nil, fmt.Errorf(
+			"--provider-url addresses one gateway but deployment %d has %d active leases; add --provider to choose one",
+			scope.DSeq, len(providers))
+	}
+
+	return providers, nil
+}
+
+// submitManifest delivers the manifest to one provider, resolving that
+// provider's gateway on the way.
+func submitManifest(cmd *cobra.Command, provider string, dseq uint64, mani manifest.Manifest) error {
+	providerURL, err := gatewayURL(cmd, provider, providerHostURILookup(cmd))
+	if err != nil {
+		return err
+	}
+
+	cl, err := gatewayClientFromCmd(cmd, providerURL)
+	if err != nil {
+		return err
+	}
+
+	if err := cl.SubmitManifest(cmd.Context(), dseq, mani); err != nil {
+		return aktprovider.GatewayError("submit manifest", err)
+	}
+
+	return nil
+}
+
 func getManifestCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-manifest [dseq]",
 		Short: "Retrieve current manifest",
-		Long:  "Retrieve the current manifest for a lease from the provider.",
+		Long:  "Retrieve the current manifest for a lease from the provider. " + leaseProviderHelp,
 		Args:  cobra.MaximumNArgs(1),
-		Example: `  # Get manifest for a lease (positional dseq)
+		Example: `  # Get manifest for a lease (provider resolved from the active lease)
+  akt provider get-manifest 12345
+
+  # Pin the provider when several leases are active
   akt provider get-manifest 12345 --provider akash1...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			providerAddr, providerURL, err := resolveAuthenticatedProvider(cmd, nil)
+			lid, providerURL, err := resolveAuthenticatedLease(cmd, args)
 			if err != nil {
 				return err
 			}
 
 			cl, err := gatewayClientFromCmd(cmd, providerURL)
-			if err != nil {
-				return err
-			}
-
-			lid, err := leaseIDFromFlags(cmd, args, providerAddr)
 			if err != nil {
 				return err
 			}
@@ -413,14 +468,24 @@ func migrateHostnamesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate-hostnames",
 		Short: "Migrate hostnames between deployments",
-		Long:  "Migrate hostnames from one deployment to another on the same provider.",
-		Args:  cobra.NoArgs,
+		Long: "Migrate hostnames onto a deployment from whichever deployment currently holds them " +
+			"on the same provider. --dseq/--gseq address the destination lease; the provider is " +
+			"resolved from that deployment's active lease unless --provider names one.",
+		Args: cobra.NoArgs,
 		Example: `  # Migrate hostnames to a new deployment
-  akt provider migrate-hostnames --dseq 12345 --gseq 1 --provider akash1... --hostnames example.com,app.example.com`,
+  akt provider migrate-hostnames --dseq 12345 --hostnames example.com,app.example.com
+
+  # Pin the destination group and provider
+  akt provider migrate-hostnames --dseq 12345 --gseq 1 --provider akash1... --hostnames example.com`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 
-			providerAddr, providerURL, err := resolveAuthenticatedProvider(cmd, nil)
+			hostnames, _ := cmd.Flags().GetStringSlice("hostnames")
+			if len(hostnames) == 0 {
+				return fmt.Errorf("--hostnames is required")
+			}
+
+			lid, providerURL, err := resolveAuthenticatedLease(cmd, nil)
 			if err != nil {
 				return err
 			}
@@ -430,19 +495,8 @@ func migrateHostnamesCmd() *cobra.Command {
 				return err
 			}
 
-			dseq, _ := cmd.Flags().GetUint64("dseq")
-			if dseq == 0 {
-				return fmt.Errorf("--dseq is required")
-			}
-
-			gseq, _ := cmd.Flags().GetUint32("gseq")
-			hostnames, _ := cmd.Flags().GetStringSlice("hostnames")
-			if len(hostnames) == 0 {
-				return fmt.Errorf("--hostnames is required")
-			}
-
-			err = cl.MigrateHostnames(ctx, hostnames, dseq, gseq)
-			recordProviderAction(ctx, "migrate-hostnames", providerAddr.String(), dseq, err)
+			err = cl.MigrateHostnames(ctx, hostnames, lid.DSeq, lid.GSeq)
+			recordProviderAction(ctx, "migrate-hostnames", lid.Provider, lid.DSeq, err)
 			if err != nil {
 				return aktprovider.GatewayError("migrate hostnames", err)
 			}
@@ -463,14 +517,24 @@ func migrateEndpointsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate-endpoints",
 		Short: "Migrate endpoints between deployments",
-		Long:  "Migrate endpoints from one deployment to another on the same provider.",
-		Args:  cobra.NoArgs,
+		Long: "Migrate IP endpoints onto a deployment from whichever deployment currently holds them " +
+			"on the same provider. --dseq/--gseq address the destination lease; the provider is " +
+			"resolved from that deployment's active lease unless --provider names one.",
+		Args: cobra.NoArgs,
 		Example: `  # Migrate endpoints to a new deployment
-  akt provider migrate-endpoints --dseq 12345 --gseq 1 --provider akash1... --endpoints ep1,ep2`,
+  akt provider migrate-endpoints --dseq 12345 --endpoints ep1,ep2
+
+  # Pin the destination group and provider
+  akt provider migrate-endpoints --dseq 12345 --gseq 1 --provider akash1... --endpoints ep1`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 
-			providerAddr, providerURL, err := resolveAuthenticatedProvider(cmd, nil)
+			endpoints, _ := cmd.Flags().GetStringSlice("endpoints")
+			if len(endpoints) == 0 {
+				return fmt.Errorf("--endpoints is required")
+			}
+
+			lid, providerURL, err := resolveAuthenticatedLease(cmd, nil)
 			if err != nil {
 				return err
 			}
@@ -480,19 +544,8 @@ func migrateEndpointsCmd() *cobra.Command {
 				return err
 			}
 
-			dseq, _ := cmd.Flags().GetUint64("dseq")
-			if dseq == 0 {
-				return fmt.Errorf("--dseq is required")
-			}
-
-			gseq, _ := cmd.Flags().GetUint32("gseq")
-			endpoints, _ := cmd.Flags().GetStringSlice("endpoints")
-			if len(endpoints) == 0 {
-				return fmt.Errorf("--endpoints is required")
-			}
-
-			err = cl.MigrateEndpoints(ctx, endpoints, dseq, gseq)
-			recordProviderAction(ctx, "migrate-endpoints", providerAddr.String(), dseq, err)
+			err = cl.MigrateEndpoints(ctx, endpoints, lid.DSeq, lid.GSeq)
+			recordProviderAction(ctx, "migrate-endpoints", lid.Provider, lid.DSeq, err)
 			if err != nil {
 				return aktprovider.GatewayError("migrate endpoints", err)
 			}
@@ -532,38 +585,6 @@ func addLeaseShellFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint32("oseq", 1, "Order sequence number")
 }
 
-// leaseIDFromFlags builds a LeaseID from the command flags and an optional
-// positional dseq argument. Only lease-shell still registers --dseq
-// (FEEDBACK 2026-07: the flag is disabled on the positional-[dseq] commands
-// for the positional-only UX trial); for those commands the flag lookup
-// below yields zero and the positional argument is the sole source.
-func leaseIDFromFlags(cmd *cobra.Command, args []string, provider sdk.AccAddress) (mtypes.LeaseID, error) {
-	cctx := sdkclient.GetClientContextFromCmd(cmd)
-	owner := cctx.GetFromAddress()
-
-	dseq, _ := cmd.Flags().GetUint64("dseq")
-
-	dseq, err := cflags.DSeqFromArgs(args, dseq)
-	if err != nil {
-		return mtypes.LeaseID{}, err
-	}
-
-	if dseq == 0 {
-		return mtypes.LeaseID{}, fmt.Errorf("dseq is required: provide the positional [dseq] argument (or --dseq for lease-shell)")
-	}
-
-	gseq, _ := cmd.Flags().GetUint32("gseq")
-	oseq, _ := cmd.Flags().GetUint32("oseq")
-
-	return mtypes.LeaseID{
-		Owner:    owner.String(),
-		DSeq:     dseq,
-		GSeq:     gseq,
-		OSeq:     oseq,
-		Provider: provider.String(),
-	}, nil
-}
-
 // resolveProvider resolves the provider address and its on-chain HostURI. An
 // explicit --provider-url remains an override for diagnostics and private
 // gateways.
@@ -571,7 +592,7 @@ func resolveProvider(cmd *cobra.Command, args []string) (sdk.AccAddress, string,
 	return resolveProviderWithLookup(cmd, args, providerHostURILookup(cmd))
 }
 
-func providerHostURILookup(cmd *cobra.Command) func(context.Context, string) (string, error) {
+func providerHostURILookup(cmd *cobra.Command) hostURIQuery {
 	return func(ctx context.Context, owner string) (string, error) {
 		cctx, err := providerQueryContext(cmd)
 		if err != nil {
@@ -587,18 +608,6 @@ func providerHostURILookup(cmd *cobra.Command) func(context.Context, string) (st
 	}
 }
 
-func resolveAuthenticatedProvider(cmd *cobra.Command, args []string) (sdk.AccAddress, string, error) {
-	return resolveProviderWithLookupAndPreflight(
-		cmd,
-		args,
-		providerHostURILookup(cmd),
-		func() error {
-			_, _, _, err := gatewayAuthenticationFromCmd(cmd)
-			return err
-		},
-	)
-}
-
 func providerQueryContext(cmd *cobra.Command) (sdkclient.Context, error) {
 	cctx, err := chaincli.GetClientQueryContext(cmd)
 	if err != nil {
@@ -611,19 +620,15 @@ func providerQueryContext(cmd *cobra.Command) (sdkclient.Context, error) {
 	return cctx, nil
 }
 
+// resolveProviderWithLookup backs `provider status`, the one command whose
+// primary value genuinely is the provider address: it accepts it positionally,
+// with --provider as the flag alternative. Lease-scoped commands never come
+// through here — their positional slot is the dseq and their provider is
+// resolved from the lease (see lease.go).
 func resolveProviderWithLookup(
 	cmd *cobra.Command,
 	args []string,
-	lookup func(context.Context, string) (string, error),
-) (sdk.AccAddress, string, error) {
-	return resolveProviderWithLookupAndPreflight(cmd, args, lookup, nil)
-}
-
-func resolveProviderWithLookupAndPreflight(
-	cmd *cobra.Command,
-	args []string,
-	lookup func(context.Context, string) (string, error),
-	preflight func() error,
+	lookup hostURIQuery,
 ) (sdk.AccAddress, string, error) {
 	var addrStr string
 
@@ -641,23 +646,10 @@ func resolveProviderWithLookupAndPreflight(
 	if err != nil {
 		return nil, "", fmt.Errorf("invalid provider address %q: %w", addrStr, err)
 	}
-	if preflight != nil {
-		if err := preflight(); err != nil {
-			return nil, "", err
-		}
-	}
 
-	providerURL, _ := cmd.Flags().GetString("provider-url")
-	if providerURL != "" {
-		return addr, providerURL, nil
-	}
-
-	providerURL, err = lookup(cmd.Context(), addr.String())
+	providerURL, err := gatewayURL(cmd, addr.String(), lookup)
 	if err != nil {
 		return nil, "", err
-	}
-	if providerURL == "" {
-		return nil, "", fmt.Errorf("provider %s has no host URI on chain", addr)
 	}
 
 	return addr, providerURL, nil

--- a/internal/cli/provider/commands_test.go
+++ b/internal/cli/provider/commands_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -43,19 +42,6 @@ func newProviderCmd(t *testing.T, args ...string) *cobra.Command {
 // A valid bech32 akash account address, used wherever the code path runs
 // through sdk.AccAddressFromBech32.
 const testProviderAddr = "akash1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5jepelx"
-
-// mustAddr decodes testProviderAddr, failing the test if the fixture is not a
-// valid bech32 address.
-func mustAddr(t *testing.T) sdk.AccAddress {
-	t.Helper()
-
-	addr, err := sdk.AccAddressFromBech32(testProviderAddr)
-	if err != nil {
-		t.Fatalf("test fixture is not a valid address: %v", err)
-	}
-
-	return addr
-}
 
 // TestResolveProviderRequiresAnAddress covers the guard that keeps a gateway
 // call from being attempted with no provider at all — without it the bech32
@@ -174,19 +160,19 @@ func TestResolveProviderFlagFallback(t *testing.T) {
 	}
 }
 
-// TestLeaseIDFromFlagsPositionalDSeq covers the positional-only UX trial path
+// TestLeaseScopePositionalDSeq covers the positional-only UX trial path
 // (FEEDBACK 2026-07): the positional [dseq] must land in the LeaseID, and the
 // gseq/oseq defaults must be 1 — a zero gseq would address a nonexistent
 // group and fail at the provider with an unhelpful error.
-func TestLeaseIDFromFlagsPositionalDSeq(t *testing.T) {
+func TestLeaseScopePositionalDSeq(t *testing.T) {
 	cmd := newProviderCmd(t)
 
-	addr := mustAddr(t)
-
-	lid, err := leaseIDFromFlags(cmd, []string{"12345"}, addr)
+	scope, err := leaseScopeFromCmd(cmd, []string{"12345"})
 	if err != nil {
-		t.Fatalf("leaseIDFromFlags: %v", err)
+		t.Fatalf("leaseScopeFromCmd: %v", err)
 	}
+
+	lid := scope.leaseID(testProviderAddr)
 
 	if lid.DSeq != 12345 {
 		t.Errorf("dseq = %d, want 12345", lid.DSeq)
@@ -197,67 +183,70 @@ func TestLeaseIDFromFlagsPositionalDSeq(t *testing.T) {
 	if lid.Provider != testProviderAddr {
 		t.Errorf("provider = %q, want %q", lid.Provider, testProviderAddr)
 	}
+	if scope.GSeqSet || scope.OSeqSet {
+		t.Errorf("unset --gseq/--oseq recorded as explicit (%v/%v)", scope.GSeqSet, scope.OSeqSet)
+	}
 }
 
-// TestLeaseIDFromFlagsPositionalWinsOverFlag pins the precedence for
-// lease-shell, the one command that still registers --dseq: an explicit
-// positional value must win, exactly as DSeqFromArgs documents.
-func TestLeaseIDFromFlagsPositionalWinsOverFlag(t *testing.T) {
+// TestLeaseScopePositionalWinsOverFlag pins the precedence for lease-shell,
+// the one lease command that still registers --dseq: an explicit positional
+// value must win, exactly as DSeqFromArgs documents.
+func TestLeaseScopePositionalWinsOverFlag(t *testing.T) {
 	cmd := newProviderCmd(t, "--dseq", "999", "--gseq", "2", "--oseq", "3")
 
-	addr := mustAddr(t)
-
-	lid, err := leaseIDFromFlags(cmd, []string{"12345"}, addr)
+	scope, err := leaseScopeFromCmd(cmd, []string{"12345"})
 	if err != nil {
-		t.Fatalf("leaseIDFromFlags: %v", err)
+		t.Fatalf("leaseScopeFromCmd: %v", err)
 	}
+
+	lid := scope.leaseID(testProviderAddr)
 	if lid.DSeq != 12345 {
 		t.Errorf("dseq = %d, want the positional 12345", lid.DSeq)
 	}
 	if lid.GSeq != 2 || lid.OSeq != 3 {
 		t.Errorf("gseq/oseq = %d/%d, want the flag values 2/3", lid.GSeq, lid.OSeq)
 	}
+	if !scope.GSeqSet || !scope.OSeqSet {
+		t.Error("explicit --gseq/--oseq must be recorded so lease resolution does not override them")
+	}
 }
 
-// TestLeaseIDFromFlagsUsesDSeqFlagWithoutPositional covers lease-shell's own
-// path: it consumes its positional args as the remote command, so --dseq is
-// the only source there.
-func TestLeaseIDFromFlagsUsesDSeqFlagWithoutPositional(t *testing.T) {
+// TestLeaseScopeUsesDSeqFlagWithoutPositional covers lease-shell's own path:
+// it consumes its positional args as the remote command, so --dseq is the
+// only source there.
+func TestLeaseScopeUsesDSeqFlagWithoutPositional(t *testing.T) {
 	cmd := newProviderCmd(t, "--dseq", "777")
 
-	addr := mustAddr(t)
-
-	lid, err := leaseIDFromFlags(cmd, nil, addr)
+	scope, err := leaseScopeFromCmd(cmd, nil)
 	if err != nil {
-		t.Fatalf("leaseIDFromFlags: %v", err)
+		t.Fatalf("leaseScopeFromCmd: %v", err)
 	}
-	if lid.DSeq != 777 {
-		t.Errorf("dseq = %d, want 777 from --dseq", lid.DSeq)
+	if scope.DSeq != 777 {
+		t.Errorf("dseq = %d, want 777 from --dseq", scope.DSeq)
 	}
 }
 
-// TestLeaseIDFromFlagsRejectsMissingDSeq covers the guard that stops a lease
-// call from being made against dseq 0, which the provider would answer with a
-// generic not-found.
-func TestLeaseIDFromFlagsRejectsMissingDSeq(t *testing.T) {
+// TestLeaseScopeRejectsMissingDSeq covers the guard that stops a lease call
+// from being made against dseq 0, which the provider would answer with a
+// generic not-found. The remedy must name --dseq here, because the command
+// under test registers it.
+func TestLeaseScopeRejectsMissingDSeq(t *testing.T) {
 	cmd := newProviderCmd(t)
 
-	addr := mustAddr(t)
-
-	if _, err := leaseIDFromFlags(cmd, nil, addr); err == nil {
+	if _, err := leaseScopeFromCmd(cmd, nil); err == nil {
 		t.Fatal("dseq 0 must be rejected")
 	} else if !strings.Contains(err.Error(), "dseq is required") {
 		t.Errorf("error should say dseq is required, got %q", err)
+	} else if !strings.Contains(err.Error(), "--dseq") {
+		t.Errorf("error should name the --dseq flag this command registers, got %q", err)
 	}
 }
 
-// TestLeaseIDFromFlagsRejectsNonNumericDSeq covers the positional parse error.
-func TestLeaseIDFromFlagsRejectsNonNumericDSeq(t *testing.T) {
+// TestLeaseScopeRejectsNonNumericDSeq covers the positional parse error.
+func TestLeaseScopeRejectsNonNumericDSeq(t *testing.T) {
 	cmd := newProviderCmd(t)
 
-	addr := mustAddr(t)
-
-	if _, err := leaseIDFromFlags(cmd, []string{"twelve"}, addr); err == nil {
+	if _, err := leaseScopeFromCmd(cmd, []string{"twelve"}); err == nil {
 		t.Fatal("a non-numeric positional dseq must be rejected")
 	} else if !strings.Contains(err.Error(), "invalid dseq") {
 		t.Errorf("error should name the bad dseq, got %q", err)
@@ -604,18 +593,64 @@ func TestAuthenticatedGatewayRejectsUnknownAuthTypeBeforeIdentityChecks(t *testi
 	}
 }
 
-// TestLeaseCommandsRequireProviderBeforeGatewayWork walks every lease-scoped
-// subcommand through its first guard. These commands take no positional
-// provider, so a missing --provider must be reported by name rather than
-// surfacing as a gateway construction failure.
-func TestLeaseCommandsRequireProviderBeforeGatewayWork(t *testing.T) {
+// TestLeaseCommandsBlameTheMissingDSeqNotTheProvider walks every lease-scoped
+// subcommand invoked with neither a deployment sequence nor a provider. The
+// deployment sequence is what the provider is resolved from, so it must be the
+// value the error names, and the remedy must name the form this particular
+// command actually accepts. The previous behavior reported "provider address
+// is required (positional argument or --provider flag)" on all eight, which
+// was doubly wrong: none of them takes a positional provider, and on four of
+// them the positional slot is the dseq, so following the hint produced a
+// second, more confusing parse error.
+func TestLeaseCommandsBlameTheMissingDSeqNotTheProvider(t *testing.T) {
+	cases := []struct {
+		args   []string
+		remedy string
+	}{
+		{[]string{"lease-status"}, "positional argument"},
+		{[]string{"lease-logs"}, "positional argument"},
+		{[]string{"lease-events"}, "positional argument"},
+		{[]string{"get-manifest"}, "positional argument"},
+		{[]string{"lease-shell", "--", "/bin/sh"}, "--dseq"},
+		{[]string{"send-manifest", "deploy.yaml"}, "--dseq"},
+		{[]string{"migrate-hostnames", "--hostnames", "a.example.com"}, "--dseq"},
+		{[]string{"migrate-endpoints", "--endpoints", "ep1"}, "--dseq"},
+	}
+
+	for _, tc := range cases {
+		root := Commands()
+		root.SetOut(&bytes.Buffer{})
+		root.SetErr(&bytes.Buffer{})
+		root.SetArgs(tc.args)
+
+		err := root.Execute()
+		if err == nil {
+			t.Errorf("%v without a dseq must fail", tc.args)
+			continue
+		}
+		if !strings.Contains(err.Error(), "dseq is required") {
+			t.Errorf("%v: error should name the missing dseq, got %v", tc.args, err)
+		}
+		if !strings.Contains(err.Error(), tc.remedy) {
+			t.Errorf("%v: error should offer %q, got %v", tc.args, tc.remedy, err)
+		}
+		if strings.Contains(err.Error(), "provider address is required") {
+			t.Errorf("%v: error still blames the provider: %v", tc.args, err)
+		}
+	}
+}
+
+// TestLeaseCommandsNeverAdvertiseAPositionalProvider pins the honesty of the
+// lease-command errors: not one of them accepts a provider positionally, so
+// none may suggest it.
+func TestLeaseCommandsNeverAdvertiseAPositionalProvider(t *testing.T) {
 	cases := [][]string{
 		{"lease-status", "1"},
 		{"lease-logs", "1"},
 		{"lease-events", "1"},
 		{"get-manifest", "1"},
 		{"lease-shell", "--dseq", "1", "--", "/bin/sh"},
-		{"send-manifest", "deploy.yaml"},
+		{"send-manifest", "deploy.yaml", "--dseq", "1"},
 		{"migrate-hostnames", "--dseq", "1", "--hostnames", "a.example.com"},
 		{"migrate-endpoints", "--dseq", "1", "--endpoints", "ep1"},
 	}
@@ -628,11 +663,16 @@ func TestLeaseCommandsRequireProviderBeforeGatewayWork(t *testing.T) {
 
 		err := root.Execute()
 		if err == nil {
-			t.Errorf("%v without a provider must fail", args)
+			t.Errorf("%v without a signing identity must fail", args)
 			continue
 		}
-		if !strings.Contains(err.Error(), "provider address is required") {
-			t.Errorf("%v: unexpected error %v", args, err)
+		// With a dseq present the next guard is the local signing identity,
+		// which every one of these needs before any provider work.
+		if !strings.Contains(err.Error(), "configured default account") {
+			t.Errorf("%v: error = %v, want the signing-identity remedy", args, err)
+		}
+		if strings.Contains(err.Error(), "positional argument or --provider") {
+			t.Errorf("%v: error suggests a positional provider that does not exist: %v", args, err)
 		}
 	}
 }

--- a/internal/cli/provider/lease.go
+++ b/internal/cli/provider/lease.go
@@ -1,0 +1,399 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/spf13/cobra"
+
+	mtypes "pkg.akt.dev/go/node/market/v1"
+	mvbeta "pkg.akt.dev/go/node/market/v1beta5"
+
+	cflags "pkg.akt.dev/akt/internal/cli/chain/flags"
+)
+
+// leasePageLimit bounds one page of the lease query used for provider
+// resolution. A deployment has one lease per group per provider, so a single
+// page covers every realistic deployment; pagination is still followed so a
+// pathological one cannot silently lose a lease.
+const leasePageLimit = 100
+
+// leaseQuery returns the leases owned by owner for one deployment, in every
+// state. It is a function type so provider resolution can be exercised without
+// a chain.
+type leaseQuery func(ctx context.Context, owner string, dseq uint64) ([]mtypes.Lease, error)
+
+// hostURIQuery resolves a provider address to its on-chain gateway host URI.
+type hostURIQuery func(ctx context.Context, provider string) (string, error)
+
+// leaseScope is the part of a lease identity that resolves locally: the owner
+// comes from the selected context's default account, and the sequence numbers
+// from the positional [dseq] argument and the --gseq/--oseq flags. The provider
+// is deliberately absent — it is resolved afterwards, either from --provider or
+// from the deployment's active lease (SPEC §2.4).
+type leaseScope struct {
+	Owner string
+	DSeq  uint64
+	GSeq  uint32
+	OSeq  uint32
+
+	// GSeqSet and OSeqSet record whether the user named the group and order
+	// sequences. When they did not, an auto-resolved lease supplies its own.
+	GSeqSet bool
+	OSeqSet bool
+}
+
+// leaseID builds the gateway LeaseID for this scope under the given provider.
+func (s leaseScope) leaseID(provider string) mtypes.LeaseID {
+	return mtypes.LeaseID{
+		Owner:    s.Owner,
+		DSeq:     s.DSeq,
+		GSeq:     s.GSeq,
+		OSeq:     s.OSeq,
+		Provider: provider,
+	}
+}
+
+// leaseScopeFromCmd resolves the deployment sequence and the owner for a
+// lease-scoped command. The deployment sequence is resolved before anything
+// touching the provider, because it is the value the provider is resolved from:
+// a command missing both must report the missing sequence, not the missing
+// provider.
+//
+// Only lease-shell, send-manifest, and the migrate-* commands still register
+// --dseq (FEEDBACK 2026-07: the flag is disabled on the positional-[dseq]
+// commands for the positional-only UX trial); elsewhere the flag lookup below
+// yields zero and the positional argument is the sole source.
+func leaseScopeFromCmd(cmd *cobra.Command, args []string) (leaseScope, error) {
+	cctx := sdkclient.GetClientContextFromCmd(cmd)
+
+	dseq, _ := cmd.Flags().GetUint64("dseq")
+
+	dseq, err := cflags.DSeqFromArgs(args, dseq)
+	if err != nil {
+		return leaseScope{}, err
+	}
+
+	if dseq == 0 {
+		return leaseScope{}, missingDSeqError(cmd)
+	}
+
+	gseq, _ := cmd.Flags().GetUint32("gseq")
+	oseq, _ := cmd.Flags().GetUint32("oseq")
+
+	return leaseScope{
+		Owner:   cctx.GetFromAddress().String(),
+		DSeq:    dseq,
+		GSeq:    gseq,
+		OSeq:    oseq,
+		GSeqSet: cmd.Flags().Changed("gseq"),
+		OSeqSet: cmd.Flags().Changed("oseq"),
+	}, nil
+}
+
+// missingDSeqError names the way this particular command actually accepts a
+// deployment sequence. Commands whose positional slot is the dseq must not be
+// told to pass a flag they do not register, and vice versa.
+func missingDSeqError(cmd *cobra.Command) error {
+	if cmd.Flags().Lookup("dseq") != nil {
+		return fmt.Errorf("dseq is required: pass --dseq <dseq> (e.g. %s --dseq 12345)", cmd.CommandPath())
+	}
+
+	return fmt.Errorf("dseq is required: pass it as the positional argument (e.g. %s 12345)", cmd.CommandPath())
+}
+
+// resolveAuthenticatedLease resolves the complete lease identity and the
+// provider gateway URL for a lease-scoped command.
+//
+// The order is deliberate and differs from provider `status`:
+//
+//  1. the deployment sequence, because the provider is resolved from it;
+//  2. the local signing identity, so a broken context fails before any network
+//     work (JWT signing and mTLS both need it);
+//  3. the provider — explicitly from --provider, otherwise from the
+//     deployment's single active lease on chain;
+//  4. the gateway URL, from --provider-url or the provider's on-chain host URI.
+func resolveAuthenticatedLease(cmd *cobra.Command, args []string) (mtypes.LeaseID, string, error) {
+	return resolveLeaseWith(cmd, args, chainLeaseQuery(cmd), providerHostURILookup(cmd), func() error {
+		_, _, _, err := gatewayAuthenticationFromCmd(cmd)
+		return err
+	})
+}
+
+func resolveLeaseWith(
+	cmd *cobra.Command,
+	args []string,
+	leases leaseQuery,
+	hostURI hostURIQuery,
+	preflight func() error,
+) (mtypes.LeaseID, string, error) {
+	scope, err := leaseScopeFromCmd(cmd, args)
+	if err != nil {
+		return mtypes.LeaseID{}, "", err
+	}
+
+	if preflight != nil {
+		if err := preflight(); err != nil {
+			return mtypes.LeaseID{}, "", err
+		}
+	}
+
+	lid, err := resolveLeaseProvider(cmd, scope, leases)
+	if err != nil {
+		return mtypes.LeaseID{}, "", err
+	}
+
+	providerURL, err := gatewayURL(cmd, lid.Provider, hostURI)
+	if err != nil {
+		return mtypes.LeaseID{}, "", err
+	}
+
+	return lid, providerURL, nil
+}
+
+// resolveLeaseProvider completes the lease identity with a provider address.
+// An explicit --provider always wins; otherwise the deployment's single active
+// lease supplies the provider and, unless the user named them, its own
+// gseq/oseq.
+func resolveLeaseProvider(cmd *cobra.Command, scope leaseScope, leases leaseQuery) (mtypes.LeaseID, error) {
+	if addrStr, _ := cmd.Flags().GetString("provider"); addrStr != "" {
+		addr, err := sdk.AccAddressFromBech32(addrStr)
+		if err != nil {
+			return mtypes.LeaseID{}, fmt.Errorf("invalid provider address %q: %w", addrStr, err)
+		}
+
+		return scope.leaseID(addr.String()), nil
+	}
+
+	lease, err := activeLeaseForScope(cmd.Context(), scope, leases)
+	if err != nil {
+		return mtypes.LeaseID{}, err
+	}
+
+	lid := scope.leaseID(lease.ID.Provider)
+	if !scope.GSeqSet {
+		lid.GSeq = lease.ID.GSeq
+	}
+	if !scope.OSeqSet {
+		lid.OSeq = lease.ID.OSeq
+	}
+
+	return lid, nil
+}
+
+// activeLeaseForScope picks the deployment's single active lease. Ambiguous and
+// impossible resolutions are refused with an error naming the real cause, the
+// way the Console rail does in internal/cli/console/gateway.go — never guessed.
+func activeLeaseForScope(ctx context.Context, scope leaseScope, leases leaseQuery) (mtypes.Lease, error) {
+	if scope.Owner == "" {
+		return mtypes.Lease{}, fmt.Errorf(
+			"cannot resolve the provider for deployment %d: the context has no configured default account; "+
+				"set one with `akt context edit <context> --default-account <key>`, or name the provider with --provider",
+			scope.DSeq)
+	}
+
+	found, err := leases(ctx, scope.Owner, scope.DSeq)
+	if err != nil {
+		return mtypes.Lease{}, err
+	}
+
+	found = leasesMatchingScope(scope, found)
+	if len(found) == 0 {
+		return mtypes.Lease{}, fmt.Errorf("%s has no leases: %s", deploymentLabel(scope), leaseRemedy(scope))
+	}
+
+	var (
+		active []mtypes.Lease
+		states []string
+	)
+	for _, lease := range found {
+		if lease.State == mtypes.LeaseActive {
+			active = append(active, lease)
+			continue
+		}
+		states = append(states, lease.State.String())
+	}
+
+	switch len(active) {
+	case 1:
+		return active[0], nil
+
+	case 0:
+		sort.Strings(states)
+		return mtypes.Lease{}, fmt.Errorf("%s has no active lease (lease states: %s): %s",
+			deploymentLabel(scope), strings.Join(states, ", "), leaseRemedy(scope))
+
+	default:
+		providers := make([]string, 0, len(active))
+		for _, lease := range active {
+			providers = append(providers, "  "+lease.ID.Provider)
+		}
+		sort.Strings(providers)
+
+		return mtypes.Lease{}, fmt.Errorf(
+			"%s has %d active leases; choose one with --provider:\n%s",
+			deploymentLabel(scope), len(active), strings.Join(providers, "\n"))
+	}
+}
+
+// leasesMatchingScope narrows the deployment's leases to the group and order
+// the user named. Sequences the user did not name are left unfiltered so a
+// lease on a re-ordered group (oseq > 1) is still found.
+func leasesMatchingScope(scope leaseScope, leases []mtypes.Lease) []mtypes.Lease {
+	if !scope.GSeqSet && !scope.OSeqSet {
+		return leases
+	}
+
+	kept := make([]mtypes.Lease, 0, len(leases))
+	for _, lease := range leases {
+		if scope.GSeqSet && lease.ID.GSeq != scope.GSeq {
+			continue
+		}
+		if scope.OSeqSet && lease.ID.OSeq != scope.OSeq {
+			continue
+		}
+		kept = append(kept, lease)
+	}
+
+	return kept
+}
+
+// deploymentLabel identifies the deployment the way the user addressed it,
+// including the group and order sequences only when they narrowed the search.
+func deploymentLabel(scope leaseScope) string {
+	label := fmt.Sprintf("deployment %d", scope.DSeq)
+	switch {
+	case scope.GSeqSet && scope.OSeqSet:
+		return fmt.Sprintf("%s (gseq %d, oseq %d)", label, scope.GSeq, scope.OSeq)
+	case scope.GSeqSet:
+		return fmt.Sprintf("%s (gseq %d)", label, scope.GSeq)
+	case scope.OSeqSet:
+		return fmt.Sprintf("%s (oseq %d)", label, scope.OSeq)
+	}
+
+	return label
+}
+
+// leaseRemedy points at a command that actually exists and shows the leases the
+// resolution looked at.
+func leaseRemedy(scope leaseScope) string {
+	return fmt.Sprintf("inspect it with `akt query market lease %d`, or name the gateway with --provider", scope.DSeq)
+}
+
+// gatewayURL resolves the gateway base URL for a provider. An explicit
+// --provider-url remains an override for diagnostics and private gateways.
+func gatewayURL(cmd *cobra.Command, provider string, hostURI hostURIQuery) (string, error) {
+	if providerURL, _ := cmd.Flags().GetString("provider-url"); providerURL != "" {
+		return providerURL, nil
+	}
+
+	providerURL, err := hostURI(cmd.Context(), provider)
+	if err != nil {
+		return "", err
+	}
+	if providerURL == "" {
+		return "", fmt.Errorf("provider %s has no host URI on chain", provider)
+	}
+
+	return providerURL, nil
+}
+
+// activeLeaseProviders returns every provider holding an active lease for the
+// deployment, sorted so output and retries are stable. It backs
+// `send-manifest` without --provider (SPEC §2.4), which fans out to all of
+// them.
+func activeLeaseProviders(ctx context.Context, scope leaseScope, leases leaseQuery) ([]string, error) {
+	if scope.Owner == "" {
+		return nil, fmt.Errorf(
+			"cannot resolve providers for deployment %d: the context has no configured default account; "+
+				"set one with `akt context edit <context> --default-account <key>`, or name the provider with --provider",
+			scope.DSeq)
+	}
+
+	found, err := leases(ctx, scope.Owner, scope.DSeq)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(found))
+	for _, lease := range found {
+		if lease.State == mtypes.LeaseActive && lease.ID.Provider != "" {
+			seen[lease.ID.Provider] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil, fmt.Errorf("%s has no active lease: %s", deploymentLabel(scope), leaseRemedy(scope))
+	}
+
+	providers := make([]string, 0, len(seen))
+	for provider := range seen {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+
+	return providers, nil
+}
+
+// chainLeaseQuery reads the deployment's leases from the market module over the
+// same query context the host-URI lookup already opens, so provider resolution
+// costs one extra round trip and no extra connection.
+func chainLeaseQuery(cmd *cobra.Command) leaseQuery {
+	return func(ctx context.Context, owner string, dseq uint64) ([]mtypes.Lease, error) {
+		cctx, err := providerQueryContext(cmd)
+		if err != nil {
+			return nil, err
+		}
+
+		client := mvbeta.NewQueryClient(cctx)
+
+		var (
+			leases   []mtypes.Lease
+			pageKey  []byte
+			seenKeys = make(map[string]struct{})
+		)
+
+		for {
+			res, err := client.Leases(ctx, &mvbeta.QueryLeasesRequest{
+				Filters: mtypes.LeaseFilters{
+					Owner: owner,
+					DSeq:  dseq,
+				},
+				Pagination: &sdkquery.PageRequest{
+					Key:   append([]byte(nil), pageKey...),
+					Limit: leasePageLimit,
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("query leases for deployment %d: %w", dseq, err)
+			}
+			if res == nil {
+				return nil, fmt.Errorf("query leases for deployment %d: empty response", dseq)
+			}
+
+			for _, entry := range res.Leases {
+				leases = append(leases, entry.Lease)
+			}
+
+			var nextKey []byte
+			if res.Pagination != nil {
+				nextKey = res.Pagination.NextKey
+			}
+			if len(nextKey) == 0 {
+				return leases, nil
+			}
+
+			key := string(nextKey)
+			if _, seen := seenKeys[key]; seen {
+				return nil, fmt.Errorf("query leases for deployment %d: repeated pagination key", dseq)
+			}
+			seenKeys[key] = struct{}{}
+			pageKey = append(pageKey[:0], nextKey...)
+		}
+	}
+}

--- a/internal/cli/provider/lease_test.go
+++ b/internal/cli/provider/lease_test.go
@@ -1,0 +1,438 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+
+	mtypes "pkg.akt.dev/go/node/market/v1"
+)
+
+// Addresses used by the lease-resolution fixtures. testProviderAddr is shared
+// with commands_test.go.
+const (
+	testOwnerAddr         = "akash1errud3wyc0pvrs9lh67mewa6hxut0d44pfj6vh"
+	otherTestProviderAddr = "akash10d07y265gmmuvt4z0w9aw880jnsr700jhe7z0f"
+)
+
+// newLeaseCmd builds a provider command whose client context carries an owner,
+// so lease resolution has the same default account production has.
+func newLeaseCmd(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+
+	cmd := newProviderCmd(t, args...)
+
+	addr := mustAddrFrom(t, testOwnerAddr)
+	cctx := sdkclient.Context{}.WithFromAddress(addr)
+	cmd.SetContext(context.WithValue(context.Background(), sdkclient.ClientContextKey, &cctx))
+
+	return cmd
+}
+
+func mustAddrFrom(t *testing.T, bech32 string) sdk.AccAddress {
+	t.Helper()
+
+	addr, err := sdk.AccAddressFromBech32(bech32)
+	if err != nil {
+		t.Fatalf("test fixture %q is not a valid address: %v", bech32, err)
+	}
+
+	return addr
+}
+
+func testLease(gseq, oseq uint32, provider string, state mtypes.Lease_State) mtypes.Lease {
+	return mtypes.Lease{
+		ID: mtypes.LeaseID{
+			Owner:    testOwnerAddr,
+			DSeq:     12345,
+			GSeq:     gseq,
+			OSeq:     oseq,
+			Provider: provider,
+		},
+		State: state,
+	}
+}
+
+// leasesFixture returns a leaseQuery serving a fixed set of leases and
+// asserting the owner/dseq the resolver filtered on.
+func leasesFixture(t *testing.T, wantDSeq uint64, leases ...mtypes.Lease) leaseQuery {
+	t.Helper()
+
+	return func(_ context.Context, owner string, dseq uint64) ([]mtypes.Lease, error) {
+		if owner != testOwnerAddr {
+			t.Errorf("lease query owner = %q, want the context default account %q", owner, testOwnerAddr)
+		}
+		if dseq != wantDSeq {
+			t.Errorf("lease query dseq = %d, want %d", dseq, wantDSeq)
+		}
+
+		return leases, nil
+	}
+}
+
+func hostURIFixture(t *testing.T, wantProvider, url string) hostURIQuery {
+	t.Helper()
+
+	return func(_ context.Context, provider string) (string, error) {
+		if provider != wantProvider {
+			t.Errorf("host URI lookup provider = %q, want %q", provider, wantProvider)
+		}
+
+		return url, nil
+	}
+}
+
+// TestResolveLeaseAdoptsTheActiveLeaseProvider is the fix for the reported bug:
+// a deployment akt set up itself is already identified by its dseq, so no
+// --provider should be needed. The resolved lease is also authoritative for
+// gseq/oseq, which the caller never named.
+func TestResolveLeaseAdoptsTheActiveLeaseProvider(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345")
+
+	lid, url, err := resolveLeaseWith(cmd, nil,
+		leasesFixture(t, 12345,
+			testLease(1, 1, otherTestProviderAddr, mtypes.LeaseClosed),
+			testLease(2, 3, testProviderAddr, mtypes.LeaseActive),
+		),
+		hostURIFixture(t, testProviderAddr, "https://gw.example.com:8443"),
+		nil)
+	if err != nil {
+		t.Fatalf("resolveLeaseWith: %v", err)
+	}
+
+	if lid.Provider != testProviderAddr {
+		t.Errorf("provider = %q, want the active lease's %q", lid.Provider, testProviderAddr)
+	}
+	if lid.Owner != testOwnerAddr {
+		t.Errorf("owner = %q, want the context default account %q", lid.Owner, testOwnerAddr)
+	}
+	if lid.DSeq != 12345 {
+		t.Errorf("dseq = %d, want 12345", lid.DSeq)
+	}
+	if lid.GSeq != 2 || lid.OSeq != 3 {
+		t.Errorf("gseq/oseq = %d/%d, want the active lease's 2/3", lid.GSeq, lid.OSeq)
+	}
+	if url != "https://gw.example.com:8443" {
+		t.Errorf("gateway url = %q, want the resolved provider's host URI", url)
+	}
+}
+
+// TestResolveLeaseKeepsExplicitSequences proves an explicitly named group or
+// order is a filter, not a suggestion: it narrows the candidate leases and is
+// never overwritten by the one that matched.
+func TestResolveLeaseKeepsExplicitSequences(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345", "--gseq", "2", "--oseq", "1")
+
+	lid, _, err := resolveLeaseWith(cmd, nil,
+		leasesFixture(t, 12345,
+			testLease(1, 1, otherTestProviderAddr, mtypes.LeaseActive),
+			testLease(2, 1, testProviderAddr, mtypes.LeaseActive),
+		),
+		hostURIFixture(t, testProviderAddr, "https://gw.example.com:8443"),
+		nil)
+	if err != nil {
+		t.Fatalf("resolveLeaseWith: %v", err)
+	}
+
+	if lid.Provider != testProviderAddr {
+		t.Errorf("provider = %q, want the gseq-2 lease's %q", lid.Provider, testProviderAddr)
+	}
+	if lid.GSeq != 2 || lid.OSeq != 1 {
+		t.Errorf("gseq/oseq = %d/%d, want the explicit 2/1", lid.GSeq, lid.OSeq)
+	}
+}
+
+// TestResolveLeaseExplicitProviderSkipsTheChain keeps --provider a genuine
+// override: naming it must not cost a lease query.
+func TestResolveLeaseExplicitProviderSkipsTheChain(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345", "--provider", testProviderAddr,
+		"--provider-url", "https://override.example.com:8443")
+
+	lid, url, err := resolveLeaseWith(cmd, nil,
+		func(context.Context, string, uint64) ([]mtypes.Lease, error) {
+			t.Fatal("an explicit --provider must not trigger a lease lookup")
+			return nil, nil
+		},
+		func(context.Context, string) (string, error) {
+			t.Fatal("an explicit --provider-url must not trigger a host URI lookup")
+			return "", nil
+		},
+		nil)
+	if err != nil {
+		t.Fatalf("resolveLeaseWith: %v", err)
+	}
+	if lid.Provider != testProviderAddr {
+		t.Errorf("provider = %q, want the explicit %q", lid.Provider, testProviderAddr)
+	}
+	if lid.GSeq != 1 || lid.OSeq != 1 {
+		t.Errorf("gseq/oseq = %d/%d, want the flag defaults 1/1", lid.GSeq, lid.OSeq)
+	}
+	if url != "https://override.example.com:8443" {
+		t.Errorf("gateway url = %q, want the explicit override", url)
+	}
+}
+
+// TestResolveLeaseReportsNoLeases covers a dseq that never reached a lease —
+// the error must say so and point at a command that works.
+func TestResolveLeaseReportsNoLeases(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345")
+
+	_, _, err := resolveLeaseWith(cmd, nil, leasesFixture(t, 12345), nil, nil)
+	if err == nil {
+		t.Fatal("a deployment with no leases must fail")
+	}
+	if !strings.Contains(err.Error(), "deployment 12345 has no leases") {
+		t.Errorf("error should name the empty deployment, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "akt query market lease 12345") {
+		t.Errorf("error should point at a real inspection command, got %q", err)
+	}
+}
+
+// TestResolveLeaseReportsInactiveLeases mirrors the Console rail's wording
+// (internal/cli/console/gateway.go): list the states that do exist so the user
+// knows whether to wait or to redeploy.
+func TestResolveLeaseReportsInactiveLeases(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345")
+
+	_, _, err := resolveLeaseWith(cmd, nil,
+		leasesFixture(t, 12345,
+			testLease(1, 1, testProviderAddr, mtypes.LeaseClosed),
+			testLease(2, 1, otherTestProviderAddr, mtypes.LeaseInsufficientFunds),
+		),
+		nil, nil)
+	if err == nil {
+		t.Fatal("a deployment with no active lease must fail")
+	}
+	if !strings.Contains(err.Error(), "no active lease") {
+		t.Errorf("error should say no lease is active, got %q", err)
+	}
+	for _, state := range []string{"closed", "insufficient_funds"} {
+		if !strings.Contains(err.Error(), state) {
+			t.Errorf("error should list the %s state, got %q", state, err)
+		}
+	}
+}
+
+// TestResolveLeaseListsAmbiguousProviders covers the only case where
+// --provider is genuinely required. The addresses must be listed in full: a
+// truncated address cannot be pasted back into --provider.
+func TestResolveLeaseListsAmbiguousProviders(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345")
+
+	_, _, err := resolveLeaseWith(cmd, nil,
+		leasesFixture(t, 12345,
+			testLease(1, 1, testProviderAddr, mtypes.LeaseActive),
+			testLease(2, 1, otherTestProviderAddr, mtypes.LeaseActive),
+		),
+		nil, nil)
+	if err == nil {
+		t.Fatal("two active leases must not be resolved silently")
+	}
+	if !strings.Contains(err.Error(), "--provider") {
+		t.Errorf("error should ask for --provider, got %q", err)
+	}
+	for _, addr := range []string{testProviderAddr, otherTestProviderAddr} {
+		if !strings.Contains(err.Error(), addr) {
+			t.Errorf("error should list %s in full, got %q", addr, err)
+		}
+	}
+}
+
+// TestResolveLeaseRequiresADefaultAccount refuses to send an empty owner to
+// the chain, which means network-wide scope (SPEC §3.8.4).
+func TestResolveLeaseRequiresADefaultAccount(t *testing.T) {
+	// newProviderCmd has no client context, so there is no default account.
+	cmd := newProviderCmd(t, "--dseq", "12345")
+
+	_, _, err := resolveLeaseWith(cmd, nil,
+		func(context.Context, string, uint64) ([]mtypes.Lease, error) {
+			t.Fatal("an empty owner must never reach the chain")
+			return nil, nil
+		},
+		nil, nil)
+	if err == nil {
+		t.Fatal("resolution without a default account must fail")
+	}
+	if !strings.Contains(err.Error(), "default account") {
+		t.Errorf("error should name the missing default account, got %q", err)
+	}
+}
+
+// TestResolveLeaseOrdersDSeqThenPreflightThenProvider pins the ordering the
+// bug report exposed. Resolving the provider first meant a command missing
+// both values blamed the provider and never mentioned the dseq; the local
+// signing identity must still be validated before any network work.
+func TestResolveLeaseOrdersDSeqThenPreflightThenProvider(t *testing.T) {
+	preflighted := false
+	preflight := func() error {
+		preflighted = true
+		return fmt.Errorf("provider gateway authentication requires a configured default account")
+	}
+
+	// No dseq: the dseq guard fires before the preflight.
+	cmd := newLeaseCmd(t)
+	_, _, err := resolveLeaseWith(cmd, nil,
+		func(context.Context, string, uint64) ([]mtypes.Lease, error) {
+			t.Fatal("provider resolution ran without a dseq")
+			return nil, nil
+		}, nil, preflight)
+	if err == nil || !strings.Contains(err.Error(), "dseq is required") {
+		t.Fatalf("error = %v, want the missing dseq", err)
+	}
+	if preflighted {
+		t.Error("preflight ran before the dseq was resolved")
+	}
+
+	// With a dseq: the preflight fires before any lease lookup.
+	cmd = newLeaseCmd(t, "--dseq", "12345")
+	_, _, err = resolveLeaseWith(cmd, nil,
+		func(context.Context, string, uint64) ([]mtypes.Lease, error) {
+			t.Fatal("lease lookup ran before the authentication preflight")
+			return nil, nil
+		}, nil, preflight)
+	if err == nil || !strings.Contains(err.Error(), "configured default account") {
+		t.Fatalf("error = %v, want the signing identity remedy", err)
+	}
+	if !preflighted {
+		t.Error("preflight never ran")
+	}
+}
+
+// TestActiveLeaseProvidersReturnsEveryProvider backs `send-manifest` without
+// --provider, which SPEC §2.4 defines as delivery to all active leases.
+func TestActiveLeaseProvidersReturnsEveryProvider(t *testing.T) {
+	scope := leaseScope{Owner: testOwnerAddr, DSeq: 12345}
+
+	providers, err := activeLeaseProviders(context.Background(), scope,
+		leasesFixture(t, 12345,
+			testLease(1, 1, testProviderAddr, mtypes.LeaseActive),
+			testLease(2, 1, otherTestProviderAddr, mtypes.LeaseActive),
+			// A second active lease with the same provider must not
+			// produce a duplicate submission.
+			testLease(3, 1, testProviderAddr, mtypes.LeaseActive),
+			testLease(4, 1, otherTestProviderAddr, mtypes.LeaseClosed),
+		))
+	if err != nil {
+		t.Fatalf("activeLeaseProviders: %v", err)
+	}
+
+	want := []string{otherTestProviderAddr, testProviderAddr}
+	if len(providers) != len(want) {
+		t.Fatalf("providers = %v, want %v", providers, want)
+	}
+	for i := range want {
+		if providers[i] != want[i] {
+			t.Errorf("providers = %v, want %v (sorted)", providers, want)
+		}
+	}
+}
+
+func TestActiveLeaseProvidersReportsNoActiveLease(t *testing.T) {
+	scope := leaseScope{Owner: testOwnerAddr, DSeq: 12345}
+
+	_, err := activeLeaseProviders(context.Background(), scope,
+		leasesFixture(t, 12345, testLease(1, 1, testProviderAddr, mtypes.LeaseClosed)))
+	if err == nil {
+		t.Fatal("a deployment with no active lease must fail")
+	}
+	if !strings.Contains(err.Error(), "no active lease") ||
+		!strings.Contains(err.Error(), "akt query market lease 12345") {
+		t.Errorf("error should name the problem and a real remedy, got %q", err)
+	}
+}
+
+// TestSendManifestTargetsRefusesOneURLForManyProviders keeps --provider-url an
+// honest single-gateway override: it cannot stand in for a fan-out.
+func TestSendManifestTargetsRefusesOneURLForManyProviders(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345", "--provider-url", "https://gw.example.com:8443")
+
+	scope, err := leaseScopeFromCmd(cmd, nil)
+	if err != nil {
+		t.Fatalf("leaseScopeFromCmd: %v", err)
+	}
+
+	leases := leasesFixture(t, 12345,
+		testLease(1, 1, testProviderAddr, mtypes.LeaseActive),
+		testLease(2, 1, otherTestProviderAddr, mtypes.LeaseActive),
+	)
+
+	if _, err := sendManifestTargets(cmd, scope, leases); err == nil {
+		t.Fatal("--provider-url with several active leases must be refused")
+	} else if !strings.Contains(err.Error(), "--provider") {
+		t.Errorf("error should ask for --provider, got %q", err)
+	}
+}
+
+// TestSendManifestTargetsFansOutToEveryActiveLease is SPEC §2.4's documented
+// default for send-manifest: no --provider means every provider holding an
+// active lease.
+func TestSendManifestTargetsFansOutToEveryActiveLease(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345")
+
+	scope, err := leaseScopeFromCmd(cmd, nil)
+	if err != nil {
+		t.Fatalf("leaseScopeFromCmd: %v", err)
+	}
+
+	providers, err := sendManifestTargets(cmd, scope, leasesFixture(t, 12345,
+		testLease(1, 1, testProviderAddr, mtypes.LeaseActive),
+		testLease(2, 1, otherTestProviderAddr, mtypes.LeaseActive),
+		testLease(3, 1, testProviderAddr, mtypes.LeaseClosed),
+	))
+	if err != nil {
+		t.Fatalf("sendManifestTargets: %v", err)
+	}
+	if len(providers) != 2 {
+		t.Fatalf("providers = %v, want both active-lease providers", providers)
+	}
+}
+
+// TestSendManifestTargetsHonorsAnExplicitProvider keeps --provider a narrowing
+// override, and must not spend a lease query to honor it.
+func TestSendManifestTargetsHonorsAnExplicitProvider(t *testing.T) {
+	cmd := newLeaseCmd(t, "--dseq", "12345", "--provider", testProviderAddr)
+
+	scope, err := leaseScopeFromCmd(cmd, nil)
+	if err != nil {
+		t.Fatalf("leaseScopeFromCmd: %v", err)
+	}
+
+	providers, err := sendManifestTargets(cmd, scope,
+		func(context.Context, string, uint64) ([]mtypes.Lease, error) {
+			t.Fatal("an explicit --provider must not trigger a lease lookup")
+			return nil, nil
+		})
+	if err != nil {
+		t.Fatalf("sendManifestTargets: %v", err)
+	}
+	if len(providers) != 1 || providers[0] != testProviderAddr {
+		t.Errorf("providers = %v, want only the explicit %s", providers, testProviderAddr)
+	}
+}
+
+// TestMissingDSeqErrorNamesTheAcceptedForm pins that the remedy matches the
+// command: a positional-[dseq] command must never be told to pass --dseq, and
+// a flag-only command must never be told to pass a positional.
+func TestMissingDSeqErrorNamesTheAcceptedForm(t *testing.T) {
+	positional := &cobra.Command{Use: "lease-status"}
+	addLeaseFlags(positional)
+
+	if err := missingDSeqError(positional); !strings.Contains(err.Error(), "positional argument") {
+		t.Errorf("positional-dseq command remedy = %q, want the positional form", err)
+	} else if strings.Contains(err.Error(), "--dseq") {
+		t.Errorf("positional-dseq command must not advertise the disabled --dseq flag: %q", err)
+	}
+
+	flagged := &cobra.Command{Use: "lease-shell"}
+	addLeaseShellFlags(flagged)
+
+	if err := missingDSeqError(flagged); !strings.Contains(err.Error(), "--dseq") {
+		t.Errorf("flag-dseq command remedy = %q, want --dseq", err)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #43; merge after #43. GitHub shows only this provider group in the
diff.

- accept the documented positional `akt query provider [address]` syntax while
  retaining `list` and `get` compatibility commands
- resolve lease-scoped gateway commands from a deployment's unique active lease
- inherit provider, gseq, and oseq from that lease unless explicitly overridden
- distinguish no leases, no active leases, and ambiguous active leases with
  actionable errors that include full provider addresses
- fan `send-manifest` out to every active lease when no provider is selected
- remove documented flags that were never registered or supported

## Reproduction

Before this change, the documented query failed during command parsing:

```console
$ akt query provider akash1...
unknown command "akash1..." for "provider"
```

Lease commands also required users to rediscover and pass `--provider`, even
though the dseq already identified active leases, and their error incorrectly
claimed the provider could be positional.

## Validation

- `GOWORK=off CGO_ENABLED=0 go build -tags
  "osusergo,netgo,nolink_libwasmvm" -o .cache/bin/akt ./cmd/akt`
- `GOWORK=off CGO_ENABLED=0 go test -tags
  "osusergo,netgo,nolink_libwasmvm" ./... -count=1`
- `GOWORK=off CGO_ENABLED=0 go vet -tags
  "osusergo,netgo,nolink_libwasmvm" ./internal/... ./cmd/...`
- `gofmt -l internal cmd e2e` (empty)
- `git diff --check`
- direct-query smoke reached the supplied RPC endpoint instead of returning an
  unknown-command error
- `provider lease-status --help` shows `[dseq]` and describes `--provider` as an
  optional override defaulting from the active lease

No deployments, leases, or other chain state were created or changed during
this validation.
