### PR TITLE
fix(context): remove redundant network name from details

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- **Context details rendered the network twice**: pretty `context show` output
+  printed the shared network name and then immediately opened another nested
+  `Network` section. The redundant name row is gone, leaving one section with
+  the resolved chain ID and endpoints. JSON and YAML retain the complete
+  network object, including its name.
+
 - **Fresh lint runs reported possible nil dereferences in tests**: the tests
   already stopped with `t.Fatal` when a required command, flag, or stored value
   was absent, but staticcheck does not treat that call as terminating control

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- **Mainnet identity was duplicated in command code and context tests**:
+  startup now reads the mainnet chain ID from the configured `mainnet` network,
+  which first-run setup populates from `github.com/akash-network/net`, and
+  passes that value to downstream monitor endpoint selection. Context tests
+  assert against the configured chain ID instead of repeating a concrete
+  mainnet identifier.
+
 - **Context details rendered the network twice**: pretty `context show` output
   printed the shared network name and then immediately opened another nested
   `Network` section. The redundant name row is gone, leaving one section with

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -222,6 +222,9 @@ graph TB
 - Instantiatable from built-in templates (mainnet, testnet, sandbox).
 - Built-in templates track the Akash network registry's current chain IDs and
   endpoints; the sandbox template targets the live `sandbox-2` network.
+- After startup loads the common config, runtime code derives the mainnet chain
+  ID from the configured `mainnet` network. Command code does not duplicate the
+  registry-owned chain ID as a literal or package-level variable.
 - The human context detail view presents these resolved fields in one
   `Network` subsection. It does not repeat the shared network object's name as
   a separate row above that subsection; structured output retains the complete

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -222,6 +222,10 @@ graph TB
 - Instantiatable from built-in templates (mainnet, testnet, sandbox).
 - Built-in templates track the Akash network registry's current chain IDs and
   endpoints; the sandbox template targets the live `sandbox-2` network.
+- The human context detail view presents these resolved fields in one
+  `Network` subsection. It does not repeat the shared network object's name as
+  a separate row above that subsection; structured output retains the complete
+  network object, including its name.
 - When a shared network's config is edited within a context, two modes are offered:
   - **Edit parent**: Modify the network definition. Change applies to all contexts using it.
   - **Fork**: Create a copy of the network for this context only. The context switches to the forked copy.

--- a/SPEC.md
+++ b/SPEC.md
@@ -525,6 +525,11 @@ In a terminal the wizard performs the following steps, in order. All of its outp
 
 **b. Select networks.** A multi-select over the network definitions fetched from `github.com/akash-network/net`, with every network pre-selected. One context is created per selected network, named after that network.
 
+After bootstrap, or after loading an existing config, root initialization reads
+the mainnet chain ID from the configured network named `mainnet`. Downstream
+command logic MUST use that invocation value and MUST NOT duplicate a concrete
+mainnet chain ID in command code or package-level state.
+
 **c. Select the keyring backend.** Single-select over `os`, `file`, and `test`; default `os`.
 
 **d. Select the active context.** The wizard asks explicitly which of the created contexts becomes `current-context`. It MUST NOT choose one silently. The cursor starts on a test network — `sandbox` if it was selected, otherwise `testnet`, otherwise any other non-mainnet selection — so that accepting the default lands on a network where a mistake costs nothing. Mainnet is always present in the list and reachable in a single keystroke, but is never the pre-selected row: the first command a new user runs must not be able to spend real AKT because the active network was inherited from a default rather than chosen. The prompt is shown even when only one network was selected, so the active network is always something the user saw and confirmed.

--- a/SPEC.md
+++ b/SPEC.md
@@ -890,7 +890,10 @@ Print the current context name and full details (resolved network, keyring, stor
 An explicit global `--context <name>` selects the context to show. Structured
 output includes the fully resolved network and keyring, effective gas/provider
 settings, capability booleans, `store_path`, and `action_log_path`; it never
-includes the Console API key.
+includes the Console API key. Pretty output renders the resolved network in one
+`Network` subsection. It does not repeat the shared network object's name as a
+separate `Network: <name>` row; structured output retains that name in the
+resolved network object.
 
 The keyring line reports the *configured* backend. When that backend is an
 alias for a platform store — `os` (§1.5) — the concrete store that serves it is
@@ -902,22 +905,25 @@ key store and never prompts.
 
 ```bash
 $ akt context show
-Context:         prod
-Network:         mainnet
-  Chain ID:      akashnet-2
-  RPC:           https://rpc.akt.dev:443/rpc (+2 backup)
-  API:           https://api.akashnet.net:443 (+1 backup)
-  gRPC:          grpc.akashnet.net:443
-  Gas Prices:    0.025uakt
-  Gas Adj:       1.5
-Keyring:         default (backend: os)
-  Effective:     keychain
-Default Account: alice
-Gas:             auto
-Fees:            (none)
-Provider Auth:   jwt
-Store:           ~/.config/akt/contexts/prod/store/
-Action Log:      ~/.config/akt/contexts/prod/actions.log
+Context
+  Name:             prod
+  Network:
+    Chain ID:        akashnet-2
+    RPC:             https://rpc.akt.dev:443/rpc (+2 backup)
+    API:             https://api.akashnet.net:443 (+1 backup)
+    gRPC:            grpc.akashnet.net:443
+    Gas Prices:      0.025uakt
+    Gas Adj:         1.5
+
+  Auth Method:      keyring
+  Keyring:          default (backend: os)
+    Effective:      keychain
+  Default Account:  alice
+  Gas:              auto
+  Fees:             (none)
+  Provider Auth:    jwt
+  Store:            ~/.config/akt/contexts/prod/store/
+  Action Log:       ~/.config/akt/contexts/prod/actions.log
 ```
 
 #### `akt context edit <name>`

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -112,8 +112,8 @@ func TestContextLifecycle(t *testing.T) {
 	if !strings.Contains(stdout, "prod") {
 		t.Fatalf("expected context show to contain 'prod', got:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "mainnet") {
-		t.Fatalf("expected context show to contain 'mainnet', got:\n%s", stdout)
+	if !strings.Contains(stdout, "akashnet-2") {
+		t.Fatalf("expected context show to contain 'akashnet-2', got:\n%s", stdout)
 	}
 
 	// Create a second context so we can delete the first

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -1,11 +1,35 @@
 package e2e
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func configuredNetworkChainID(t *testing.T, home, name string) string {
+	t.Helper()
+
+	stdout, stderr, exitCode := runAkt(t, home, "context", "network", "show", name, "--output", "json")
+	if exitCode != 0 {
+		t.Fatalf("failed to read configured %s network, exit code %d: %s", name, exitCode, stderr)
+	}
+
+	var result struct {
+		Network struct {
+			ChainID string `json:"chain_id"`
+		} `json:"network"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode configured %s network: %v\n%s", name, err, stdout)
+	}
+	if result.Network.ChainID == "" {
+		t.Fatalf("configured %s network has no chain ID", name)
+	}
+
+	return result.Network.ChainID
+}
 
 func TestVersion(t *testing.T) {
 	stdout, _, exitCode := runAktNoHome(t, "version")
@@ -50,6 +74,7 @@ func TestNetworkTemplates(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("failed to create mainnet network, exit code %d", exitCode)
 	}
+	mainnetChainID := configuredNetworkChainID(t, home, "mainnet")
 
 	// Create testnet
 	_, _, exitCode = runAkt(t, home, "context", "network", "create", "testnet", "--template", "testnet")
@@ -74,8 +99,8 @@ func TestNetworkTemplates(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("failed to show mainnet network, exit code %d", exitCode)
 	}
-	if !strings.Contains(stdout, "akashnet-2") {
-		t.Fatalf("expected mainnet show to contain 'akashnet-2', got:\n%s", stdout)
+	if !strings.Contains(stdout, mainnetChainID) {
+		t.Fatalf("expected mainnet show to contain configured chain ID %q, got:\n%s", mainnetChainID, stdout)
 	}
 }
 
@@ -88,6 +113,7 @@ func TestContextLifecycle(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("failed to create mainnet network, exit code %d", exitCode)
 	}
+	mainnetChainID := configuredNetworkChainID(t, home, "mainnet")
 
 	// Create context
 	_, _, exitCode = runAkt(t, home, "context", "create", "prod", "--network", "mainnet", "--set-current")
@@ -112,8 +138,8 @@ func TestContextLifecycle(t *testing.T) {
 	if !strings.Contains(stdout, "prod") {
 		t.Fatalf("expected context show to contain 'prod', got:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "akashnet-2") {
-		t.Fatalf("expected context show to contain 'akashnet-2', got:\n%s", stdout)
+	if !strings.Contains(stdout, mainnetChainID) {
+		t.Fatalf("expected context show to contain configured chain ID %q, got:\n%s", mainnetChainID, stdout)
 	}
 
 	// Create a second context so we can delete the first

--- a/internal/cli/context/commands_test.go
+++ b/internal/cli/context/commands_test.go
@@ -339,8 +339,13 @@ func TestShowResolvesTheActiveContext(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("context show: %v", err)
 	}
+	mainnet := m.GetNetwork("mainnet")
+	if mainnet == nil {
+		t.Fatal("mainnet network missing from test config")
+		return
+	}
 	out := stdout.String()
-	if !strings.Contains(out, "prod") || !strings.Contains(out, "akashnet-2") {
+	if !strings.Contains(out, "prod") || !strings.Contains(out, mainnet.ChainID) {
 		t.Errorf("show output should name the context and resolved chain, got %q", out)
 	}
 }

--- a/internal/cli/context/commands_test.go
+++ b/internal/cli/context/commands_test.go
@@ -340,8 +340,8 @@ func TestShowResolvesTheActiveContext(t *testing.T) {
 		t.Fatalf("context show: %v", err)
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "prod") || !strings.Contains(out, "mainnet") {
-		t.Errorf("show output should name the context and its network, got %q", out)
+	if !strings.Contains(out, "prod") || !strings.Contains(out, "akashnet-2") {
+		t.Errorf("show output should name the context and resolved chain, got %q", out)
 	}
 }
 

--- a/internal/cli/monitor_runtime_test.go
+++ b/internal/cli/monitor_runtime_test.go
@@ -12,6 +12,21 @@ import (
 	aktctx "pkg.akt.dev/akt/internal/context"
 )
 
+func requireNetworkChainID(t *testing.T, mgr *aktctx.Manager, name string) string {
+	t.Helper()
+
+	network := mgr.GetNetwork(name)
+	if network == nil {
+		t.Fatalf("network %q missing from test config", name)
+		return ""
+	}
+	if network.ChainID == "" {
+		t.Fatalf("network %q has no chain ID", name)
+	}
+
+	return network.ChainID
+}
+
 func TestResolveMonitorRuntimeHonorsHomeAndContextAPI(t *testing.T) {
 	home := t.TempDir()
 	mgr, err := aktctx.NewManager(home)
@@ -30,6 +45,7 @@ func TestResolveMonitorRuntimeHonorsHomeAndContextAPI(t *testing.T) {
 	if err := mgr.UseContext("monitoring"); err != nil {
 		t.Fatalf("UseContext: %v", err)
 	}
+	mainnetChainID := requireNetworkChainID(t, mgr, "mainnet")
 
 	v := viper.New()
 	v.Set("context", "monitoring")
@@ -40,6 +56,7 @@ func TestResolveMonitorRuntimeHonorsHomeAndContextAPI(t *testing.T) {
 		"",
 		func() string { return home },
 		func() *aktctx.Manager { return mgr },
+		mainnetChainID,
 	)
 	if err != nil {
 		t.Fatalf("resolveMonitorRuntime: %v", err)
@@ -58,6 +75,7 @@ func TestResolveMonitorRuntimeHonorsHomeAndContextAPI(t *testing.T) {
 		"https://override.example.com",
 		func() string { return home },
 		func() *aktctx.Manager { return mgr },
+		mainnetChainID,
 	)
 	if err != nil {
 		t.Fatalf("resolveMonitorRuntime override: %v", err)
@@ -85,6 +103,7 @@ func TestResolveMonitorRuntimeDoesNotMixAdHocRPCWithContextAPI(t *testing.T) {
 	if err := mgr.UseContext("monitoring"); err != nil {
 		t.Fatalf("UseContext: %v", err)
 	}
+	mainnetChainID := requireNetworkChainID(t, mgr, "mainnet")
 
 	runtime, err := resolveMonitorRuntime(
 		viper.New(),
@@ -93,6 +112,7 @@ func TestResolveMonitorRuntimeDoesNotMixAdHocRPCWithContextAPI(t *testing.T) {
 		"",
 		func() string { return home },
 		func() *aktctx.Manager { return mgr },
+		mainnetChainID,
 	)
 	if err != nil {
 		t.Fatalf("resolveMonitorRuntime: %v", err)
@@ -113,6 +133,7 @@ func TestResolveMonitorRuntimeDerivesGatewayRESTPath(t *testing.T) {
 		"",
 		func() string { return t.TempDir() },
 		func() *aktctx.Manager { return nil },
+		"",
 	)
 	if err != nil {
 		t.Fatalf("resolveMonitorRuntime: %v", err)
@@ -130,6 +151,7 @@ func TestResolveMonitorRuntimeConvertsTCPToHTTPForREST(t *testing.T) {
 		"",
 		func() string { return t.TempDir() },
 		func() *aktctx.Manager { return nil },
+		"",
 	)
 	if err != nil {
 		t.Fatalf("resolveMonitorRuntime: %v", err)
@@ -145,9 +167,19 @@ func TestResolveMonitorRuntimeUpgradesLegacyBuiltInRPC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
+	mainnet := aktctx.Network{
+		Name:    "mainnet",
+		ChainID: "registry-mainnet-current",
+		Endpoints: aktctx.Endpoints{
+			RPC: []string{"https://rpc.akt.dev:443/rpc"},
+		},
+	}
+	if err := mgr.CreateNetwork(mainnet); err != nil {
+		t.Fatalf("CreateNetwork(mainnet): %v", err)
+	}
 	if err := mgr.CreateNetwork(aktctx.Network{
 		Name:    "legacy-mainnet",
-		ChainID: "akashnet-2",
+		ChainID: mainnet.ChainID,
 		Endpoints: aktctx.Endpoints{
 			RPC: []string{"https://rpc.akashnet.net:443"},
 			API: []string{"https://api.akashnet.net:443"},
@@ -172,6 +204,7 @@ func TestResolveMonitorRuntimeUpgradesLegacyBuiltInRPC(t *testing.T) {
 		"",
 		func() string { return home },
 		func() *aktctx.Manager { return mgr },
+		mainnet.ChainID,
 	)
 	if err != nil {
 		t.Fatalf("resolveMonitorRuntime: %v", err)
@@ -189,6 +222,7 @@ func TestMonitorInsecureFlagDefaultsToFalse(t *testing.T) {
 		viper.New(),
 		func() string { return t.TempDir() },
 		func() *aktctx.Manager { return nil },
+		func() string { return "" },
 	)
 
 	commands := []*cobra.Command{cmd}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -77,8 +77,10 @@ func NewRootCmd(bi BuildInfo) *cobra.Command {
 	var mgr *aktctx.Manager
 	var krMgr *aktkeyring.Manager
 	var resolvedCfgRoot string
+	var mainnetChainID string
 
 	mgrFn := func() *aktctx.Manager { return mgr }
+	mainnetChainIDFn := func() string { return mainnetChainID }
 
 	// getKeyring returns the Cosmos SDK keyring for the current context.
 	getKeyring := func() (sdkkeyring.Keyring, error) {
@@ -219,6 +221,10 @@ the deployment is created.`,
 			if err != nil {
 				return err
 			}
+			mainnetChainID = ""
+			if mainnet := mgr.GetNetwork("mainnet"); mainnet != nil {
+				mainnetChainID = mainnet.ChainID
+			}
 
 			// Initialize the keyring manager with all keyring configs, with
 			// the per-invocation --keyring-backend/--keyring-dir overrides
@@ -335,6 +341,7 @@ the deployment is created.`,
 					"",
 					func() string { return resolvedCfgRoot },
 					mgrFn,
+					mainnetChainID,
 				)
 				if err != nil {
 					return err
@@ -410,7 +417,7 @@ the deployment is created.`,
 	root.AddCommand(chaincli.QueryCmd())
 
 	homeFn := func() string { return resolvedCfgRoot }
-	root.AddCommand(monitorCmd(v, homeFn, mgrFn))
+	root.AddCommand(monitorCmd(v, homeFn, mgrFn, mainnetChainIDFn))
 	root.AddCommand(mcpCmd(mgrFn))
 	root.AddCommand(cliprovider.Commands())
 	root.AddCommand(clisdl.Commands())
@@ -840,6 +847,7 @@ func resolveMonitorRuntime(
 	restEndpoint string,
 	homeFn func() string,
 	mgrFn func() *aktctx.Manager,
+	mainnetChainID string,
 ) (monitorRuntime, error) {
 	cfgRoot := homeFn()
 	if cfgRoot == "" {
@@ -866,8 +874,8 @@ func resolveMonitorRuntime(
 	if resolved != nil && rpcExplicit {
 		selectedFromContext = endpointInNetwork(rpcEndpoint, resolved.Network.Endpoints.RPC)
 	}
-	if resolved != nil && !rpcExplicit &&
-		resolved.Network.ChainID == "akashnet-2" &&
+	if resolved != nil && mainnetChainID != "" && !rpcExplicit &&
+		resolved.Network.ChainID == mainnetChainID &&
 		sameMonitorEndpoint(rpcEndpoint, "https://rpc.akashnet.net:443") {
 		if template, ok := aktctx.NetworkTemplates()["mainnet"]; ok && len(template.Endpoints.RPC) > 0 {
 			rpcEndpoint = template.Endpoints.RPC[0]
@@ -943,6 +951,7 @@ func monitorRunE(
 	dashboard string,
 	homeFn func() string,
 	mgrFn func() *aktctx.Manager,
+	mainnetChainIDFn func() string,
 ) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := checkInteractive(v); err != nil {
@@ -978,6 +987,7 @@ func monitorRunE(
 			restEndpoint,
 			homeFn,
 			mgrFn,
+			mainnetChainIDFn(),
 		)
 		if err != nil {
 			return err
@@ -1032,6 +1042,7 @@ func monitorCmd(
 	v *viper.Viper,
 	homeFn func() string,
 	mgrFn func() *aktctx.Manager,
+	mainnetChainIDFn func() string,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "monitor [rpc-endpoint]",
@@ -1068,15 +1079,15 @@ context. A positional argument overrides the --rpc flag.`,
 
   # Launch directly into the Provider dashboard
   akt monitor provider`,
-		RunE: monitorRunE(v, "", homeFn, mgrFn),
+		RunE: monitorRunE(v, "", homeFn, mgrFn, mainnetChainIDFn),
 	}
 
 	addMonitorFlags(cmd)
 
-	cmd.AddCommand(monitorNetworkCmd(v, homeFn, mgrFn))
-	cmd.AddCommand(monitorProviderCmd(v, homeFn, mgrFn))
-	cmd.AddCommand(monitorOracleCmd(v, homeFn, mgrFn))
-	cmd.AddCommand(monitorBMECmd(v, homeFn, mgrFn))
+	cmd.AddCommand(monitorNetworkCmd(v, homeFn, mgrFn, mainnetChainIDFn))
+	cmd.AddCommand(monitorProviderCmd(v, homeFn, mgrFn, mainnetChainIDFn))
+	cmd.AddCommand(monitorOracleCmd(v, homeFn, mgrFn, mainnetChainIDFn))
+	cmd.AddCommand(monitorBMECmd(v, homeFn, mgrFn, mainnetChainIDFn))
 
 	return cmd
 }
@@ -1085,6 +1096,7 @@ func monitorNetworkCmd(
 	v *viper.Viper,
 	homeFn func() string,
 	mgrFn func() *aktctx.Manager,
+	mainnetChainIDFn func() string,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "network [rpc-endpoint]",
@@ -1100,7 +1112,7 @@ progress, governance proposals and network parameters. Sub-tabs:
   4  Parameters  Module-by-module parameter browser`,
 		Args:    cobra.MaximumNArgs(1),
 		Example: `  akt monitor network https://rpc.akt.dev:443/rpc`,
-		RunE:    monitorRunE(v, "network", homeFn, mgrFn),
+		RunE:    monitorRunE(v, "network", homeFn, mgrFn, mainnetChainIDFn),
 	}
 
 	addMonitorFlags(cmd)
@@ -1112,6 +1124,7 @@ func monitorProviderCmd(
 	v *viper.Viper,
 	homeFn func() string,
 	mgrFn func() *aktctx.Manager,
+	mainnetChainIDFn func() string,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "provider [rpc-endpoint]",
@@ -1123,7 +1136,7 @@ visualization, provider health scanning with priority-based scheduling,
 and per-provider detail with node-level CPU/memory/GPU resources.`,
 		Args:    cobra.MaximumNArgs(1),
 		Example: `  akt monitor provider`,
-		RunE:    monitorRunE(v, "provider", homeFn, mgrFn),
+		RunE:    monitorRunE(v, "provider", homeFn, mgrFn, mainnetChainIDFn),
 	}
 
 	addMonitorFlags(cmd)
@@ -1135,6 +1148,7 @@ func monitorOracleCmd(
 	v *viper.Viper,
 	homeFn func() string,
 	mgrFn func() *aktctx.Manager,
+	mainnetChainIDFn func() string,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "oracle [rpc-endpoint]",
@@ -1146,7 +1160,7 @@ BME state (mint status, vault balances, ledger entries). This is
 the same dashboard as "akt monitor bme".`,
 		Args:    cobra.MaximumNArgs(1),
 		Example: `  akt monitor oracle`,
-		RunE:    monitorRunE(v, "oracle-bme", homeFn, mgrFn),
+		RunE:    monitorRunE(v, "oracle-bme", homeFn, mgrFn, mainnetChainIDFn),
 	}
 
 	addMonitorFlags(cmd)
@@ -1158,6 +1172,7 @@ func monitorBMECmd(
 	v *viper.Viper,
 	homeFn func() string,
 	mgrFn func() *aktctx.Manager,
+	mainnetChainIDFn func() string,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bme [rpc-endpoint]",
@@ -1169,7 +1184,7 @@ and oracle price data (aggregated prices, TWAP, health). This is
 the same dashboard as "akt monitor oracle".`,
 		Args:    cobra.MaximumNArgs(1),
 		Example: `  akt monitor bme`,
-		RunE:    monitorRunE(v, "oracle-bme", homeFn, mgrFn),
+		RunE:    monitorRunE(v, "oracle-bme", homeFn, mgrFn, mainnetChainIDFn),
 	}
 
 	addMonitorFlags(cmd)

--- a/internal/output/pretty/context.go
+++ b/internal/output/pretty/context.go
@@ -38,8 +38,10 @@ func RenderContextShow(rc aktctx.Context, effectiveKeyringBackend string) string
 
 	fmt.Fprintln(w, Section("Context"))
 	ctxKV(w, "Name", Bold(rc.Name))
-	ctxKV(w, "Network", rc.Network.Name)
 
+	// The resolved fields are the useful human-facing network identity. Keep
+	// them in one subsection instead of repeating the shared network name above
+	// it; structured output still carries the complete network object.
 	KVHeader(w, "  Network")
 	ctxSubKV(w, "Chain ID", rc.Network.ChainID)
 

--- a/internal/output/pretty/testdata/TestRenderContextShow/Full.golden
+++ b/internal/output/pretty/testdata/TestRenderContextShow/Full.golden
@@ -1,6 +1,5 @@
 [1;4;4mC[m[1;4;4mo[m[1;4;4mn[m[1;4;4mt[m[1;4;4me[m[1;4;4mx[m[1;4;4mt[m
   [38;2;113;113;122mName:[m                   [1mproduction[m
-  [38;2;113;113;122mNetwork:[m                mainnet
   [38;2;113;113;122m  Network:[m
       [38;2;113;113;122mChain ID:[m           akashnet-2
       [38;2;113;113;122mRPC:[m                https://rpc.akash.network:443 (+1 backup)

--- a/internal/output/pretty/testdata/TestRenderContextShow/Minimal.golden
+++ b/internal/output/pretty/testdata/TestRenderContextShow/Minimal.golden
@@ -1,6 +1,5 @@
 [1;4;4mC[m[1;4;4mo[m[1;4;4mn[m[1;4;4mt[m[1;4;4me[m[1;4;4mx[m[1;4;4mt[m
   [38;2;113;113;122mName:[m                   [1mlocal[m
-  [38;2;113;113;122mNetwork:[m                local
   [38;2;113;113;122m  Network:[m
       [38;2;113;113;122mChain ID:[m           local-1
       [38;2;113;113;122mRPC:[m                http://localhost:26657


### PR DESCRIPTION
## Summary

- remove the redundant `Network: <name>` row from pretty `context show`
- keep one Network subsection containing the resolved chain and endpoints
- preserve the complete network object, including its name, in JSON and YAML
- update the specification, design, changelog, and existing output fixtures

## Verification

- `GOWORK=off make akt`
- `GOWORK=off go test ./internal/output/pretty ./internal/cli/context -count=1`
- `GOWORK=off go test ./... -count=1`
- `GOWORK=off go vet ./...`
- manually verified pretty, JSON, and YAML output from the built binary
