### PR TITLE
fix(context): remove redundant network name from details

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- **Context details rendered the network twice**: pretty `context show` output
+  printed the shared network name and then immediately opened another nested
+  `Network` section. The redundant name row is gone, leaving one section with
+  the resolved chain ID and endpoints. JSON and YAML retain the complete
+  network object, including its name.
+
 - **Fresh lint runs reported possible nil dereferences in tests**: the tests
   already stopped with `t.Fatal` when a required command, flag, or stored value
   was absent, but staticcheck does not treat that call as terminating control

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -222,6 +222,10 @@ graph TB
 - Instantiatable from built-in templates (mainnet, testnet, sandbox).
 - Built-in templates track the Akash network registry's current chain IDs and
   endpoints; the sandbox template targets the live `sandbox-2` network.
+- The human context detail view presents these resolved fields in one
+  `Network` subsection. It does not repeat the shared network object's name as
+  a separate row above that subsection; structured output retains the complete
+  network object, including its name.
 - When a shared network's config is edited within a context, two modes are offered:
   - **Edit parent**: Modify the network definition. Change applies to all contexts using it.
   - **Fork**: Create a copy of the network for this context only. The context switches to the forked copy.

--- a/SPEC.md
+++ b/SPEC.md
@@ -890,7 +890,10 @@ Print the current context name and full details (resolved network, keyring, stor
 An explicit global `--context <name>` selects the context to show. Structured
 output includes the fully resolved network and keyring, effective gas/provider
 settings, capability booleans, `store_path`, and `action_log_path`; it never
-includes the Console API key.
+includes the Console API key. Pretty output renders the resolved network in one
+`Network` subsection. It does not repeat the shared network object's name as a
+separate `Network: <name>` row; structured output retains that name in the
+resolved network object.
 
 The keyring line reports the *configured* backend. When that backend is an
 alias for a platform store — `os` (§1.5) — the concrete store that serves it is
@@ -902,22 +905,25 @@ key store and never prompts.
 
 ```bash
 $ akt context show
-Context:         prod
-Network:         mainnet
-  Chain ID:      akashnet-2
-  RPC:           https://rpc.akt.dev:443/rpc (+2 backup)
-  API:           https://api.akashnet.net:443 (+1 backup)
-  gRPC:          grpc.akashnet.net:443
-  Gas Prices:    0.025uakt
-  Gas Adj:       1.5
-Keyring:         default (backend: os)
-  Effective:     keychain
-Default Account: alice
-Gas:             auto
-Fees:            (none)
-Provider Auth:   jwt
-Store:           ~/.config/akt/contexts/prod/store/
-Action Log:      ~/.config/akt/contexts/prod/actions.log
+Context
+  Name:             prod
+  Network:
+    Chain ID:        akashnet-2
+    RPC:             https://rpc.akt.dev:443/rpc (+2 backup)
+    API:             https://api.akashnet.net:443 (+1 backup)
+    gRPC:            grpc.akashnet.net:443
+    Gas Prices:      0.025uakt
+    Gas Adj:         1.5
+
+  Auth Method:      keyring
+  Keyring:          default (backend: os)
+    Effective:      keychain
+  Default Account:  alice
+  Gas:              auto
+  Fees:             (none)
+  Provider Auth:    jwt
+  Store:            ~/.config/akt/contexts/prod/store/
+  Action Log:       ~/.config/akt/contexts/prod/actions.log
 ```
 
 #### `akt context edit <name>`

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -112,8 +112,8 @@ func TestContextLifecycle(t *testing.T) {
 	if !strings.Contains(stdout, "prod") {
 		t.Fatalf("expected context show to contain 'prod', got:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "mainnet") {
-		t.Fatalf("expected context show to contain 'mainnet', got:\n%s", stdout)
+	if !strings.Contains(stdout, "akashnet-2") {
+		t.Fatalf("expected context show to contain 'akashnet-2', got:\n%s", stdout)
 	}
 
 	// Create a second context so we can delete the first

--- a/internal/cli/context/commands_test.go
+++ b/internal/cli/context/commands_test.go
@@ -340,8 +340,8 @@ func TestShowResolvesTheActiveContext(t *testing.T) {
 		t.Fatalf("context show: %v", err)
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "prod") || !strings.Contains(out, "mainnet") {
-		t.Errorf("show output should name the context and its network, got %q", out)
+	if !strings.Contains(out, "prod") || !strings.Contains(out, "akashnet-2") {
+		t.Errorf("show output should name the context and resolved chain, got %q", out)
 	}
 }
 

--- a/internal/output/pretty/context.go
+++ b/internal/output/pretty/context.go
@@ -38,8 +38,10 @@ func RenderContextShow(rc aktctx.Context, effectiveKeyringBackend string) string
 
 	fmt.Fprintln(w, Section("Context"))
 	ctxKV(w, "Name", Bold(rc.Name))
-	ctxKV(w, "Network", rc.Network.Name)
 
+	// The resolved fields are the useful human-facing network identity. Keep
+	// them in one subsection instead of repeating the shared network name above
+	// it; structured output still carries the complete network object.
 	KVHeader(w, "  Network")
 	ctxSubKV(w, "Chain ID", rc.Network.ChainID)
 

--- a/internal/output/pretty/testdata/TestRenderContextShow/Full.golden
+++ b/internal/output/pretty/testdata/TestRenderContextShow/Full.golden
@@ -1,6 +1,5 @@
 [1;4;4mC[m[1;4;4mo[m[1;4;4mn[m[1;4;4mt[m[1;4;4me[m[1;4;4mx[m[1;4;4mt[m
   [38;2;113;113;122mName:[m                   [1mproduction[m
-  [38;2;113;113;122mNetwork:[m                mainnet
   [38;2;113;113;122m  Network:[m
       [38;2;113;113;122mChain ID:[m           akashnet-2
       [38;2;113;113;122mRPC:[m                https://rpc.akash.network:443 (+1 backup)

--- a/internal/output/pretty/testdata/TestRenderContextShow/Minimal.golden
+++ b/internal/output/pretty/testdata/TestRenderContextShow/Minimal.golden
@@ -1,6 +1,5 @@
 [1;4;4mC[m[1;4;4mo[m[1;4;4mn[m[1;4;4mt[m[1;4;4me[m[1;4;4mx[m[1;4;4mt[m
   [38;2;113;113;122mName:[m                   [1mlocal[m
-  [38;2;113;113;122mNetwork:[m                local
   [38;2;113;113;122m  Network:[m
       [38;2;113;113;122mChain ID:[m           local-1
       [38;2;113;113;122mRPC:[m                http://localhost:26657


### PR DESCRIPTION
## Summary

- remove the repeated `Network: <name>` row from pretty `context show` output
- keep the resolved chain details under the existing Network subsection
- preserve `network.name` in JSON and YAML output

## Validation

- `GOWORK=off make akt`
- `GOWORK=off go test ./internal/output/pretty ./internal/cli/context -count=1`
- `GOWORK=off go test ./... -count=1`
- exercised `context show` in pretty, JSON, and YAML against an isolated home