### PR TITLE
fix(actionlog): reconcile confirmed transactions

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Fixed
 
+- **Confirmed transactions stayed pending forever in the action log**: the
+  default sync broadcast records the honest CheckTx state before a block height
+  exists, but nothing revisited that entry after inclusion. `akt context log`
+  now best-effort resolves the pending hashes it is about to display through
+  the active context's RPC endpoint and appends terminal success or failure
+  revisions with height, gas, code, and error details. Reads collapse revisions
+  by transaction hash before applying the limit, so the on-disk audit trail
+  remains append-only while human and machine output show one current row per
+  transaction. An unavailable node leaves the row pending without breaking
+  offline log inspection.
+
 - **Fresh lint runs reported possible nil dereferences in tests**: the tests
   already stopped with `t.Fatal` when a required command, flag, or stored value
   was absent, but staticcheck does not treat that call as terminating control

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -241,6 +241,10 @@ graph TB
 - Append-only log of all mutating user actions within the context.
 - Each entry records what was done, when, and the result.
 - A transaction action consists of two parts: the tx message and the chain response.
+- A sync broadcast is first recorded as pending. When the log is viewed, akt
+  best-effort reconciles pending transaction hashes against the context's RPC
+  endpoint and appends a terminal revision. Reads collapse revisions by hash,
+  preserving append-only storage while presenting one current transaction row.
 - Workflow steps, provider operations, context changes, Console API calls, and errors are also logged. Read-only queries are not recorded by default.
 
 #### 3.1.2 Context Propagation

--- a/SPEC.md
+++ b/SPEC.md
@@ -1008,6 +1008,14 @@ Addresses and workflow run ids are printed in full; only the error text shown in
 the `STATUS` column is shortened. The table is a summary view — machine output
 (`-o json|yaml`) always serializes complete entries with every field of §5.4.
 
+Before rendering, `akt context log` best-effort reconciles displayed `tx`
+entries whose status is `pending` and whose transaction hash is non-empty. Each
+hash is queried through the active context's RPC endpoint. A transaction found
+in a block is recorded as a terminal `success` or `failed` revision with its
+height, gas used, result code, and error text. A missing transaction, unavailable
+RPC endpoint, timeout, or other lookup failure leaves the entry `pending` and
+does not make this local audit command fail.
+
 ```bash
 $ akt context log --limit 6
   TIME                 TYPE      SUMMARY                                                     STATUS
@@ -3494,6 +3502,13 @@ bids:
 
 The action log is an append-only log unique to each context. It records every user action performed within the context, providing an audit trail and enabling troubleshooting.
 
+Transaction status changes do not rewrite historical bytes. A terminal lookup
+appends a revision carrying the same non-empty `tx_hash` and original timestamp.
+Readers collapse transaction revisions by hash, retaining the latest appended
+revision, before reversing and applying the requested limit. The submission
+time and one-row-per-transaction view are therefore preserved without making
+the log mutable.
+
 ### 5.1 Action Log Location
 
 Each context has its own action log at:
@@ -3611,7 +3626,7 @@ The action log records entries for the following command categories:
 
 | Command category | Logged | Entry type | When |
 |---|---|---|---|
-| `tx *` | Always | `tx` | After broadcast (success or failure). On success: includes tx hash, plus height and gas used when the broadcast mode reports them. Status is `pending` when the transaction was accepted into the mempool but not yet included in a block (the default `sync` mode), and `success` once a height is known. On failure: includes error message and result code. |
+| `tx *` | Always | `tx` | After broadcast (success or failure). On success: includes tx hash, plus height and gas used when the broadcast mode reports them. Status is `pending` when the transaction was accepted into the mempool but not yet included in a block (the default `sync` mode), and `success` once a height is known. `akt context log` reconciles displayed pending hashes and appends a terminal revision when the node reports inclusion. On failure: includes error message and result code. |
 | `query *` | Never by default | `query` | Read-only queries are not state changes and are not recorded by default (see verbose row below). |
 | Workflow commands (`deploy`, `update`, `close`) | Always | `workflow` | One entry per workflow step. Each entry includes the step name, step index, result, and workflow run ID, and `akt context log` renders the step and run in `SUMMARY` so the steps of a run stay distinguishable and a failed step is identifiable (§2.2). |
 | `provider *` (state-changing: `send-manifest`, `migrate-hostnames`, `migrate-endpoints`, `lease-shell`) | Always | `provider` | After the provider gateway operation completes (success or failure). Read-only provider queries (`status`, `lease-status`, `lease-logs`, `lease-events`, `get-manifest`) are not recorded. |

--- a/e2e/localnet_test.go
+++ b/e2e/localnet_test.go
@@ -299,15 +299,15 @@ func TestLocalnet(t *testing.T) {
 		}
 
 		// AKT-211 acceptance: the synchronous broadcast is recorded in the
-		// context action log as a pending tx entry. CheckTx acceptance carries
-		// no block height, even though the balance poll above later proves the
-		// transaction was committed (SPEC §10.11.4).
+		// context action log. CheckTx acceptance initially records it as pending;
+		// reading the log reconciles the hash after the balance poll above proves
+		// the transaction was committed (SPEC §10.11.4).
 		logOut := stripANSI(mustRunAkt(t, home, "context", "log", "--type", "tx"))
 		if !strings.Contains(logOut, "bank.MsgSend") {
 			t.Fatalf("expected action log to contain a bank.MsgSend tx entry, got:\n%s", logOut)
 		}
-		if !strings.Contains(logOut, "pending") {
-			t.Fatalf("expected a pending sync-broadcast entry in the action log, got:\n%s", logOut)
+		if !strings.Contains(logOut, "success") {
+			t.Fatalf("expected the confirmed transaction to reconcile to success, got:\n%s", logOut)
 		}
 	})
 }

--- a/internal/actionlog/log.go
+++ b/internal/actionlog/log.go
@@ -143,6 +143,7 @@ func (l *Logger) Read(filter Filter) ([]Entry, error) {
 	}
 
 	allEntries = append(allEntries, entries...)
+	allEntries = collapseTransactionRevisions(allEntries)
 
 	// Reverse to get most-recent-first.
 	for i, j := 0, len(allEntries)-1; i < j; i, j = i+1, j-1 {
@@ -154,6 +155,31 @@ func (l *Logger) Read(filter Filter) ([]Entry, error) {
 	}
 
 	return allEntries, nil
+}
+
+// collapseTransactionRevisions turns the append-only submission and terminal
+// records for one transaction into one logical entry. The replacement keeps
+// the first record's timestamp so list order continues to reflect when the
+// transaction was submitted, not when a later read observed confirmation.
+func collapseTransactionRevisions(entries []Entry) []Entry {
+	collapsed := make([]Entry, 0, len(entries))
+	indices := make(map[string]int)
+
+	for _, entry := range entries {
+		if entry.Type == TypeTx && entry.TxHash != "" {
+			if index, ok := indices[entry.TxHash]; ok {
+				entry.Timestamp = collapsed[index].Timestamp
+				collapsed[index] = entry
+				continue
+			}
+
+			indices[entry.TxHash] = len(collapsed)
+		}
+
+		collapsed = append(collapsed, entry)
+	}
+
+	return collapsed
 }
 
 // Close flushes and closes the log file.

--- a/internal/actionlog/log_test.go
+++ b/internal/actionlog/log_test.go
@@ -132,6 +132,66 @@ func TestFilterByLimit(t *testing.T) {
 	}
 }
 
+func TestReadCollapsesTransactionRevisionsBeforeLimit(t *testing.T) {
+	l := newTestLogger(t)
+
+	submitted := time.Date(2026, time.August, 6, 18, 29, 4, 0, time.UTC)
+	later := submitted.Add(time.Minute)
+
+	for _, entry := range []actionlog.Entry{
+		{
+			Timestamp: submitted,
+			Type:      actionlog.TypeTx,
+			Action:    "deployment.MsgCreateDeployment",
+			TxHash:    "ABC123",
+			Status:    "pending",
+		},
+		{
+			Timestamp: later,
+			Type:      actionlog.TypeContext,
+			Action:    "edit",
+			Status:    "success",
+		},
+		{
+			Timestamp:  submitted,
+			Type:       actionlog.TypeTx,
+			Action:     "deployment.MsgCreateDeployment",
+			TxHash:     "ABC123",
+			Height:     4694579,
+			GasUsed:    138868,
+			ResultCode: 0,
+			Status:     "success",
+		},
+	} {
+		if err := l.Log(entry); err != nil {
+			t.Fatalf("Log: %v", err)
+		}
+	}
+
+	result, err := l.Read(actionlog.Filter{})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("read returned %d logical entries, want 2: %+v", len(result), result)
+	}
+	if result[0].Action != "edit" {
+		t.Errorf("newest entry = %q, want edit", result[0].Action)
+	}
+	confirmed := result[1]
+	if confirmed.TxHash != "ABC123" || confirmed.Status != "success" || confirmed.Height != 4694579 || confirmed.GasUsed != 138868 {
+		t.Errorf("transaction revision was not collapsed to its terminal state: %+v", confirmed)
+	}
+
+	limited, err := l.Read(actionlog.Filter{Limit: 1})
+	if err != nil {
+		t.Fatalf("Read limit: %v", err)
+	}
+	if len(limited) != 1 || limited[0].Action != "edit" {
+		t.Fatalf("limit was applied before revision collapse: %+v", limited)
+	}
+}
+
 func TestFilterByAccount(t *testing.T) {
 	l := newTestLogger(t)
 

--- a/internal/cli/context/commands.go
+++ b/internal/cli/context/commands.go
@@ -2,6 +2,8 @@ package context
 
 import (
 	"bufio"
+	stdcontext "context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -9,11 +11,13 @@ import (
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
 	"pkg.akt.dev/akt/internal/actionlog"
 	"pkg.akt.dev/akt/internal/capability"
+	chaincli "pkg.akt.dev/akt/internal/cli/chain"
 	clikeys "pkg.akt.dev/akt/internal/cli/keys"
 	clinetwork "pkg.akt.dev/akt/internal/cli/network"
 	"pkg.akt.dev/akt/internal/cliutil"
@@ -21,7 +25,13 @@ import (
 	aktkeyring "pkg.akt.dev/akt/internal/keyring"
 	"pkg.akt.dev/akt/internal/output"
 	"pkg.akt.dev/akt/internal/output/pretty"
+
+	nutils "pkg.akt.dev/go/node/utils"
 )
+
+const pendingTransactionReconcileTimeout = 5 * time.Second
+
+type transactionLookupFunc func(stdcontext.Context, sdkclient.Context, []byte) (*sdk.TxResponse, error)
 
 // Commands returns the "context" command tree, including "network" and "keys" as subcommands.
 func Commands(mgr func() *aktctx.Manager, getKeyring func() (sdkkeyring.Keyring, error)) *cobra.Command {
@@ -742,6 +752,12 @@ func logCmd(mgr func() *aktctx.Manager) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if refreshPendingTransactions(cmd, logger, entries) > 0 {
+				entries, err = logger.Read(filter)
+				if err != nil {
+					return err
+				}
+			}
 
 			// The human hint is only correct for the table renderer. Emitting
 			// it under -o json handed a JSON consumer a line of prose at exit
@@ -785,6 +801,75 @@ func logCmd(mgr func() *aktctx.Manager) *cobra.Command {
 	cmd.Flags().String("since", "", "Show entries since duration (1h) or date (2006-01-02)")
 
 	return cmd
+}
+
+// refreshPendingTransactions resolves the active context's RPC client and
+// reconciles only the pending transactions already selected for display. Log
+// viewing remains usable offline: context resolution and lookup failures leave
+// the existing pending entries untouched.
+func refreshPendingTransactions(cmd *cobra.Command, logger *actionlog.Logger, entries []actionlog.Entry) int {
+	// Root execution injects the selected chain context before this command
+	// runs. Keep the log command usable when invoked directly (for example by
+	// unit tests) or anywhere else that deliberately has no chain context.
+	if cmd.Context() == nil || cmd.Context().Value(chaincli.ClientContextKey) == nil {
+		return 0
+	}
+
+	cctx, err := chaincli.GetClientQueryContext(cmd)
+	if err != nil || cctx.Client == nil {
+		return 0
+	}
+
+	ctx, cancel := stdcontext.WithTimeout(cmd.Context(), pendingTransactionReconcileTimeout)
+	defer cancel()
+
+	return reconcilePendingTransactions(ctx, logger, cctx, entries, nutils.QueryTx)
+}
+
+// reconcilePendingTransactions appends terminal revisions for transactions the
+// node now knows. actionlog.Read collapses those revisions by hash, so storage
+// stays append-only while callers see one current row per transaction.
+func reconcilePendingTransactions(
+	ctx stdcontext.Context,
+	logger *actionlog.Logger,
+	cctx sdkclient.Context,
+	entries []actionlog.Entry,
+	lookup transactionLookupFunc,
+) int {
+	reconciled := 0
+
+	for _, entry := range entries {
+		if entry.Type != actionlog.TypeTx || entry.Status != "pending" || entry.TxHash == "" {
+			continue
+		}
+
+		hash, err := hex.DecodeString(entry.TxHash)
+		if err != nil {
+			continue
+		}
+
+		response, err := lookup(ctx, cctx, hash)
+		if err != nil || response == nil || response.Height <= 0 {
+			continue
+		}
+
+		revision := entry
+		revision.Height = response.Height
+		revision.GasUsed = response.GasUsed
+		revision.ResultCode = response.Code
+		revision.Error = ""
+		revision.Status = "success"
+		if response.Code != 0 {
+			revision.Status = "failed"
+			revision.Error = response.RawLog
+		}
+
+		if err := logger.Log(revision); err == nil {
+			reconciled++
+		}
+	}
+
+	return reconciled
 }
 
 func validActionType(value string) bool {

--- a/internal/cli/context/commands_test.go
+++ b/internal/cli/context/commands_test.go
@@ -2,7 +2,9 @@ package context
 
 import (
 	"bytes"
+	stdcontext "context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,7 +12,9 @@ import (
 	"testing"
 	"time"
 
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -524,6 +528,83 @@ func TestLogRendersEntriesAndFilters(t *testing.T) {
 	out = captureStdout(t, func() { runOK(t, logCmd(mgrFn), "--type", "workflow") })
 	if !strings.Contains(out, "No action log entries") {
 		t.Errorf("an empty filter result should say so, got %q", out)
+	}
+}
+
+func TestReconcilePendingTransactionsAppendsTerminalRevisions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "actions.log")
+	logger, err := actionlog.Open(path)
+	if err != nil {
+		t.Fatalf("open action log: %v", err)
+	}
+	defer func() { _ = logger.Close() }()
+
+	submitted := time.Date(2026, time.August, 6, 18, 29, 4, 0, time.UTC)
+	for _, entry := range []actionlog.Entry{
+		{Timestamp: submitted, Type: actionlog.TypeTx, Action: "success", TxHash: "AA", Status: "pending"},
+		{Timestamp: submitted.Add(time.Second), Type: actionlog.TypeTx, Action: "failure", TxHash: "BB", Status: "pending"},
+		{Timestamp: submitted.Add(2 * time.Second), Type: actionlog.TypeTx, Action: "already-done", TxHash: "CC", Status: "success"},
+		{Timestamp: submitted.Add(3 * time.Second), Type: actionlog.TypeTx, Action: "invalid-hash", TxHash: "not-hex", Status: "pending"},
+		{Timestamp: submitted.Add(4 * time.Second), Type: actionlog.TypeTx, Action: "not-found", TxHash: "DD", Status: "pending"},
+	} {
+		if err := logger.Log(entry); err != nil {
+			t.Fatalf("seed action log: %v", err)
+		}
+	}
+
+	entries, err := logger.Read(actionlog.Filter{})
+	if err != nil {
+		t.Fatalf("read pending entries: %v", err)
+	}
+
+	calls := make(map[byte]int)
+	lookup := func(_ stdcontext.Context, _ sdkclient.Context, hash []byte) (*sdk.TxResponse, error) {
+		calls[hash[0]]++
+		switch hash[0] {
+		case 0xAA:
+			return &sdk.TxResponse{TxHash: "AA", Height: 4694579, GasUsed: 138868}, nil
+		case 0xBB:
+			return &sdk.TxResponse{TxHash: "BB", Height: 4694580, GasUsed: 90000, Code: 7, RawLog: "unauthorized"}, nil
+		default:
+			return nil, errors.New("transaction not found")
+		}
+	}
+
+	if got := reconcilePendingTransactions(stdcontext.Background(), logger, sdkclient.Context{}, entries, lookup); got != 2 {
+		t.Fatalf("appended %d terminal revisions, want 2", got)
+	}
+
+	got, err := logger.Read(actionlog.Filter{})
+	if err != nil {
+		t.Fatalf("read reconciled entries: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("read returned %d logical transactions, want 5: %+v", len(got), got)
+	}
+
+	byHash := make(map[string]actionlog.Entry, len(got))
+	for _, entry := range got {
+		byHash[entry.TxHash] = entry
+	}
+	if entry := byHash["AA"]; entry.Status != "success" || entry.Height != 4694579 || entry.GasUsed != 138868 || !entry.Timestamp.Equal(submitted) {
+		t.Errorf("successful transaction was not reconciled: %+v", entry)
+	}
+	if entry := byHash["BB"]; entry.Status != "failed" || entry.ResultCode != 7 || entry.Error != "unauthorized" {
+		t.Errorf("failed transaction was not reconciled: %+v", entry)
+	}
+	if entry := byHash["DD"]; entry.Status != "pending" {
+		t.Errorf("lookup failure changed pending transaction: %+v", entry)
+	}
+	if calls[0xAA] != 1 || calls[0xBB] != 1 || calls[0xDD] != 1 || len(calls) != 3 {
+		t.Errorf("lookup calls = %v, want one call for each valid pending hash only", calls)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read append-only log: %v", err)
+	}
+	if lines := strings.Count(strings.TrimSpace(string(raw)), "\n") + 1; lines != 7 {
+		t.Errorf("raw log has %d lines, want 5 submissions plus 2 revisions", lines)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve displayed pending transaction hashes through the active context RPC
- append terminal revisions instead of rewriting the audit log
- collapse revisions by hash before applying limits so output shows one current row
- leave transactions pending and keep local log inspection working when RPC lookup fails

## Validation

- `GOTOOLCHAIN=local GOWORK=off make akt`
- `GOTOOLCHAIN=local GOWORK=off go test ./... -count=1`
- `GOTOOLCHAIN=local GOWORK=off go vet ./...`
- live, read-only mainnet check reconciled four previously pending transactions to success with block heights and gas used
- direct `akt query tx` cross-check matched the reconciled height, gas, and code
- a second `akt context log` read appended no additional revisions

No transactions were broadcast during live validation.