### PR TITLE
fix(cli): address v0.0.4 review follow-ups

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- **Stored bids always exported empty provider metadata**: workflow and
+  reconciliation bid reads now enrich each unique provider with its advertised
+  attributes and current audit presence. Console-only workflows use provider
+  details from the Console API, and transient metadata lookup failures preserve
+  previously stored values instead of failing the deployment.
+
 - **Rejected transactions buried the useful chain explanation**: terminal
   errors now remove repeated unknown-gRPC prefixes, the Cosmos SDK message-index
   wrapper, and trailing internal Go source locations. The specific cause, such

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Changed
+
+- **Store status hid bid and lease outcomes and called untouched reconciliation
+  state a fault**: record totals now break down non-zero deployment, lease, and
+  bid states, including an `other` count for unfamiliar values. The former
+  `Sync State: not synced` section is now `Network Reconciliation`; it reports
+  `not yet run` and points to the existing `akt store sync` command, or shows
+  the height and time of the last completed snapshot.
+
 ### Fixed
 
 - **Mainnet identity was duplicated in command code and context tests**:

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- **Rejected transactions buried the useful chain explanation**: terminal
+  errors now remove repeated unknown-gRPC prefixes, the Cosmos SDK message-index
+  wrapper, and trailing internal Go source locations. The specific cause, such
+  as the spendable and required balances, remains visible while action logs and
+  exit-code handling retain the original error.
+
 - **Deploy could stay silent for five minutes and then print its template
   condition**: the bid wait now reports bids received, elapsed time, and time
   remaining at useful intervals on interactive stderr. Its timeout says that

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- **Deploy could stay silent for five minutes and then print its template
+  condition**: the bid wait now reports bids received, elapsed time, and time
+  remaining at useful intervals on interactive stderr. Its timeout says that
+  no bids arrived and how long it waited, while machine output stays free of
+  progress text and the internal Go-template condition is never exposed.
+
 - **Store status hid bid and lease outcomes and called untouched reconciliation
   state a fault**: record totals now break down non-zero deployment, lease, and
   bid states, including an `other` count for unfamiliar values. The former

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- **Exports showed every `record_version` as zero without explaining the other
+  version fields**: bbolt now assigns revision 1 to a new deployment, lease, or
+  bid and advances it atomically on later writes while preserving newer
+  imported revisions. Store documentation and export help distinguish record
+  revision, database schema version, and export-envelope format version.
+
 - **Stored bids always exported empty provider metadata**: workflow and
   reconciliation bid reads now enrich each unique provider with its advertised
   attributes and current audit presence. Console-only workflows use provider

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -786,6 +786,13 @@ The deployment store is defined as a Go interface, with bbolt as the default bac
 
 The store is sync-ready: every record has a `version` field (monotonically increasing) and `updated_at` timestamp. The sync engine updates records through the same interface, enabling future remote sync without changing the data model.
 
+Bid persistence enriches each unique provider once per workflow query or
+reconciliation pass. Self-declared attributes come from the provider record;
+the audited flag means at least one current on-chain audit exists. Console-only
+workflows use the Console provider detail endpoint for the same fields. This
+metadata is ancillary: a lookup failure does not fail a deployment, and a
+reconciliation that cannot refresh it preserves the last stored values.
+
 ### 5.4 Plugin System (exec-based)
 
 Following kubectl's proven plugin model:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -547,6 +547,12 @@ known), and exact retry and explicit-close commands in both human and JSONL
 output. This keeps irreversible cleanup under the user's control while making
 the continuing escrow liability unmistakable.
 
+Long wait steps expose progress through an optional engine callback rather
+than writing from the workflow package. The CLI installs that callback only
+for human TTY output, keeping workflow results and JSONL stdout deterministic.
+The workflow definition owns a wait step's user-facing timeout explanation;
+the engine never substitutes its internal template condition into an error.
+
 Console mutation responses are not trusted as the only evidence of resulting
 state. A non-idempotent lease POST is never replayed after an error; the client
 instead reads the deployment back and accepts success only when every exact

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -884,6 +884,11 @@ error and a non-zero process status while retaining the response for
 diagnostics. Only pure construction (`--generate-only` or `--offline`) may
 carry a non-zero-shaped fixture without converting it into an execution
 failure.
+At the final terminal boundary, known redundant gRPC and Cosmos SDK execution
+wrappers are removed from the displayed text when the chain already supplied a
+specific explanation. The underlying error value is never rewritten, so
+structured action logs and exit-code classification retain the full diagnostic
+chain.
 The CLI parses fee strings and validates multisig record types and batch
 cardinality before calling SDK helpers whose invalid-input behavior includes
 panics. Unsigned construction preserves a supplied signer address without

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -503,6 +503,12 @@ both are deliberate rather than a fallback:
   escape hatch for everything a single run cannot see — pre-existing
   deployments, escrow balances that move every block, leases a provider closed.
 
+`akt store status` presents this separately as **Network Reconciliation**.
+Before the first explicit reconciliation it says `not yet run` and names
+`akt store sync`; it does not describe workflow-written records as unsynced or
+faulty. After a run it reports the height and time of that snapshot, without
+implying that a one-shot CLI remains continuously synchronized.
+
 The subscription path remains the design for long-lived sessions; it is not the
 mechanism the one-shot CLI depends on.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -784,7 +784,13 @@ The deployment store is defined as a Go interface, with bbolt as the default bac
 - **Future backends**: SQLite, remote/networked stores, or other embedded databases.
 - **Import/Export**: Backends implement serialization to YAML/JSON for backup, restore, and machine portability.
 
-The store is sync-ready: every record has a `version` field (monotonically increasing) and `updated_at` timestamp. The sync engine updates records through the same interface, enabling future remote sync without changing the data model.
+The store is sync-ready: every deployment, lease, and bid has a monotonic
+`record_version`, advanced atomically with each bbolt write. An imported higher
+revision is preserved; an equal or older write advances from the local
+revision. This is deliberately separate from the database `schema_version`
+(migration level) and the export envelope `version` (file format). The sync
+engine updates records through the same interface, enabling future remote sync
+without changing the data model.
 
 Bid persistence enriches each unique provider once per workflow query or
 reconciliation pass. Self-declared attributes come from the provider record;

--- a/SPEC.md
+++ b/SPEC.md
@@ -3408,6 +3408,16 @@ type BidRecord struct {
 }
 ```
 
+`ProviderAttributes` is populated from the provider's current on-chain
+registration, and `ProviderAudited` is true when at least one current audit
+record exists for that provider. The deploy workflow enriches the bids it
+observes before persisting them; full reconciliation performs the same lookup
+for every unique bidding provider. A Console-only workflow may use the Console
+provider detail response when no chain query client is available. Metadata
+lookup is best-effort and must never turn an otherwise usable bid into a failed
+deployment; when a refresh cannot complete, reconciliation preserves metadata
+already stored for that bid.
+
 #### SyncState
 
 ```go

--- a/SPEC.md
+++ b/SPEC.md
@@ -1284,6 +1284,7 @@ steps:
       dseq: "{{ (index .Steps \"create-deployment\").dseq }}"
     timeout: "{{ index .Params \"bid-timeout\" }}"
     until: "{{ ge (len .Result.bids) 1 }}"
+    timeout-error: "no bids received (at least 1 required)"
     on-error: abort
 
   - name: select-bid
@@ -1341,7 +1342,7 @@ the same validation from their declared parameter types.
 |------------|------------------------------------------------|-----------------------------------------------|
 | `tx`       | Broadcast a transaction                        | `msg`, `params`, `output`, `on-error`         |
 | `query`    | Execute a chain query                          | `query`, `params`, `output`                   |
-| `wait`     | Poll a query until a condition is met          | `query`, `params`, `until`, `timeout`         |
+| `wait`     | Poll a query until a condition is met          | `query`, `params`, `until`, `timeout`, `timeout-error` |
 | `prompt`   | Interactive user input (bid selection, confirm) | `mode`, `data`, `display`, `output`          |
 | `provider` | Provider gateway call                          | `action`, `params`, `retry`                   |
 | `output`   | Display formatted output                       | `template`                                    |
@@ -1400,6 +1401,11 @@ Each step's `on-error` field controls behavior on failure:
 | `skip`     | Skip silently                       |
 
 Steps can also define `retry` with `max` attempts and `delay` between retries.
+Wait steps may define `timeout-error`, a user-facing explanation of what did
+not arrive. On timeout the engine appends the elapsed limit to that explanation
+and never exposes the internal `until` template. Without `timeout-error`, it
+reports that the condition was not met before the limit without printing the
+condition source.
 
 #### 2.3.6 Error Recovery and Partial State
 
@@ -1443,6 +1449,10 @@ Workflows support two execution modes:
 - `prompt` steps render interactive selection tables (e.g., bid selection).
 - `output` steps render formatted text.
 - Errors are displayed inline with the step that failed.
+- A deployment waiting for bids reports the number received, elapsed time, and
+  remaining time immediately, whenever the count changes, and at least every
+  30 seconds. Progress is informational stderr output and is suppressed by
+  `--quiet`, non-TTY execution, and structured workflow output modes.
 
 **JSONL mode** (`--output jsonl`, or auto-selected when no TTY is attached):
 - Emits one JSONL line to stdout per completed workflow step.

--- a/SPEC.md
+++ b/SPEC.md
@@ -6132,6 +6132,16 @@ Errors presented to users include:
 2. **Context**: What operation was being performed.
 3. **Suggestion**: An actionable next step.
 
+The process-level stderr boundary removes transport and implementation wrappers
+that add no user-facing information. In particular, nested
+`rpc error: code = Unknown desc =` prefixes, Cosmos SDK
+`failed to execute message; message index: N:` wrappers, and trailing Go source
+locations are omitted when a more specific chain explanation remains. For
+example, an insufficient-funds response ends with the spendable balance and
+required amount rather than an SDK file path. This is display-only: the
+original error remains intact for exit-code classification, action logs, and
+debugging.
+
 ```
 Error: cannot connect to RPC endpoint
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -3492,6 +3492,15 @@ meta/
   without migrating would be read and written at whatever schema it was last
   left at, which is exactly the drift the versioning exists to prevent.
 
+`RecordVersion` has a different scope: it is the monotonic revision of one
+deployment, lease, or bid record. A newly created local record starts at 1;
+each write over the same key advances it. Importing a record with a higher
+revision preserves that higher value, while importing an equal or older
+revision advances from the existing local value. This makes merge/import and
+future remote synchronization orderable without changing the database schema.
+Version advancement happens inside the same bbolt write transaction as the
+record update.
+
 ### 4.6 Export Format
 
 Exports include a header with metadata:
@@ -3510,6 +3519,7 @@ deployments:
   - owner: akash1abc...
     dseq: 12345
     state: active
+    record_version: 4
     sdl_hash: sha256:abc123...
     # ... full DeploymentRecord fields
 leases:
@@ -3529,6 +3539,12 @@ bids:
       provider: akash1prov...
     # ... full BidRecord fields
 ```
+
+The three version values are independent:
+
+- top-level `version` is the export-envelope format;
+- top-level `schema_version` is the bbolt layout and migration level;
+- each `record_version` is that individual record's monotonic update revision.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2019,14 +2019,25 @@ Schema:       v3
 
 Records:
   Deployments:  47 (12 active, 35 closed)
-  Leases:       52
-  Bids:         156
+  Leases:       52 (12 active, 40 closed)
+  Bids:         156 (3 open, 12 matched, 138 lost, 3 closed)
 
-Sync State:
+Network Reconciliation:
   Last Block:   18234567
-  Last Sync:    2026-03-23 10:15:32 UTC
-  Status:       synced
+  Last Run:     2026-03-23T10:15:32Z
+  Status:       completed
 ```
+
+Record totals include a non-zero breakdown for every known state. Records with
+an unrecognized state are included as `other`, so the breakdown always accounts
+for the displayed total.
+
+Network reconciliation is separate from workflow persistence. A store that has
+records but has never run an explicit reconciliation displays `Status: not yet
+run` and `Run: akt store sync`; this is an available action, not a fault. A
+completed reconciliation reports the last chain height and run time without
+claiming that the local snapshot remains continuously synchronized after the
+one-shot command exits.
 
 #### `akt store export`
 

--- a/cmd/akt/main.go
+++ b/cmd/akt/main.go
@@ -24,7 +24,7 @@ func main() {
 	})
 
 	if err := cli.Execute(root); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, cli.UserFacingError(err))
 		os.Exit(cli.ExitCode(err))
 	}
 }

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -228,8 +228,11 @@ func TestStoreStatusEmpty(t *testing.T) {
 	}
 
 	combined := stdout + stderr
-	if !strings.Contains(strings.ToLower(combined), "not synced") {
-		t.Fatalf("expected output to contain 'not synced', got:\n%s", combined)
+	if !strings.Contains(strings.ToLower(combined), "not yet run") {
+		t.Fatalf("expected output to contain 'not yet run', got:\n%s", combined)
+	}
+	if !strings.Contains(combined, "akt store sync") {
+		t.Fatalf("expected output to name the reconciliation command, got:\n%s", combined)
 	}
 	if !strings.Contains(combined, "0") {
 		t.Fatalf("expected output to contain '0' (zero records), got:\n%s", combined)

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -18,6 +18,12 @@ const (
 
 type CLIError = cliutil.CLIError
 
+// UserFacingError renders an error for stderr without changing its diagnostic
+// value or exit-code classification.
+func UserFacingError(err error) string {
+	return cliutil.UserFacingError(err)
+}
+
 var (
 	ExitCode       = cliutil.ExitCode
 	ErrUsage       = cliutil.ErrUsage

--- a/internal/cli/store/commands.go
+++ b/internal/cli/store/commands.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
@@ -87,11 +88,13 @@ func statusCmd(homeFn func() string, ctxNameFn func() string) *cobra.Command {
 
 			if f := output.FormatFromCmd(cmd); f != output.FormatTable {
 				return output.Fprint(cmd.OutOrStdout(), f, struct {
-					Context       string `json:"context"       yaml:"context"`
-					StorePath     string `json:"storePath"     yaml:"storePath"`
-					DatabaseBytes int64  `json:"databaseBytes" yaml:"databaseBytes"`
-					SchemaVersion uint64 `json:"schemaVersion" yaml:"schemaVersion"`
-				}{ctxName, p, dbSize, s.SchemaVersion()})
+					Context               string               `json:"context"               yaml:"context"`
+					StorePath             string               `json:"storePath"             yaml:"storePath"`
+					DatabaseBytes         int64                `json:"databaseBytes"         yaml:"databaseBytes"`
+					SchemaVersion         uint64               `json:"schemaVersion"         yaml:"schemaVersion"`
+					Records               *sstore.StoreStats   `json:"records"               yaml:"records"`
+					NetworkReconciliation reconciliationStatus `json:"networkReconciliation" yaml:"networkReconciliation"`
+				}{ctxName, p, dbSize, s.SchemaVersion(), stats, describeReconciliation(ss)})
 			}
 
 			out := output.TerminalAwareWriter(cmd.OutOrStdout())
@@ -103,26 +106,85 @@ func statusCmd(homeFn func() string, ctxNameFn func() string) *cobra.Command {
 			pretty.KV(out, "Schema", fmt.Sprintf("v%d", s.SchemaVersion()))
 			pretty.Newline(out)
 
-			total := stats.ActiveDeployments + stats.ClosedDeployments
 			fmt.Fprintln(out, pretty.Section("Records"))
-			pretty.KV(out, "Deployments", fmt.Sprintf("%d (%d active, %d closed)",
-				total, stats.ActiveDeployments, stats.ClosedDeployments))
-			pretty.KV(out, "Leases", fmt.Sprintf("%d", stats.Leases))
-			pretty.KV(out, "Bids", fmt.Sprintf("%d", stats.Bids))
+			pretty.KV(out, "Deployments", formatStateCounts(stats.Deployments,
+				stateCount{"active", stats.ActiveDeployments},
+				stateCount{"closed", stats.ClosedDeployments},
+			))
+			pretty.KV(out, "Leases", formatStateCounts(stats.Leases,
+				stateCount{"active", stats.ActiveLeases},
+				stateCount{"closed", stats.ClosedLeases},
+				stateCount{"insufficient funds", stats.InsufficientFundsLeases},
+			))
+			pretty.KV(out, "Bids", formatStateCounts(stats.Bids,
+				stateCount{"open", stats.OpenBids},
+				stateCount{"matched", stats.MatchedBids},
+				stateCount{"lost", stats.LostBids},
+				stateCount{"closed", stats.ClosedBids},
+			))
 			pretty.Newline(out)
 
-			fmt.Fprintln(out, pretty.Section("Sync State"))
+			fmt.Fprintln(out, pretty.Section("Network Reconciliation"))
 			if ss != nil && ss.LastBlockHeight > 0 {
 				syncTime := time.Unix(ss.LastSyncTime, 0).UTC().Format(time.RFC3339)
 				pretty.KV(out, "Last Block", pretty.FormatNumber(ss.LastBlockHeight))
-				pretty.KV(out, "Last Sync", syncTime)
-				pretty.KV(out, "Status", "synced")
+				pretty.KV(out, "Last Run", syncTime)
+				pretty.KV(out, "Status", "completed")
 			} else {
-				pretty.KV(out, "Status", "not synced")
+				pretty.KV(out, "Status", "not yet run")
+				pretty.KV(out, "Run", "akt store sync")
 			}
 
 			return nil
 		},
+	}
+}
+
+type stateCount struct {
+	name  string
+	count int64
+}
+
+func formatStateCounts(total int64, counts ...stateCount) string {
+	if total == 0 {
+		return "0"
+	}
+
+	parts := make([]string, 0, len(counts)+1)
+	var known int64
+	for _, count := range counts {
+		known += count.count
+		if count.count > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", count.count, count.name))
+		}
+	}
+
+	if other := total - known; other > 0 {
+		parts = append(parts, fmt.Sprintf("%d other", other))
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("%d", total)
+	}
+
+	return fmt.Sprintf("%d (%s)", total, strings.Join(parts, ", "))
+}
+
+type reconciliationStatus struct {
+	Status          string `json:"status"                    yaml:"status"`
+	LastBlockHeight int64  `json:"lastBlockHeight,omitempty" yaml:"lastBlockHeight,omitempty"`
+	LastRun         string `json:"lastRun,omitempty"         yaml:"lastRun,omitempty"`
+	Command         string `json:"command,omitempty"         yaml:"command,omitempty"`
+}
+
+func describeReconciliation(ss *sstore.SyncState) reconciliationStatus {
+	if ss == nil || ss.LastBlockHeight == 0 {
+		return reconciliationStatus{Status: "not_yet_run", Command: "akt store sync"}
+	}
+
+	return reconciliationStatus{
+		Status:          "completed",
+		LastBlockHeight: ss.LastBlockHeight,
+		LastRun:         time.Unix(ss.LastSyncTime, 0).UTC().Format(time.RFC3339),
 	}
 }
 

--- a/internal/cli/store/commands.go
+++ b/internal/cli/store/commands.go
@@ -195,6 +195,9 @@ func exportCmd(homeFn func() string, ctxNameFn func() string) *cobra.Command {
 		Use:   "export",
 		Args:  cobra.NoArgs,
 		Short: "Export the local store to YAML or JSON",
+		Long: "Export the local store to YAML or JSON. The top-level version is " +
+			"the export format, schema_version is the database layout, and each " +
+			"record_version is that record's update revision.",
 		Example: `  # Export to stdout as YAML
   akt store export
 

--- a/internal/cli/store/commands_test.go
+++ b/internal/cli/store/commands_test.go
@@ -2,11 +2,15 @@ package store
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	sstore "pkg.akt.dev/akt/internal/store"
+	"pkg.akt.dev/akt/internal/store/bbolt"
 )
 
 func TestStatusPrettyOutputStripsANSIForNonTTY(t *testing.T) {
@@ -37,6 +41,40 @@ func TestStatusPrettyOutputHonorsNoColor(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	require.Contains(t, stdout.String(), "Store")
 	require.NotContains(t, stdout.String(), "\x1b[")
+}
+
+func TestStatusExplainsRecordsAndNetworkReconciliation(t *testing.T) {
+	home := t.TempDir()
+	ctx := context.Background()
+	s, err := bbolt.OpenContext(ctx, home, "mainnet")
+	require.NoError(t, err)
+	require.NoError(t, s.PutLease(ctx, &sstore.LeaseRecord{
+		ID:    sstore.LeaseID{Owner: "akash1owner", DSeq: 1, Provider: "akash1provider"},
+		State: "active",
+	}))
+	require.NoError(t, s.PutBid(ctx, &sstore.BidRecord{
+		ID:    sstore.BidID{Owner: "akash1owner", DSeq: 1, Provider: "akash1winner"},
+		State: "matched",
+	}))
+	require.NoError(t, s.PutBid(ctx, &sstore.BidRecord{
+		ID:    sstore.BidID{Owner: "akash1owner", DSeq: 1, Provider: "akash1loser"},
+		State: "lost",
+	}))
+	require.NoError(t, s.Close())
+
+	cmd := statusCmd(func() string { return home }, func() string { return "mainnet" })
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	require.NoError(t, cmd.Execute())
+	output := stdout.String()
+	require.Contains(t, output, "1 (1 active)")
+	require.Contains(t, output, "2 (1 matched, 1 lost)")
+	require.Contains(t, output, "Network Reconciliation")
+	require.Contains(t, output, "not yet run")
+	require.Contains(t, output, "akt store sync")
+	require.NotContains(t, output, "not synced")
 }
 
 func TestImportQuietSuppressesInformationalMessages(t *testing.T) {

--- a/internal/cli/workflow/commands.go
+++ b/internal/cli/workflow/commands.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -359,6 +360,11 @@ func executeWorkflow(
 	}
 
 	registry := steps.NewRegistry(chainCl, providerCl)
+	if outputFormat(cmd) == "pretty" {
+		registry.Register(steps.NewWaitExecutor(chainCl, newBidWaitProgressReporter(func(message string) {
+			cliutil.Status(cmd, message)
+		})))
+	}
 	if jsonl {
 		// Keep stdout pure JSONL: output-step text is recorded in the step
 		// result ("text" output) instead of printed.
@@ -387,6 +393,40 @@ func executeWorkflow(
 	}
 
 	return nil
+}
+
+func newBidWaitProgressReporter(report func(string)) steps.WaitProgressReporter {
+	lastCount := -1
+	nextPeriodicReport := time.Duration(0)
+
+	return func(progress steps.WaitProgress) {
+		if progress.Query != "market.bids" || report == nil {
+			return
+		}
+
+		var result struct {
+			Bids []json.RawMessage `json:"bids"`
+		}
+		if err := json.Unmarshal(progress.Result, &result); err != nil {
+			return
+		}
+
+		elapsed := progress.Elapsed.Round(time.Second)
+		remaining := progress.Remaining.Round(time.Second)
+		count := len(result.Bids)
+		if count == lastCount && elapsed < nextPeriodicReport {
+			return
+		}
+
+		lastCount = count
+		nextPeriodicReport = (elapsed/(30*time.Second) + 1) * 30 * time.Second
+		report(fmt.Sprintf(
+			"Waiting for bids: %d received, %s elapsed, %s remaining",
+			count,
+			elapsed,
+			remaining,
+		))
+	}
 }
 
 // resolveContext resolves the active context, returning nil when no manager

--- a/internal/cli/workflow/commands_test.go
+++ b/internal/cli/workflow/commands_test.go
@@ -486,6 +486,10 @@ func TestExecuteConsoleDeployEndToEnd(t *testing.T) {
 				{"bid":{"id":{"owner":"o","dseq":"4242","gseq":1,"oseq":1,"provider":"akash1exp"},"state":"open","price":{"denom":"uakt","amount":"25"}}},
 				{"bid":{"id":{"owner":"o","dseq":"4242","gseq":1,"oseq":1,"provider":"akash1cheap"},"state":"open","price":{"denom":"uakt","amount":"10"}}}
 			]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/providers/akash1cheap":
+			_, _ = w.Write([]byte(`{"owner":"akash1cheap","isAudited":true,"attributes":[{"key":"region","value":"us-west"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/providers/akash1exp":
+			_, _ = w.Write([]byte(`{"owner":"akash1exp","isAudited":false,"attributes":[{"key":"region","value":"eu-west"}]}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
 			if err := json.NewDecoder(r.Body).Decode(&leaseBody); err != nil {
 				t.Errorf("decode lease body: %v", err)
@@ -590,6 +594,11 @@ func TestExecuteConsoleDeployEndToEnd(t *testing.T) {
 		want := "lost"
 		if b.ID.Provider == "akash1cheap" {
 			want = "matched"
+			if !b.ProviderAudited || b.ProviderAttributes["region"] != "us-west" {
+				t.Errorf("cheap provider metadata = %#v audited=%v", b.ProviderAttributes, b.ProviderAudited)
+			}
+		} else if b.ProviderAudited || b.ProviderAttributes["region"] != "eu-west" {
+			t.Errorf("expensive provider metadata = %#v audited=%v", b.ProviderAttributes, b.ProviderAudited)
 		}
 		if b.State != want {
 			t.Errorf("bid from %s = %q, want %q", b.ID.Provider, b.State, want)

--- a/internal/cli/workflow/helpers_test.go
+++ b/internal/cli/workflow/helpers_test.go
@@ -6,12 +6,60 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	aktctx "pkg.akt.dev/akt/internal/context"
 	wf "pkg.akt.dev/akt/internal/workflow"
+	"pkg.akt.dev/akt/internal/workflow/steps"
 )
+
+func TestBidWaitProgressReportsChangesAndThirtySecondIntervals(t *testing.T) {
+	var messages []string
+	reporter := newBidWaitProgressReporter(func(message string) {
+		messages = append(messages, message)
+	})
+
+	reporter(steps.WaitProgress{
+		Query:     "market.bids",
+		Elapsed:   0,
+		Remaining: 5 * time.Minute,
+		Result:    json.RawMessage(`{"bids":[]}`),
+	})
+	reporter(steps.WaitProgress{
+		Query:     "market.bids",
+		Elapsed:   5 * time.Second,
+		Remaining: 4*time.Minute + 55*time.Second,
+		Result:    json.RawMessage(`{"bids":[]}`),
+	})
+	reporter(steps.WaitProgress{
+		Query:     "market.bids",
+		Elapsed:   15 * time.Second,
+		Remaining: 4*time.Minute + 45*time.Second,
+		Result:    json.RawMessage(`{"bids":[{}]}`),
+	})
+	reporter(steps.WaitProgress{
+		Query:     "market.bids",
+		Elapsed:   30 * time.Second,
+		Remaining: 4*time.Minute + 30*time.Second,
+		Result:    json.RawMessage(`{"bids":[{}]}`),
+	})
+
+	want := []string{
+		"Waiting for bids: 0 received, 0s elapsed, 5m0s remaining",
+		"Waiting for bids: 1 received, 15s elapsed, 4m45s remaining",
+		"Waiting for bids: 1 received, 30s elapsed, 4m30s remaining",
+	}
+	if len(messages) != len(want) {
+		t.Fatalf("messages = %#v, want %#v", messages, want)
+	}
+	for i := range want {
+		if messages[i] != want[i] {
+			t.Errorf("message %d = %q, want %q", i, messages[i], want[i])
+		}
+	}
+}
 
 // TestResolveContextToleratesMissingManager covers every nil-safe arm of
 // resolveContext. It runs before the rail is chosen, so a panic here would

--- a/internal/cli/workflow/persist.go
+++ b/internal/cli/workflow/persist.go
@@ -140,10 +140,12 @@ func persistDeploy(ctx context.Context, s sstore.Store, state *wf.RunState, now 
 
 	for _, b := range observedBids(state) {
 		bid := &sstore.BidRecord{
-			ID:        b.id,
-			State:     "lost",
-			Price:     b.price,
-			CreatedAt: now,
+			ID:                 b.id,
+			State:              "lost",
+			Price:              b.price,
+			ProviderAttributes: b.attributes,
+			ProviderAudited:    b.audited,
+			CreatedAt:          now,
 		}
 		if bid.ID.Owner == "" {
 			bid.ID.Owner = owner
@@ -413,8 +415,10 @@ func paramString(state *wf.RunState, name string) string {
 
 // observedBid is the identity and price of one bid a run saw.
 type observedBid struct {
-	id    sstore.BidID
-	price string
+	id         sstore.BidID
+	price      string
+	attributes map[string]string
+	audited    bool
 }
 
 // observedBids extracts every bid the wait-for-bids step returned.
@@ -435,6 +439,7 @@ func observedBids(state *wf.RunState) []observedBid {
 	}
 
 	out := make([]observedBid, 0, len(list))
+	metadata := observedProviderMetadata(sr.Output["provider_metadata"])
 	for _, item := range list {
 		inner, ok := item.(map[string]any)
 		if !ok {
@@ -459,6 +464,7 @@ func observedBids(state *wf.RunState) []observedBid {
 		gseq, _ := asUint64(id["gseq"])
 		oseq, _ := asUint64(id["oseq"])
 
+		providerMetadata := metadata[provider]
 		out = append(out, observedBid{
 			id: sstore.BidID{
 				Owner:    owner,
@@ -467,11 +473,54 @@ func observedBids(state *wf.RunState) []observedBid {
 				OSeq:     uint32(oseq), //nolint:gosec // order sequences are small by construction
 				Provider: provider,
 			},
-			price: coinString(inner["price"]),
+			price:      coinString(inner["price"]),
+			attributes: providerMetadata.attributes,
+			audited:    providerMetadata.audited,
 		})
 	}
 
 	return out
+}
+
+type observedMetadata struct {
+	attributes map[string]string
+	audited    bool
+}
+
+func observedProviderMetadata(value any) map[string]observedMetadata {
+	entries, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	result := make(map[string]observedMetadata, len(entries))
+	for provider, raw := range entries {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		attributes := map[string]string{}
+		switch rawAttributes := entry["attributes"].(type) {
+		case map[string]any:
+			for key, value := range rawAttributes {
+				if stringValue, ok := value.(string); ok {
+					attributes[key] = stringValue
+				}
+			}
+		case map[string]string:
+			for key, value := range rawAttributes {
+				attributes[key] = value
+			}
+		default:
+			continue
+		}
+
+		audited, _ := entry["audited"].(bool)
+		result[provider] = observedMetadata{attributes: attributes, audited: audited}
+	}
+
+	return result
 }
 
 // coinString renders a {amount, denom} object as a coin string, normalized

--- a/internal/cli/workflow/persist_test.go
+++ b/internal/cli/workflow/persist_test.go
@@ -64,6 +64,15 @@ func deployRunState(t *testing.T, sdlPath string) *wf.RunState {
 				},
 				"price": map[string]any{"denom": "uakt", "amount": "25"},
 			}},
+		}, "provider_metadata": map[string]any{
+			"akash1cheap": map[string]any{
+				"attributes": map[string]any{"region": "us-west"},
+				"audited":    true,
+			},
+			"akash1exp": map[string]any{
+				"attributes": map[string]any{},
+				"audited":    false,
+			},
 		}},
 	})
 	state.SetStepResult("select-bid", &wf.StepResult{
@@ -178,6 +187,18 @@ func TestPersistDeployRecordsWhatTheRunObserved(t *testing.T) {
 		states[b.ID.Provider] = b.State
 		if b.Price == "" {
 			t.Errorf("bid from %s has no price", b.ID.Provider)
+		}
+	}
+	for _, b := range bids {
+		switch b.ID.Provider {
+		case "akash1cheap":
+			if b.ProviderAttributes["region"] != "us-west" || !b.ProviderAudited {
+				t.Errorf("winning provider metadata = %#v audited=%v", b.ProviderAttributes, b.ProviderAudited)
+			}
+		case "akash1exp":
+			if b.ProviderAttributes == nil || b.ProviderAudited {
+				t.Errorf("losing provider metadata = %#v audited=%v", b.ProviderAttributes, b.ProviderAudited)
+			}
 		}
 	}
 	if states["akash1cheap"] != "matched" {

--- a/internal/cliutil/errors.go
+++ b/internal/cliutil/errors.go
@@ -78,6 +78,80 @@ func ExitCode(err error) int {
 	return ExitGeneral
 }
 
+// UserFacingError renders err for terminal display while leaving the error
+// value itself untouched for exit-code classification and action logging.
+func UserFacingError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	original := err.Error()
+	lines := strings.Split(original, "\n")
+	for i, line := range lines {
+		lines[i] = cleanErrorLine(line)
+	}
+	cleaned := strings.Join(lines, "\n")
+	if strings.TrimSpace(cleaned) == "" {
+		return original
+	}
+
+	return cleaned
+}
+
+func cleanErrorLine(line string) string {
+	line = strings.ReplaceAll(line, "rpc error: code = Unknown desc = ", "")
+	line = stripMessageExecutionPrefix(line)
+
+	trimmed := strings.TrimRight(line, " \t")
+	if !strings.HasSuffix(trimmed, "]") {
+		return line
+	}
+
+	start := strings.LastIndex(trimmed, " [")
+	if start < 0 {
+		return line
+	}
+	source := trimmed[start+2 : len(trimmed)-1]
+	goLine := strings.LastIndex(source, ".go:")
+	if goLine < 0 || !decimalDigits(source[goLine+4:]) || !strings.Contains(source[:goLine], "/") {
+		return line
+	}
+
+	return strings.TrimRight(trimmed[:start], " \t")
+}
+
+func stripMessageExecutionPrefix(line string) string {
+	const marker = "failed to execute message; message index: "
+
+	for {
+		start := strings.Index(line, marker)
+		if start < 0 {
+			return line
+		}
+
+		remainder := line[start+len(marker):]
+		separator := strings.Index(remainder, ": ")
+		if separator < 0 || !decimalDigits(remainder[:separator]) {
+			return line
+		}
+
+		line = line[:start] + remainder[separator+2:]
+	}
+}
+
+func decimalDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Convenience constructors for common error categories.
 
 func ErrUsage(msg string, cause error) *CLIError {

--- a/internal/cliutil/errors_test.go
+++ b/internal/cliutil/errors_test.go
@@ -1,0 +1,35 @@
+package cliutil
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUserFacingErrorRemovesRedundantSDKWrappers(t *testing.T) {
+	raw := "rpc error: code = Unknown desc = rpc error: code = Unknown desc = " +
+		"failed to execute message; message index: 0: spendable balance 5493015uakt " +
+		"is smaller than 999999999999uakt: insufficient funds " +
+		"[cosmos/cosmos-sdk@v0.53.6/x/bank/keeper/send.go:298]"
+	err := ErrTransaction("transaction failed", errors.New(raw))
+
+	want := "Error: transaction failed\n\n" +
+		"  Cause:      spendable balance 5493015uakt is smaller than " +
+		"999999999999uakt: insufficient funds"
+	if got := UserFacingError(err); got != want {
+		t.Fatalf("UserFacingError() = %q, want %q", got, want)
+	}
+
+	if err.Cause.Error() != raw {
+		t.Fatal("display cleanup mutated the underlying diagnostic error")
+	}
+	if ExitCode(err) != ExitTransaction {
+		t.Fatalf("exit code = %d, want %d", ExitCode(err), ExitTransaction)
+	}
+}
+
+func TestUserFacingErrorLeavesOrdinaryErrorsAlone(t *testing.T) {
+	err := errors.New("provider returned [quota exceeded]")
+	if got := UserFacingError(err); got != err.Error() {
+		t.Fatalf("UserFacingError() = %q, want %q", got, err)
+	}
+}

--- a/internal/provider/metadata.go
+++ b/internal/provider/metadata.go
@@ -1,0 +1,106 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+
+	atypes "pkg.akt.dev/go/node/audit/v1"
+	ptypes "pkg.akt.dev/go/node/provider/v1beta4"
+	attrv1 "pkg.akt.dev/go/node/types/attributes/v1"
+)
+
+// Metadata is the provider information persisted alongside a bid.
+type Metadata struct {
+	Attributes map[string]string `json:"attributes" yaml:"attributes"`
+	Audited    bool              `json:"audited"    yaml:"audited"`
+}
+
+// MetadataQueries is the narrow chain-query surface needed to enrich bids.
+type MetadataQueries interface {
+	Provider() ptypes.QueryClient
+	Audit() atypes.QueryClient
+}
+
+// FetchChainMetadata resolves each unique provider once. Metadata is
+// best-effort: an entry is returned only when both the provider registration
+// and audit query completed, allowing callers to distinguish a known false
+// audit result from an unavailable refresh.
+func FetchChainMetadata(ctx context.Context, queries MetadataQueries, owners []string) map[string]Metadata {
+	unique := make(map[string]struct{}, len(owners))
+	for _, owner := range owners {
+		if owner != "" {
+			unique[owner] = struct{}{}
+		}
+	}
+
+	ordered := make([]string, 0, len(unique))
+	for owner := range unique {
+		ordered = append(ordered, owner)
+	}
+	sort.Strings(ordered)
+
+	result := make(map[string]Metadata, len(ordered))
+	for _, owner := range ordered {
+		provider, err := queries.Provider().Provider(ctx, &ptypes.QueryProviderRequest{Owner: owner})
+		if err != nil {
+			continue
+		}
+
+		audits, err := queries.Audit().ProviderAttributes(ctx, &atypes.QueryProviderAttributesRequest{Owner: owner})
+		if err != nil {
+			continue
+		}
+
+		result[owner] = Metadata{
+			Attributes: attributeMap(provider.Provider.Attributes),
+			Audited:    len(audits.Providers) > 0,
+		}
+	}
+
+	return result
+}
+
+func attributeMap(attributes attrv1.Attributes) map[string]string {
+	result := make(map[string]string, len(attributes))
+	for _, attribute := range attributes {
+		result[attribute.Key] = attribute.Value
+	}
+
+	return result
+}
+
+// AttributesFromProviderJSON reads the attributes field of a Console provider
+// detail response. Console deployments have returned both [{key,value}] and
+// object forms over time, so both wire shapes are accepted at this boundary.
+func AttributesFromProviderJSON(raw json.RawMessage) map[string]string {
+	var document struct {
+		Attributes json.RawMessage `json:"attributes"`
+	}
+	if err := json.Unmarshal(raw, &document); err != nil || len(document.Attributes) == 0 {
+		return nil
+	}
+
+	var list []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(document.Attributes, &list); err == nil {
+		result := make(map[string]string, len(list))
+		for _, attribute := range list {
+			result[attribute.Key] = attribute.Value
+		}
+
+		return result
+	}
+
+	var object map[string]string
+	if err := json.Unmarshal(document.Attributes, &object); err != nil {
+		return nil
+	}
+	if object == nil {
+		return map[string]string{}
+	}
+
+	return object
+}

--- a/internal/provider/metadata_test.go
+++ b/internal/provider/metadata_test.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	atypes "pkg.akt.dev/go/node/audit/v1"
+	ptypes "pkg.akt.dev/go/node/provider/v1beta4"
+	attrv1 "pkg.akt.dev/go/node/types/attributes/v1"
+)
+
+type metadataQueries struct {
+	provider ptypes.QueryClient
+	audit    atypes.QueryClient
+}
+
+func (q metadataQueries) Provider() ptypes.QueryClient { return q.provider }
+func (q metadataQueries) Audit() atypes.QueryClient    { return q.audit }
+
+type providerMetadataQuery struct {
+	ptypes.QueryClient
+	calls []string
+}
+
+func (q *providerMetadataQuery) Provider(_ context.Context, req *ptypes.QueryProviderRequest, _ ...grpc.CallOption) (*ptypes.QueryProviderResponse, error) {
+	q.calls = append(q.calls, req.Owner)
+	if req.Owner == "akash1missing" {
+		return nil, errors.New("provider not found")
+	}
+
+	attrs := attrv1.Attributes{}
+	if req.Owner == "akash1audited" {
+		attrs = append(attrs, attrv1.Attribute{Key: "region", Value: "us-west"})
+	}
+
+	return &ptypes.QueryProviderResponse{Provider: ptypes.Provider{
+		Owner:      req.Owner,
+		Attributes: attrs,
+	}}, nil
+}
+
+type auditMetadataQuery struct {
+	atypes.QueryClient
+	calls []string
+}
+
+func (q *auditMetadataQuery) ProviderAttributes(_ context.Context, req *atypes.QueryProviderAttributesRequest, _ ...grpc.CallOption) (*atypes.QueryProvidersResponse, error) {
+	q.calls = append(q.calls, req.Owner)
+	if req.Owner == "akash1audited" {
+		return &atypes.QueryProvidersResponse{Providers: atypes.AuditedProviders{{Owner: req.Owner, Auditor: "akash1auditor"}}}, nil
+	}
+
+	return &atypes.QueryProvidersResponse{}, nil
+}
+
+func TestFetchChainMetadataDeduplicatesAndPreservesKnownFalse(t *testing.T) {
+	providerQuery := &providerMetadataQuery{}
+	auditQuery := &auditMetadataQuery{}
+
+	got := FetchChainMetadata(context.Background(), metadataQueries{
+		provider: providerQuery,
+		audit:    auditQuery,
+	}, []string{"akash1plain", "akash1audited", "akash1audited", "akash1missing"})
+
+	if len(got) != 2 {
+		t.Fatalf("metadata = %#v, want two successfully resolved providers", got)
+	}
+	if got["akash1audited"].Attributes["region"] != "us-west" || !got["akash1audited"].Audited {
+		t.Errorf("audited metadata = %#v", got["akash1audited"])
+	}
+	if got["akash1plain"].Attributes == nil || got["akash1plain"].Audited {
+		t.Errorf("plain metadata = %#v, want known empty attributes and audited=false", got["akash1plain"])
+	}
+	if len(providerQuery.calls) != 3 {
+		t.Errorf("provider calls = %v, want each unique owner once", providerQuery.calls)
+	}
+	if len(auditQuery.calls) != 2 {
+		t.Errorf("audit calls = %v, want only providers whose registration resolved", auditQuery.calls)
+	}
+}
+
+func TestAttributesFromProviderJSONAcceptsArrayAndObject(t *testing.T) {
+	for name, raw := range map[string]string{
+		"array":  `{"attributes":[{"key":"region","value":"eu-west"}]}`,
+		"object": `{"attributes":{"region":"eu-west"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := AttributesFromProviderJSON([]byte(raw))
+			if got["region"] != "eu-west" {
+				t.Fatalf("attributes = %#v", got)
+			}
+		})
+	}
+}

--- a/internal/store/bbolt/export_test.go
+++ b/internal/store/bbolt/export_test.go
@@ -106,6 +106,9 @@ func TestExportJSON(t *testing.T) {
 	assert.Len(t, env.Deployments, 2)
 	assert.Len(t, env.Leases, 1)
 	assert.Len(t, env.Bids, 1)
+	assert.Equal(t, uint64(1), env.Deployments[0].RecordVersion)
+	assert.Equal(t, uint64(1), env.Leases[0].RecordVersion)
+	assert.Equal(t, uint64(1), env.Bids[0].RecordVersion)
 	require.NotNil(t, env.SyncState)
 	assert.Equal(t, int64(18234567), env.SyncState.LastBlockHeight)
 }

--- a/internal/store/bbolt/store.go
+++ b/internal/store/bbolt/store.go
@@ -89,11 +89,18 @@ func (s *BoltStore) Close() error {
 func (s *BoltStore) PutDeployment(_ context.Context, d *store.DeploymentRecord) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketDeployments)
-		data, err := json.Marshal(d)
+		key := store.DeploymentKey(d.Owner, d.DSeq)
+		version, err := nextRecordVersion(b.Get([]byte(key)), d.RecordVersion)
+		if err != nil {
+			return fmt.Errorf("version deployment: %w", err)
+		}
+
+		record := *d
+		record.RecordVersion = version
+		data, err := json.Marshal(&record)
 		if err != nil {
 			return fmt.Errorf("marshal deployment: %w", err)
 		}
-		key := store.DeploymentKey(d.Owner, d.DSeq)
 		return b.Put([]byte(key), data)
 	})
 }
@@ -153,11 +160,18 @@ func (s *BoltStore) DeleteDeployment(_ context.Context, owner string, dseq uint6
 func (s *BoltStore) PutLease(_ context.Context, l *store.LeaseRecord) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketLeases)
-		data, err := json.Marshal(l)
+		key := store.LeaseKey(l.ID)
+		version, err := nextRecordVersion(b.Get([]byte(key)), l.RecordVersion)
+		if err != nil {
+			return fmt.Errorf("version lease: %w", err)
+		}
+
+		record := *l
+		record.RecordVersion = version
+		data, err := json.Marshal(&record)
 		if err != nil {
 			return fmt.Errorf("marshal lease: %w", err)
 		}
-		key := store.LeaseKey(l.ID)
 		return b.Put([]byte(key), data)
 	})
 }
@@ -217,13 +231,47 @@ func (s *BoltStore) DeleteLease(_ context.Context, id store.LeaseID) error {
 func (s *BoltStore) PutBid(_ context.Context, b *store.BidRecord) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(bucketBids)
-		data, err := json.Marshal(b)
+		key := store.BidKey(b.ID)
+		version, err := nextRecordVersion(bucket.Get([]byte(key)), b.RecordVersion)
+		if err != nil {
+			return fmt.Errorf("version bid: %w", err)
+		}
+
+		record := *b
+		record.RecordVersion = version
+		data, err := json.Marshal(&record)
 		if err != nil {
 			return fmt.Errorf("marshal bid: %w", err)
 		}
-		key := store.BidKey(b.ID)
 		return bucket.Put([]byte(key), data)
 	})
+}
+
+type recordVersionEnvelope struct {
+	RecordVersion uint64 `json:"record_version"`
+}
+
+func nextRecordVersion(existing []byte, incoming uint64) (uint64, error) {
+	if len(existing) == 0 {
+		if incoming == 0 {
+			return 1, nil
+		}
+
+		return incoming, nil
+	}
+
+	var stored recordVersionEnvelope
+	if err := json.Unmarshal(existing, &stored); err != nil {
+		return 0, fmt.Errorf("decode stored record revision: %w", err)
+	}
+	if incoming > stored.RecordVersion {
+		return incoming, nil
+	}
+	if stored.RecordVersion == ^uint64(0) {
+		return 0, fmt.Errorf("record revision cannot advance beyond %d", stored.RecordVersion)
+	}
+
+	return stored.RecordVersion + 1, nil
 }
 
 // GetBid retrieves a bid by its ID.

--- a/internal/store/bbolt/store.go
+++ b/internal/store/bbolt/store.go
@@ -359,19 +359,45 @@ func (s *BoltStore) Stats(_ context.Context) (*store.StoreStats, error) {
 			return err
 		}
 
-		// Count leases.
+		// Count leases and categorize by state.
 		leaseBucket := tx.Bucket(bucketLeases)
-		if err := leaseBucket.ForEach(func(_, _ []byte) error {
+		if err := leaseBucket.ForEach(func(_, v []byte) error {
+			var lease store.LeaseRecord
+			if err := json.Unmarshal(v, &lease); err != nil {
+				return nil //nolint:nilerr // skip one unreadable row without hiding the remaining store statistics
+			}
 			stats.Leases++
+			switch lease.State {
+			case "active":
+				stats.ActiveLeases++
+			case "closed":
+				stats.ClosedLeases++
+			case "insufficient_funds":
+				stats.InsufficientFundsLeases++
+			}
 			return nil
 		}); err != nil {
 			return err
 		}
 
-		// Count bids.
+		// Count bids and categorize by state.
 		bidBucket := tx.Bucket(bucketBids)
-		if err := bidBucket.ForEach(func(_, _ []byte) error {
+		if err := bidBucket.ForEach(func(_, v []byte) error {
+			var bid store.BidRecord
+			if err := json.Unmarshal(v, &bid); err != nil {
+				return nil //nolint:nilerr // skip one unreadable row without hiding the remaining store statistics
+			}
 			stats.Bids++
+			switch bid.State {
+			case "open":
+				stats.OpenBids++
+			case "matched":
+				stats.MatchedBids++
+			case "closed":
+				stats.ClosedBids++
+			case "lost":
+				stats.LostBids++
+			}
 			return nil
 		}); err != nil {
 			return err

--- a/internal/store/bbolt/store_test.go
+++ b/internal/store/bbolt/store_test.go
@@ -244,6 +244,74 @@ func TestSchemaVersion(t *testing.T) {
 	assert.Equal(t, uint64(1), s.SchemaVersion())
 }
 
+func TestRecordVersionsStartAtOneAndAdvancePerKey(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	deployment := &store.DeploymentRecord{Owner: "akash1abc", DSeq: 1, State: "active"}
+	lease := &store.LeaseRecord{ID: store.LeaseID{
+		Owner: "akash1abc", DSeq: 1, Provider: "akash1provider",
+	}, State: "active"}
+	bid := &store.BidRecord{ID: store.BidID{
+		Owner: "akash1abc", DSeq: 1, Provider: "akash1provider",
+	}, State: "open"}
+
+	require.NoError(t, s.PutDeployment(ctx, deployment))
+	require.NoError(t, s.PutLease(ctx, lease))
+	require.NoError(t, s.PutBid(ctx, bid))
+
+	storedDeployment, err := s.GetDeployment(ctx, deployment.Owner, deployment.DSeq)
+	require.NoError(t, err)
+	storedLease, err := s.GetLease(ctx, lease.ID)
+	require.NoError(t, err)
+	storedBid, err := s.GetBid(ctx, bid.ID)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), storedDeployment.RecordVersion)
+	assert.Equal(t, uint64(1), storedLease.RecordVersion)
+	assert.Equal(t, uint64(1), storedBid.RecordVersion)
+
+	// The caller does not need to carry the stored revision back into a later
+	// write; version advancement is atomic inside the bucket transaction.
+	require.NoError(t, s.PutDeployment(ctx, deployment))
+	require.NoError(t, s.PutLease(ctx, lease))
+	require.NoError(t, s.PutBid(ctx, bid))
+
+	storedDeployment, err = s.GetDeployment(ctx, deployment.Owner, deployment.DSeq)
+	require.NoError(t, err)
+	storedLease, err = s.GetLease(ctx, lease.ID)
+	require.NoError(t, err)
+	storedBid, err = s.GetBid(ctx, bid.ID)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), storedDeployment.RecordVersion)
+	assert.Equal(t, uint64(2), storedLease.RecordVersion)
+	assert.Equal(t, uint64(2), storedBid.RecordVersion)
+}
+
+func TestRecordVersionPreservesNewerImportedRevision(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.PutDeployment(ctx, &store.DeploymentRecord{
+		Owner: "akash1abc", DSeq: 1, RecordVersion: 2,
+	}))
+	require.NoError(t, s.PutDeployment(ctx, &store.DeploymentRecord{
+		Owner: "akash1abc", DSeq: 1, RecordVersion: 10,
+	}))
+
+	record, err := s.GetDeployment(ctx, "akash1abc", 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(10), record.RecordVersion)
+
+	// An older incoming revision is still a local write, so it advances from
+	// the stored value rather than moving the counter backwards.
+	require.NoError(t, s.PutDeployment(ctx, &store.DeploymentRecord{
+		Owner: "akash1abc", DSeq: 1, RecordVersion: 3,
+	}))
+	record, err = s.GetDeployment(ctx, "akash1abc", 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(11), record.RecordVersion)
+}
+
 func TestStats(t *testing.T) {
 	s := openTestStore(t)
 	ctx := context.Background()

--- a/internal/store/bbolt/store_test.go
+++ b/internal/store/bbolt/store_test.go
@@ -262,39 +262,50 @@ func TestStats(t *testing.T) {
 		State: "closed",
 	}))
 
-	// 2 leases
-	for i := uint64(1); i <= 2; i++ {
+	// 4 leases across every known state plus one future state.
+	leaseStates := []string{"active", "closed", "insufficient_funds", "future"}
+	for i, state := range leaseStates {
 		require.NoError(t, s.PutLease(ctx, &store.LeaseRecord{
 			ID: store.LeaseID{
 				Owner:    "akash1abc",
-				DSeq:     i,
+				DSeq:     uint64(i + 1),
 				GSeq:     1,
 				OSeq:     1,
 				Provider: "akash1prov",
 			},
-			State: "active",
+			State: state,
 		}))
 	}
 
-	// 1 bid
-	require.NoError(t, s.PutBid(ctx, &store.BidRecord{
-		ID: store.BidID{
-			Owner:    "akash1abc",
-			DSeq:     1,
-			GSeq:     1,
-			OSeq:     1,
-			Provider: "akash1prov",
-		},
-		State: "open",
-	}))
+	// 5 bids across every known state plus one future state.
+	bidStates := []string{"open", "matched", "lost", "closed", "future"}
+	for i, state := range bidStates {
+		require.NoError(t, s.PutBid(ctx, &store.BidRecord{
+			ID: store.BidID{
+				Owner:    "akash1abc",
+				DSeq:     uint64(i + 1),
+				GSeq:     1,
+				OSeq:     1,
+				Provider: "akash1prov",
+			},
+			State: state,
+		}))
+	}
 
 	stats, err := s.Stats(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), stats.Deployments)
 	assert.Equal(t, int64(2), stats.ActiveDeployments)
 	assert.Equal(t, int64(1), stats.ClosedDeployments)
-	assert.Equal(t, int64(2), stats.Leases)
-	assert.Equal(t, int64(1), stats.Bids)
+	assert.Equal(t, int64(4), stats.Leases)
+	assert.Equal(t, int64(1), stats.ActiveLeases)
+	assert.Equal(t, int64(1), stats.ClosedLeases)
+	assert.Equal(t, int64(1), stats.InsufficientFundsLeases)
+	assert.Equal(t, int64(5), stats.Bids)
+	assert.Equal(t, int64(1), stats.OpenBids)
+	assert.Equal(t, int64(1), stats.MatchedBids)
+	assert.Equal(t, int64(1), stats.LostBids)
+	assert.Equal(t, int64(1), stats.ClosedBids)
 }
 
 func TestConcurrentAccess(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -202,11 +202,18 @@ type BidFilter struct {
 
 // StoreStats contains aggregate statistics about the store contents.
 type StoreStats struct {
-	Deployments       int64 `json:"deployments"        yaml:"deployments"`
-	ActiveDeployments int64 `json:"active_deployments" yaml:"active_deployments"`
-	ClosedDeployments int64 `json:"closed_deployments" yaml:"closed_deployments"`
-	Leases            int64 `json:"leases"             yaml:"leases"`
-	Bids              int64 `json:"bids"               yaml:"bids"`
+	Deployments             int64 `json:"deployments"               yaml:"deployments"`
+	ActiveDeployments       int64 `json:"active_deployments"        yaml:"active_deployments"`
+	ClosedDeployments       int64 `json:"closed_deployments"        yaml:"closed_deployments"`
+	Leases                  int64 `json:"leases"                    yaml:"leases"`
+	ActiveLeases            int64 `json:"active_leases"             yaml:"active_leases"`
+	ClosedLeases            int64 `json:"closed_leases"             yaml:"closed_leases"`
+	InsufficientFundsLeases int64 `json:"insufficient_funds_leases" yaml:"insufficient_funds_leases"`
+	Bids                    int64 `json:"bids"                      yaml:"bids"`
+	OpenBids                int64 `json:"open_bids"                 yaml:"open_bids"`
+	MatchedBids             int64 `json:"matched_bids"              yaml:"matched_bids"`
+	ClosedBids              int64 `json:"closed_bids"               yaml:"closed_bids"`
+	LostBids                int64 `json:"lost_bids"                 yaml:"lost_bids"`
 }
 
 // DeploymentKey returns the colon-separated bucket key for a deployment.

--- a/internal/sync/querier.go
+++ b/internal/sync/querier.go
@@ -16,6 +16,7 @@ import (
 	mv1 "pkg.akt.dev/go/node/market/v1"
 	mv1beta "pkg.akt.dev/go/node/market/v1beta5"
 
+	aktprovider "pkg.akt.dev/akt/internal/provider"
 	"pkg.akt.dev/akt/internal/store"
 )
 
@@ -121,9 +122,17 @@ func (q *chainQuerier) Bids(ctx context.Context, owner string, dseq uint64) ([]*
 
 		nextKey = nextPageKey(res.GetPagination())
 		if len(nextKey) == 0 {
-			return out, nil
+			break
 		}
 	}
+
+	providers := make([]string, 0, len(out))
+	for _, bid := range out {
+		providers = append(providers, bid.ID.Provider)
+	}
+	applyBidMetadata(out, aktprovider.FetchChainMetadata(ctx, q.cl.Query(), providers))
+
+	return out, nil
 }
 
 // nextPageKey returns the continuation key of a paginated response, or nil
@@ -212,6 +221,24 @@ func bidRecords(res *mv1beta.QueryBidsResponse) []*store.BidRecord {
 	}
 
 	return out
+}
+
+func applyBidMetadata(records []*store.BidRecord, metadata map[string]aktprovider.Metadata) {
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		providerMetadata, ok := metadata[record.ID.Provider]
+		if !ok {
+			continue
+		}
+
+		record.ProviderAttributes = make(map[string]string, len(providerMetadata.Attributes))
+		for key, value := range providerMetadata.Attributes {
+			record.ProviderAttributes[key] = value
+		}
+		record.ProviderAudited = providerMetadata.Audited
+	}
 }
 
 // deploymentState maps the chain deployment state onto the store vocabulary.

--- a/internal/sync/querier_test.go
+++ b/internal/sync/querier_test.go
@@ -11,6 +11,9 @@ import (
 	etypes "pkg.akt.dev/go/node/escrow/types/v1"
 	mv1 "pkg.akt.dev/go/node/market/v1"
 	mv1beta "pkg.akt.dev/go/node/market/v1beta5"
+
+	aktprovider "pkg.akt.dev/akt/internal/provider"
+	"pkg.akt.dev/akt/internal/store"
 )
 
 const querierOwner = "akash1zn43lmk4dmvcjmfhtaqk4wa9zpuru3xy0kzupu"
@@ -169,6 +172,37 @@ func TestBidRecordsTranslateChainStateVocabulary(t *testing.T) {
 		if rec.ID.Owner != querierOwner || rec.ID.DSeq != 4649141 {
 			t.Errorf("bid %d identity = %+v", i, rec.ID)
 		}
+	}
+}
+
+func TestApplyBidMetadataPopulatesKnownValues(t *testing.T) {
+	records := []*store.BidRecord{{ID: store.BidID{Provider: "akash1provider"}}}
+	applyBidMetadata(records, map[string]aktprovider.Metadata{
+		"akash1provider": {
+			Attributes: map[string]string{"region": "us-west"},
+			Audited:    true,
+		},
+	})
+
+	if records[0].ProviderAttributes["region"] != "us-west" || !records[0].ProviderAudited {
+		t.Fatalf("bid metadata = %#v audited=%v", records[0].ProviderAttributes, records[0].ProviderAudited)
+	}
+}
+
+func TestMergeBidPreservesMetadataOnlyWhenRefreshWasUnavailable(t *testing.T) {
+	existing := &store.BidRecord{
+		ProviderAttributes: map[string]string{"region": "us-west"},
+		ProviderAudited:    true,
+	}
+
+	unavailable := mergeBid(existing, &store.BidRecord{}, 1)
+	if unavailable.ProviderAttributes["region"] != "us-west" || !unavailable.ProviderAudited {
+		t.Fatalf("unavailable refresh lost metadata: %#v", unavailable)
+	}
+
+	knownUnaudited := mergeBid(existing, &store.BidRecord{ProviderAttributes: map[string]string{}}, 1)
+	if knownUnaudited.ProviderAttributes == nil || knownUnaudited.ProviderAudited {
+		t.Fatalf("known unaudited refresh kept stale metadata: %#v", knownUnaudited)
 	}
 }
 

--- a/internal/sync/reconcile.go
+++ b/internal/sync/reconcile.go
@@ -223,8 +223,10 @@ func mergeBid(existing, fresh *store.BidRecord, now int64) *store.BidRecord {
 	merged := *fresh
 
 	if existing != nil {
-		merged.ProviderAttributes = existing.ProviderAttributes
-		merged.ProviderAudited = existing.ProviderAudited
+		if fresh.ProviderAttributes == nil {
+			merged.ProviderAttributes = existing.ProviderAttributes
+			merged.ProviderAudited = existing.ProviderAudited
+		}
 		merged.CreatedAt = existing.CreatedAt
 	}
 

--- a/internal/workflow/adapters/chain.go
+++ b/internal/workflow/adapters/chain.go
@@ -21,6 +21,8 @@ import (
 	mv1 "pkg.akt.dev/go/node/market/v1"
 	mtypes "pkg.akt.dev/go/node/market/v1beta5"
 	depositv1 "pkg.akt.dev/go/node/types/deposit/v1"
+
+	aktprovider "pkg.akt.dev/akt/internal/provider"
 )
 
 // Workflow tx message identifiers, matching the `msg:` values used by the
@@ -177,7 +179,16 @@ func (c *chainClient) Query(ctx context.Context, path string, params map[string]
 			return nil, fmt.Errorf("query %s: %w", path, err)
 		}
 
-		return c.marshalJSON(res)
+		raw, err := c.marshalJSON(res)
+		if err != nil {
+			return nil, err
+		}
+		providers := make([]string, 0, len(res.Bids))
+		for _, bid := range res.Bids {
+			providers = append(providers, bid.Bid.ID.Provider)
+		}
+
+		return attachProviderMetadata(raw, aktprovider.FetchChainMetadata(ctx, c.cl.Query(), providers))
 
 	case queryMarketLeases:
 		filters := mv1.LeaseFilters{

--- a/internal/workflow/adapters/console.go
+++ b/internal/workflow/adapters/console.go
@@ -86,7 +86,10 @@ func (c *consoleChainClient) Query(ctx context.Context, path string, params map[
 			wrapped = append(wrapped, map[string]console.Bid{"bid": b})
 		}
 
-		return json.Marshal(map[string]any{"bids": wrapped})
+		return json.Marshal(map[string]any{
+			"bids":              wrapped,
+			"provider_metadata": fetchConsoleProviderMetadata(ctx, c.cc, bids),
+		})
 
 	default:
 		return nil, fmt.Errorf("query %q is not supported with console-api auth without chain access. Use a context with auth-method: keyring for this operation", path)

--- a/internal/workflow/adapters/console_test.go
+++ b/internal/workflow/adapters/console_test.go
@@ -401,10 +401,18 @@ func TestConsoleCreateLeaseMissingManifest(t *testing.T) {
 
 func TestConsoleQueryBidsFallback(t *testing.T) {
 	c, _ := newConsoleClient(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/bids" || r.URL.Query().Get("dseq") != "4242" {
-			t.Errorf("request = %s?%s, want /v1/bids?dseq=4242", r.URL.Path, r.URL.RawQuery)
+		switch r.URL.Path {
+		case "/v1/bids":
+			if r.URL.Query().Get("dseq") != "4242" {
+				t.Errorf("request = %s?%s, want /v1/bids?dseq=4242", r.URL.Path, r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"bid":{"id":{"owner":"akash1x","dseq":"4242","gseq":1,"oseq":1,"provider":"akash1p"},"state":"open","price":{"denom":"uakt","amount":"10"}}}]}`))
+		case "/v1/providers/akash1p":
+			_, _ = w.Write([]byte(`{"owner":"akash1p","isAudited":true,"attributes":[{"key":"region","value":"us-west"}]}`))
+		default:
+			t.Errorf("unexpected request path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
 		}
-		_, _ = w.Write([]byte(`{"data":[{"bid":{"id":{"owner":"akash1x","dseq":"4242","gseq":1,"oseq":1,"provider":"akash1p"},"state":"open","price":{"denom":"uakt","amount":"10"}}}]}`))
 	})
 
 	raw, err := c.Query(context.Background(), queryMarketBids, map[string]string{"dseq": "4242"})
@@ -425,6 +433,10 @@ func TestConsoleQueryBidsFallback(t *testing.T) {
 				State string `json:"state"`
 			} `json:"bid"`
 		} `json:"bids"`
+		ProviderMetadata map[string]struct {
+			Attributes map[string]string `json:"attributes"`
+			Audited    bool              `json:"audited"`
+		} `json:"provider_metadata"`
 	}
 	if err := json.Unmarshal(raw, &res); err != nil {
 		t.Fatalf("unmarshal bids: %v", err)
@@ -434,6 +446,9 @@ func TestConsoleQueryBidsFallback(t *testing.T) {
 	}
 	if res.Bids[0].Bid.ID.Provider != "akash1p" || res.Bids[0].Bid.ID.DSeq != "4242" {
 		t.Errorf("bid id = %+v", res.Bids[0].Bid.ID)
+	}
+	if res.ProviderMetadata["akash1p"].Attributes["region"] != "us-west" || !res.ProviderMetadata["akash1p"].Audited {
+		t.Errorf("provider metadata = %#v", res.ProviderMetadata)
 	}
 }
 

--- a/internal/workflow/adapters/metadata.go
+++ b/internal/workflow/adapters/metadata.go
@@ -1,0 +1,63 @@
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+
+	"pkg.akt.dev/akt/internal/console"
+	aktprovider "pkg.akt.dev/akt/internal/provider"
+)
+
+func attachProviderMetadata(raw json.RawMessage, metadata map[string]aktprovider.Metadata) (json.RawMessage, error) {
+	if len(metadata) == 0 {
+		return raw, nil
+	}
+
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &document); err != nil {
+		return nil, err
+	}
+
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, err
+	}
+	document["provider_metadata"] = encoded
+
+	return json.Marshal(document)
+}
+
+func fetchConsoleProviderMetadata(ctx context.Context, cc *console.Client, bids []console.Bid) map[string]aktprovider.Metadata {
+	unique := make(map[string]struct{}, len(bids))
+	for _, bid := range bids {
+		if bid.ID.Provider != "" {
+			unique[bid.ID.Provider] = struct{}{}
+		}
+	}
+
+	owners := make([]string, 0, len(unique))
+	for owner := range unique {
+		owners = append(owners, owner)
+	}
+	sort.Strings(owners)
+
+	metadata := make(map[string]aktprovider.Metadata, len(owners))
+	for _, owner := range owners {
+		detail, err := cc.GetProvider(ctx, owner)
+		if err != nil {
+			continue
+		}
+
+		attributes := aktprovider.AttributesFromProviderJSON(detail.Raw)
+		if attributes == nil {
+			attributes = map[string]string{}
+		}
+		metadata[owner] = aktprovider.Metadata{
+			Attributes: attributes,
+			Audited:    detail.IsAudited,
+		}
+	}
+
+	return metadata
+}

--- a/internal/workflow/builtin/deploy.yaml
+++ b/internal/workflow/builtin/deploy.yaml
@@ -59,6 +59,7 @@ steps:
       dseq: "{{ (index .Steps \"create-deployment\").dseq }}"
     timeout: "{{ index .Params \"bid-timeout\" }}"
     until: "{{ ge (len .Result.bids) 1 }}"
+    timeout-error: "no bids received (at least 1 required)"
     on-error: abort
 
   - name: select-bid

--- a/internal/workflow/steps/registry.go
+++ b/internal/workflow/steps/registry.go
@@ -49,7 +49,7 @@ func NewRegistry(chain ChainClient, provider ProviderClient) *Registry {
 	// Register built-in step types.
 	r.Register(&TxExecutor{chain: chain})
 	r.Register(&QueryExecutor{chain: chain})
-	r.Register(&WaitExecutor{chain: chain})
+	r.Register(NewWaitExecutor(chain, nil))
 	r.Register(&PromptExecutor{})
 	r.Register(&ProviderExecutor{provider: provider})
 	r.Register(&OutputExecutor{})

--- a/internal/workflow/steps/wait.go
+++ b/internal/workflow/steps/wait.go
@@ -2,7 +2,10 @@ package steps
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"pkg.akt.dev/akt/internal/workflow"
@@ -15,7 +18,26 @@ const (
 
 // WaitExecutor polls a query until a condition is met or timeout expires.
 type WaitExecutor struct {
-	chain ChainClient
+	chain    ChainClient
+	progress WaitProgressReporter
+}
+
+// WaitProgress describes one successful poll of a wait step.
+type WaitProgress struct {
+	Step      string
+	Query     string
+	Elapsed   time.Duration
+	Remaining time.Duration
+	Result    json.RawMessage
+}
+
+// WaitProgressReporter receives successful wait polls. It is optional; the
+// workflow engine itself never writes progress to a terminal.
+type WaitProgressReporter func(WaitProgress)
+
+// NewWaitExecutor returns a wait executor with optional progress reporting.
+func NewWaitExecutor(chain ChainClient, progress WaitProgressReporter) *WaitExecutor {
+	return &WaitExecutor{chain: chain, progress: progress}
 }
 
 func (e *WaitExecutor) Type() workflow.StepType { return workflow.StepWait }
@@ -38,6 +60,18 @@ func (e *WaitExecutor) Execute(ctx context.Context, step workflow.StepDef, state
 			return failedWaitResult(step, start, fmt.Errorf("wait timeout must be greater than zero"))
 		}
 		timeout = duration
+	}
+	timeoutError := fmt.Sprintf("condition was not met; timed out after %s", timeout)
+	if step.TimeoutError != "" {
+		resolved, err := workflow.ResolveTemplate(step.TimeoutError, state)
+		if err != nil {
+			return failedWaitResult(step, start, fmt.Errorf("resolve wait timeout error: %w", err))
+		}
+		resolved = strings.TrimSpace(resolved)
+		if resolved == "" {
+			return failedWaitResult(step, start, fmt.Errorf("wait timeout error must not be empty"))
+		}
+		timeoutError = fmt.Sprintf("%s; timed out after %s", resolved, timeout)
 	}
 
 	if e.chain == nil {
@@ -62,6 +96,21 @@ func (e *WaitExecutor) Execute(ctx context.Context, step workflow.StepDef, state
 	for {
 		data, err := e.chain.Query(ctx, step.Query, params)
 		if err == nil {
+			if e.progress != nil {
+				elapsed := time.Since(start)
+				remaining := timeout - elapsed
+				if remaining < 0 {
+					remaining = 0
+				}
+				e.progress(WaitProgress{
+					Step:      step.Name,
+					Query:     step.Query,
+					Elapsed:   elapsed,
+					Remaining: remaining,
+					Result:    data,
+				})
+			}
+
 			// Check the until condition.
 			met, evalErr := workflow.EvalCondition(step.Until, data, state)
 			if evalErr == nil && met {
@@ -92,9 +141,9 @@ func (e *WaitExecutor) Execute(ctx context.Context, step workflow.StepDef, state
 				Name:     step.Name,
 				Type:     step.Type,
 				Status:   "failed",
-				Error:    fmt.Sprintf("timeout after %s waiting for condition: %s", timeout, step.Until),
+				Error:    timeoutError,
 				Duration: time.Since(start),
-			}, fmt.Errorf("timeout after %s", timeout)
+			}, errors.New(timeoutError)
 		case <-ticker.C:
 			// Poll again.
 		}

--- a/internal/workflow/steps/wait_test.go
+++ b/internal/workflow/steps/wait_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"pkg.akt.dev/akt/internal/workflow"
 )
 
 type waitTestChain struct {
 	queries int
+	result  json.RawMessage
 }
 
 func (*waitTestChain) BroadcastTx(context.Context, string, map[string]string) (*TxResult, error) {
@@ -19,6 +21,9 @@ func (*waitTestChain) BroadcastTx(context.Context, string, map[string]string) (*
 
 func (c *waitTestChain) Query(context.Context, string, map[string]string) (json.RawMessage, error) {
 	c.queries++
+	if c.result != nil {
+		return c.result, nil
+	}
 	return json.RawMessage(`{"ready":true}`), nil
 }
 
@@ -49,5 +54,42 @@ func TestWaitRejectsInvalidTimeoutBeforeQuery(t *testing.T) {
 				t.Errorf("timeout %q reached the query client %d times", timeout, chain.queries)
 			}
 		})
+	}
+}
+
+func TestWaitReportsProgressAndUsesUserFacingTimeout(t *testing.T) {
+	chain := &waitTestChain{result: json.RawMessage(`{"bids":[]}`)}
+	step := workflow.StepDef{
+		Name:         "wait-for-bids",
+		Type:         workflow.StepWait,
+		Query:        "market.bids",
+		Timeout:      "5ms",
+		Until:        `{{ ge (len .Result.bids) 1 }}`,
+		TimeoutError: "no bids received (at least 1 required)",
+	}
+
+	var progress []WaitProgress
+	result, err := NewWaitExecutor(chain, func(update WaitProgress) {
+		progress = append(progress, update)
+	}).Execute(context.Background(), step, workflow.NewRunState("id", "deploy", "", nil))
+
+	if err == nil {
+		t.Fatal("wait returned nil error after its timeout")
+	}
+	want := "no bids received (at least 1 required); timed out after 5ms"
+	if err.Error() != want {
+		t.Fatalf("wait error = %q, want %q", err, want)
+	}
+	if result == nil || result.Error != want {
+		t.Fatalf("wait result = %+v, want user-facing timeout", result)
+	}
+	if strings.Contains(result.Error, ".Result") || strings.Contains(result.Error, "{{") {
+		t.Fatalf("wait exposed its template condition: %q", result.Error)
+	}
+	if len(progress) == 0 {
+		t.Fatal("wait emitted no progress before timing out")
+	}
+	if got := progress[0]; got.Query != "market.bids" || got.Remaining > 5*time.Millisecond {
+		t.Fatalf("first progress = %+v", got)
 	}
 }

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -80,8 +80,9 @@ type StepDef struct {
 	Query string `yaml:"query,omitempty" json:"query,omitempty"` // query path, e.g. "market.bids"
 
 	// wait step fields
-	Timeout string `yaml:"timeout,omitempty" json:"timeout,omitempty"` // duration template
-	Until   string `yaml:"until,omitempty"   json:"until,omitempty"`   // condition expression template
+	Timeout      string `yaml:"timeout,omitempty"       json:"timeout,omitempty"`       // duration template
+	Until        string `yaml:"until,omitempty"         json:"until,omitempty"`         // condition expression template
+	TimeoutError string `yaml:"timeout-error,omitempty" json:"timeout_error,omitempty"` // user-facing timeout explanation
 
 	// prompt step fields
 	Mode    string     `yaml:"mode,omitempty"    json:"mode,omitempty"`    // "interactive", "cheapest", "provider=<addr>"


### PR DESCRIPTION
## Summary

Addresses every actionable observation in the latest v0.0.4 review:

- break store deployment, lease, and bid totals down by state
- rename misleading sync status to network reconciliation and point to `akt store sync`
- report bid count, elapsed time, and remaining time during interactive deploy waits
- replace leaked wait templates and redundant SDK transaction wrappers with useful errors
- persist provider attributes and audit state on both chain and Console workflow paths
- make per-record revisions monotonic and document export, schema, and record version scopes

The source-of-truth changes are recorded in `SPEC.md`, `DESIGN.md`, and `AICHANGELOG.md`.

Review: https://gist.github.com/chainzero/ecfa7b466e2aadf8e7b2a52e15c46bfe

## Verification

- `direnv exec . bash -c "GOWORK=off make akt"`
- `direnv exec . bash -c "GOWORK=off go test ./... -count=1"`
- `GOWORK=off go vet ./internal/... ./cmd/...`
- built-binary smoke test of pretty and parsed JSON `store status` output
- all six commits are signed and carry Signed-off-by trailers

No deployments or transactions were created during this verification.