### PR TITLE
fix(cli): resolve open correctness and UX backlog

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Fixed
 
+- **Six partially addressed backlog issues now have complete boundary
+  contracts**: every successful Console leaf prints an action-specific `Next:`
+  hint on stderr without contaminating structured stdout, while quiet mode
+  suppresses it (#66); `context keys add` accepts Cosmos-compatible `--yes` /
+  `-y` without weakening duplicate-key or secret handling (#71); provider
+  status exposes a positive `--timeout` that configures the actual gateway
+  request deadline (#73); already-closed or absent deployments fail before a
+  close mutation and retain a failed action-log entry through direct and
+  workflow paths (#75); API-key deletion proves the UUID exists before DELETE,
+  preserving a missing target as failure even though the live endpoint returns
+  idempotent success, and never prints `deleted: true` for an absent key (#79);
+  and every rail accepts USD
+  deposits only as plain decimal values with at most two fractional digits,
+  rejecting exponent, non-finite, signed, and sub-cent forms before network
+  work (#82). Structural and boundary tests pin each behavior.
+
 - **Automatic transaction fees now use the selected network's configured
   policy**: First-run bootstrap stores each Akash network registry entry's
   `high_gas_price` instead of its inadequate average, and CLI initialization
@@ -100,13 +116,13 @@
   The generated active-union report exposes the remaining provider gap without
   treating that run's package counts as policy.
 
-- **Console repeated-close E2E follows the live idempotency contract**: The
-  Console backend can return the same successful close envelope for both an
-  initial close and an already-closed no-op, so `already_closed: false` cannot
-  distinguish those cases. The live lifecycle now requires the repeated CLI
-  command to succeed with an exact close acknowledgement and action-log entry,
-  then independently verifies that GET/list retain terminal state with no
-  active lease. A hermetic two-close test pins the successful-200 behavior.
+- **Console repeated-close E2E rejects false mutation success**: The client
+  reads current deployment state before DELETE, so a terminal or absent
+  deployment returns a non-zero already-closed error without a success
+  document or another DELETE. The live lifecycle requires that failure,
+  verifies its failed action-log entry, and independently confirms that the
+  deployment remains terminal with no active lease. The same truthfulness rule
+  now covers repeated deletion of an already-absent API key.
 
 - **Console sandbox escrow verification accepts the chain's decimal coin
   encoding**: Production deposit reconciliation preserves fixed-point `funds`
@@ -339,10 +355,10 @@
   provider readiness and workload ingress, semantically validates bounded log
   and event streams, executes a deterministic non-interactive shell command,
   and proves read calls remain absent from the action log. It also creates,
-  authenticates with, lists, revokes, and re-revokes a child API key while an
-  independent HTTP observer corroborates tenant identity and the temporary
-  home is scanned for parent and child secrets. Structured API-key deletion now
-  emits a structured acknowledgement instead of plain text.
+  authenticates with, lists, revokes, and rejects re-revocation of a child API
+  key while an independent HTTP observer corroborates tenant identity and the
+  temporary home is scanned for parent and child secrets. Structured API-key
+  deletion now emits a structured acknowledgement instead of plain text.
 
 - **Audit logging now fails closed at both startup and storage boundaries**:
   a selected context cannot execute when its action log cannot be opened, one
@@ -556,10 +572,10 @@
 - **Adversarial regression review closed terminal and Console false-success
   paths**: the standalone monitor once again owns Bubble Tea's alternate screen
   instead of painting into the caller's scrollback, while the embedded monitor
-  leaves screen ownership to its shell. Console close now recognizes only
-  unambiguous already-closed or not-found responses as idempotent success; a
-  server rejection such as "cannot be closed while active leases exist" stays
-  failed and cannot be logged as a successful close. Console-only MCP startup
+  leaves screen ownership to its shell. Console close now preserves
+  unambiguous already-closed or not-found responses as typed failed mutations;
+  a server rejection such as "cannot be closed while active leases exist"
+  likewise stays failed and cannot be logged as a successful close. Console-only MCP startup
   is also defined for an environment API key with no active context, without
   manufacturing chain or provider capabilities or invoking the first-run
   wizard. Contextless MCP remains read-only: write enablement fails closed
@@ -890,7 +906,7 @@
   unmarked endpoints,
   makes provider readiness mandatory after opt-in, bounds captured output,
   redacts response bodies and action payloads from failures, scans the complete
-  temporary home for credentials, requires idempotent-close acknowledgement,
+  temporary home for credentials, requires truthful repeated-close failure,
   and gives discovery, auto-top-up disable/close, terminal verification, and
   final balance observation separate cleanup deadlines. Ambiguous creates are
   rediscovered by unique post-baseline SDL hash; in-process cleanup attempts
@@ -1844,9 +1860,9 @@
 
 - **Workflow execution with auth-aware routing (AKT-647)**: `akt deploy/update/close` now actually execute (previously they printed a plan and bailed with "Execution requires chain client (not yet wired)"). The generated commands resolve the active context and pick the auth mechanism per action, hidden from the user: `console-api` contexts route tx steps through the Console API (provider send-manifest steps are skipped with a note — Console submits manifests internally; missing key → clear guidance to set `AKT_CONSOLE_API_KEY`, store a per-context key, or switch context), `keyring` contexts sign and broadcast locally via the chain adapters (tx flags merged onto workflow commands; missing wallet/chain client → clear error). Per-step results render in pretty mode; `-o jsonl` emits one SPEC §2.3.8 line per step; steps are recorded in the per-context action log. Full httptest-backed console deploy e2e test (create → bids → cheapest → lease from cached manifest). 17 new tests across adapters/steps/CLI.
 
-- **`akt console` command group (AKT-648)**: New top-level command group porting the managed-Console CLI surface to Go per the console-axi reference: `login/logout/whoami` (login validates against `/v1/user/me` before storing the per-context credential; TTY prompt hides input), `deployment list/get/create/update/close/deposit/settings`, `bid list`, `lease create` (defaults to the per-context manifest cache), `wallet list/balance/settings/cost`, `usage`, public keyless `provider list/get/regions/auditors`, `gpu`, `template list/get/sdl` (raw SDL to stdout for piping), `apikey list/create/delete` (secret shown once), and `jwt create`. Positional-primary args per AKT-650 conventions; idempotent close; USD `$X.XX` formatting; mutations recorded in the action log. SPEC gains §2.9 "Console Commands". 8 command tests.
+- **`akt console` command group (AKT-648)**: New top-level command group porting the managed-Console CLI surface to Go per the console-axi reference: `login/logout/whoami` (login validates against `/v1/user/me` before storing the per-context credential; TTY prompt hides input), `deployment list/get/create/update/close/deposit/settings`, `bid list`, `lease create` (defaults to the per-context manifest cache), `wallet list/balance/settings/cost`, `usage`, public keyless `provider list/get/regions/auditors`, `gpu`, `template list/get/sdl` (raw SDL to stdout for piping), `apikey list/create/delete` (secret shown once), and `jwt create`. Positional-primary args per AKT-650 conventions; truthful already-closed failure; USD `$X.XX` formatting; mutations recorded in the action log. SPEC gains §2.9 "Console Commands". 8 command tests.
 
-- **Console API client reworked to match the real API (AKT-648)**: The client's request shapes were wrong — the Console API wraps write bodies/responses in a `{"data": ...}` envelope and `deposit-deployment` takes `{data:{dseq,deposit}}`, not `{dseq,amount}`. Rebuilt the client with correct wire shapes (verified against the console-axi reference CLI) and expanded it from 8 to ~30 endpoints across deployments (incl. `/v2/deployment-settings` with PATCH→POST fallback and idempotent close via `ErrAlreadyClosed`), wallet/balances/usage, public marketplace (providers, regions, auditors, GPU prices, templates, bid screening), API keys, and provider-scoped JWT minting. Adds a per-context manifest cache at `contexts/<name>/manifests/<dseq>.json` (0600) so `deployment create` → `lease create` works without re-passing the manifest. µACT↔USD helpers (1 ACT = 1 USD, 1e6 micro). 36 tests.
+- **Console API client reworked to match the real API (AKT-648)**: The client's request shapes were wrong — the Console API wraps write bodies/responses in a `{"data": ...}` envelope and `deposit-deployment` takes `{data:{dseq,deposit}}`, not `{dseq,amount}`. Rebuilt the client with correct wire shapes (verified against the console-axi reference CLI) and expanded it from 8 to ~30 endpoints across deployments (incl. `/v2/deployment-settings` with PATCH→POST fallback and typed already-closed failure via `ErrAlreadyClosed`), wallet/balances/usage, public marketplace (providers, regions, auditors, GPU prices, templates, bid screening), API keys, and provider-scoped JWT minting. Adds a per-context manifest cache at `contexts/<name>/manifests/<dseq>.json` (0600) so `deployment create` → `lease create` works without re-passing the manifest. µACT↔USD helpers (1 ACT = 1 USD, 1e6 micro). 36 tests.
 
 - **Workflow execution adapters (AKT-647)**: New `internal/workflow/adapters` package implementing the engine's `steps.ChainClient`/`steps.ProviderClient` interfaces over the real chain client and provider gateway: msg builders for deployment create/update/close and market lease-create replicating the tx command logic (SDL groups + version hash, dseq from chain height, `auto` deposit via min-deposit params, update-group safety check), workflow query routing for `market.bids`/`market.leases`/`deployment.deployments` shaped for the wait-step's `until:` templates, and a provider adapter that resolves gateway URLs from on-chain HostURI. dseq is deliberately emitted as a JSON string in step outputs so Go templates don't render it in scientific notation. 22 tests.
 

--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Fixed
 
+- **The open CLI correctness and UX backlog now shares enforceable
+  boundaries**: workflow JSONL preserves step outputs and deployment results;
+  deploy completion reports identity, URIs, readiness, and next actions;
+  Console commands validate DSEQs, pagination, UUIDs, names, JWT lifetimes,
+  active mutation state, and the $0.50 deposit minimum before transport work;
+  dry-runs resolve the deposit and signer they will actually use; MCP query
+  tools remain available when optional signing cannot initialize; and Console
+  pretty output uses human semantic renderers with correct micro-ACT dollar
+  and monthly cost semantics. Shell service selection, resource-based provider
+  screening, state filtering, context creation confirmations, bootstrap
+  warnings, keyring guidance, empty streams, and store/SDL documentation now follow the same
+  command-boundary rules. This resolves the behavior tracked in issues #57
+  through #82 without masking
+  failures with fallback values.
+
 - **Console sandbox spend accounting now uses the owned deployment ledger**:
   the point-in-time account total has no lifecycle-run identity or observation
   height, so its pre/post change cannot prove one deployment's spend. The

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -461,6 +461,11 @@ Each context has an `auth-method` that determines how transactions are signed an
   requires an explicitly selected context because every mutation must have a
   durable per-context action-log destination; contextless writes fail before
   any tool is registered.
+- Console request construction is a validation boundary shared by direct CLI,
+  workflows, and MCP. Numeric identities, pagination, minimum USD deposits,
+  UUIDs, key names, mutation state, and JWT lifetime are rejected there before
+  transport work. This prevents each surface from acquiring its own partial
+  version of the same rules.
 
 A context uses **one** auth method. Users who need both can create separate contexts (e.g., `prod` with keyring auth and `console` with console-api auth), potentially sharing the same network definition.
 
@@ -512,6 +517,12 @@ that provider, deployment identity, and required scope (`status` or
 `send-manifest`). They never send the provider client's broad full-access JWT,
 so a registered provider cannot replay an observed MCP credential against a
 different provider, deployment, or operation.
+
+MCP startup assembles read and write capabilities independently. A usable
+query client always registers its read tools. Requesting writes does not make
+query availability depend on a signer: when signing cannot be initialized,
+only signing-dependent tools are omitted and the server remains useful for
+queries.
 
 MCP tool schemas are executable boundaries. Unknown fields, blank required
 strings, invalid enums, and numeric identifiers that cannot be represented
@@ -780,6 +791,13 @@ The final workflow report has the same contract as an output step. Human and
 JSONL renderers return writer and short-write failures to the Cobra boundary;
 a successful engine run cannot exit zero after its promised stdout payload was
 lost.
+
+Step outputs are first-class workflow data. JSONL carries the values produced
+by each step instead of reducing a successful action to its status. Deployment
+completion therefore exposes its DSEQ, full provider address, selected price,
+service URIs, readiness, and rail-appropriate deep link. The Console and chain
+adapters both feed a bounded readiness observation through this shared result
+rather than adding rail-specific command output.
 
 Console mutation responses are not trusted as the only evidence of resulting
 state. Before creating a deployment, the client derives the SDL's deterministic
@@ -1210,6 +1228,13 @@ For Console API values, the public JSON representation is canonical. YAML is
 generated from that JSON semantic tree rather than by reflecting the Go
 transport type, so JSON field names, raw embedded objects, byte/string
 representations, and integer precision remain identical across formats.
+
+Human Console output walks the canonical JSON semantic model through a
+field-aware renderer. It applies USD conversion for micro-ACT escrow values,
+monthly estimates for `uact` per-block prices, full identifiers, and empty-state
+text without changing JSON/YAML wire semantics. Workflow completion has its own
+summary renderer for readiness and next actions. Pretty mode never obtains its
+layout by colorizing or indenting raw API JSON.
 
 The output flag is an enum at the parsing boundary. A misspelling such as
 `-o josn` is a usage error; it must never fall through to pretty output. The

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -460,26 +460,32 @@ Each context has an `auth-method` that determines how transactions are signed an
   response is surfaced rather than followed to an intermediary-selected URL.
   Neither a redirect target nor any other transport diagnostic may reach the
   returned error or action log without exact API-key redaction.
-- Console accepts a 2xx close only when the response acknowledges
-  `success: true`. Console may return that same acknowledgement when its
-  server-side idempotency check finds the deployment already closed. A
-  non-2xx response is converted to idempotent success only when it
-  unambiguously states that the deployment is already closed or absent; a
-  rejection that merely contains the word `closed` (for example, "cannot be
-  closed while leases are active") remains a failed mutation and a failed
-  action-log entry. `already_closed: false` means only that the response did
-  not explicitly report prior terminal state; callers prove the idempotent
-  outcome by observing that the deployment remains closed or absent.
+- Console close first reads the deployment and rejects a terminal or absent
+  deployment as an already-closed error. That error remains non-zero through
+  both the direct Console command and the shared `akt close` workflow, because
+  reaching the desired state before this invocation is not evidence that this
+  invocation changed it. An active deployment is then deleted, and a 2xx close
+  is accepted only when the response acknowledges `success: true`. A later
+  non-2xx response that unambiguously reports already closed or absent retains
+  the same typed failure. A rejection that merely contains the word `closed`
+  (for example, "cannot be closed while leases are active") remains its
+  original failed mutation. Already-closed attempts are failed action-log
+  entries and never produce a green workflow step or mutation acknowledgement.
 - A process-level Console key is sufficient for read-only MCP without creating
   configuration or running the first-run wizard. `--enable-writes` still
   requires an explicitly selected context because every mutation must have a
   durable per-context action-log destination; contextless writes fail before
   any tool is registered.
 - Console request construction is a validation boundary shared by direct CLI,
-  workflows, and MCP. Numeric identities, pagination, minimum USD deposits,
-  UUIDs, key names, mutation state, and JWT lifetime are rejected there before
-  transport work. This prevents each surface from acquiring its own partial
-  version of the same rules.
+  workflows, and MCP. Numeric identities, pagination, fixed-point USD deposit
+  syntax and minimums, UUIDs, key names, mutation state, and JWT lifetime are
+  rejected there before transport work. API-key deletion first lists the
+  account's keys and requires the requested UUID to be present before issuing
+  DELETE. An absent UUID is a failed cleanup attempt with no DELETE, even when
+  the Console API would otherwise acknowledge an idempotent delete; only a
+  present key followed by a successful DELETE may produce `deleted: true`.
+  This prevents each surface from acquiring its own partial version of the
+  same rules.
 
 A context uses **one** auth method. Users who need both can create separate contexts (e.g., `prod` with keyring auth and `console` with console-api auth), potentially sharing the same network definition.
 
@@ -487,7 +493,11 @@ Provider authentication is selected by operation, not merely by command
 group. Provider `/status` is a public read: CLI and MCP callers construct it
 through `internal/provider.NewPublicGatewayClient`, which attaches neither a
 wallet JWT nor an mTLS certificate and therefore works without a default
-account or keyring. Lease-, service-, manifest-, migration-, log-, event-, and
+account or keyring. The CLI exposes its positive one-shot deadline as
+`--timeout`, defaulting to 30 seconds, and passes that value into the gateway
+boundary itself so it can both shorten and extend the request rather than
+nesting an ineffective outer timeout around a fixed inner deadline. Lease-,
+service-, manifest-, migration-, log-, event-, and
 shell-scoped chain-backed operations construct clients through
 `internal/provider.NewGatewayClient`. That boundary validates the resolved
 auth enum, account, keyring, and signing-key presence before installing the
@@ -861,9 +871,9 @@ merely the first HTTP response.
 
 | Form | Examples | Meaning |
 |---|---|---|
-| USD | `5usd`, `$5`, `5.50usd` | A USD amount. The `usd` unit is case-insensitive and always wins over coin parsing, so a value ending in `usd` is never read as a chain denomination. |
+| USD | `5usd`, `$5`, `5.50usd` | A plain decimal USD amount with at most two fractional digits. The `usd` unit is case-insensitive and always wins over coin parsing, so a value ending in `usd` is never read as a chain denomination. Scientific notation, non-finite values, and sub-cent precision are rejected. |
 | Coin | an explicit `<amount><denom>` | A chain coin amount, parsed as a decimal coin. The denomination must match the active network's deployment deposit parameter. |
-| Bare number | `5`, `5.50` | Unit-less: USD on the console rail, rejected on the chain rail (coins have always required a denomination). |
+| Bare number | `5`, `5.50` | Unit-less plain decimal: USD on the console rail, rejected on the chain rail (coins have always required a denomination). |
 | `auto` / empty | `auto` | Defer to the rail default: the chain-minimum deployment deposit on the chain rail; the console rail has no default and asks for an explicit USD amount. |
 
 Every form parses on every rail; only the *interpretation* is rail-specific,
@@ -1249,6 +1259,19 @@ monthly estimates for `uact` per-block prices, full identifiers, and empty-state
 text without changing JSON/YAML wire semantics. Workflow completion has its own
 summary renderer for readiness and next actions. Pretty mode never obtains its
 layout by colorizing or indenting raw API JSON.
+
+Every successful Console leaf also emits at least one actionable `Next:`
+suggestion through the informational stderr channel. Keeping guidance off
+stdout preserves canonical JSON/YAML, raw template SDL, and stream payloads;
+`--quiet` suppresses it. Bounded streams and shell commands emit the suggestion
+only after successful completion. A structural command-tree test requires this
+metadata on every Console action leaf so new commands cannot silently omit it.
+
+`akt context keys add` accepts the familiar `--yes`/`-y` spelling for scripted
+Cosmos CLI compatibility even though add has no confirmation prompt. It never
+authorizes overwriting an existing key and cannot bypass mnemonic, Ledger, or
+keyring-passphrase input; `--no-backup` remains the separate control that keeps
+a newly generated mnemonic out of command output.
 
 The output flag is an enum at the parsing boundary. A misspelling such as
 `-o josn` is a usage error; it must never fall through to pretty output. The

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Transport-independent SDL scaffolding, generation, and linting. Every `akt sdl` 
 - **`akt sdl init <scaffold>`** -- print a deployable SDL to stdout, self-checked against the validator before it is printed. Flags (`--image`, `--cpu`, `--memory`, `--gpu-model`, `--price`, ...) are generation parameters with per-scaffold defaults, so the zero-flag invocation always produces valid output. Pipe it into `akt sdl validate -`, or redirect it to a file for `akt deploy` / `akt console deployment create`.
 - **`akt sdl validate <file>`** -- validate offline (`-` reads stdin). Parsing uses `pkg.akt.dev/go/sdl`, the same parser behind `akt deploy` and the chain tx commands, followed by lint rules.
 
-Lint rules: an unpinned image is an **error** -- every service image must carry an explicit tag or `@sha256:` digest, so untagged images and `:latest` are rejected as non-reproducible. For pricing, `uact` passes, `uakt` is a **warning** (valid on-chain, but managed console-api deployments are priced in `uact`), and any other denom is an error. Exit 0 when valid, 1 when not. See [SPEC.md §2.11](SPEC.md#211-sdl-commands).
+Lint rules: an unpinned image is an **error** -- every service image must carry an explicit tag or `@sha256:` digest, so untagged images and `:latest` are rejected as non-reproducible. For pricing, `uact` passes on both rails. `uakt` is a **warning** because it requires an explicitly matching `--deposit <amount>uakt` on chain; any other denom is an error. Exit 0 when valid, 1 when not. See [SPEC.md §2.11](SPEC.md#211-sdl-commands).
 
 ### Console Integration (`akt console`)
 
@@ -309,6 +309,9 @@ akt context network edit mainnet --gas-prices 0.04uakt
 # Add a new key
 akt context keys add alice
 
+# Non-interactive creation without printing a mnemonic backup
+akt context keys add ci-deployer --no-backup
+
 # Recover from mnemonic
 akt context keys add alice --recover
 
@@ -328,6 +331,9 @@ akt context keys import alice-backup alice.key
 # Parse an address between formats
 akt context keys parse akash1abc...
 ```
+
+`keys add` has no confirmation prompt, so it does not accept `--yes`. Blank
+names are rejected before the keyring is opened.
 
 ### SDL Authoring
 
@@ -356,7 +362,7 @@ A valid document prints `valid: 1 service(s), 1 group(s), 0 warning(s)`. Problem
 invalid: 1 error(s), 1 warning(s)
   error: services/web/image: image "nginx" has no tag; pin an explicit version for reproducible deployments
     hint: use "nginx:<version>" instead of an untagged image
-  warning: profiles/placement/dcloud/pricing: pricing denom "uakt" is on-chain only; managed (console-api) deployments are priced in "uact" (micro-ACT, 1:1 USD)
+  warning: profiles/placement/dcloud/pricing: pricing denom "uakt" does not match the default deposit; use "uact" on either rail or pass a matching explicit uakt deposit on chain
 ```
 
 Redirect the generated SDL to a file to feed `akt deploy` or `akt console deployment create`; both take a file path.
@@ -393,6 +399,17 @@ All transaction commands accept `--from`, `--gas`, `--fees`, `--broadcast-mode`,
 
 Workflow commands orchestrate multi-step operations, routing each step through the active context's auth method (local signing for `keyring`, Console API for `console-api`). They support two execution modes:
 
+SDL prices use canonical `uact` on both rails. A legacy `uakt` price is valid
+on chain only with an explicitly matching `--deposit <amount>uakt`. Console
+deposits are USD with a $0.50 minimum. On the
+chain rail, an omitted or `auto` deposit resolves the live on-chain minimum;
+an explicit coin is preserved. `--dry-run` displays the resolved rail-specific
+deposit and fails if it cannot be determined.
+
+Successful deploys wait up to two minutes for service readiness and then print
+live URIs. Use `--ready-timeout` to change the bound or `--no-wait-active` to
+return immediately after manifest submission.
+
 **Interactive mode** (default) -- a per-workflow progress display:
 ```bash
 # Full deployment lifecycle with interactive bid selection
@@ -409,7 +426,8 @@ Output is one JSON object per line, one line per step (`create-deployment`, `wai
 ```jsonl
 {"workflow":"deploy","id":"wf_a1b2c3","step":"create-deployment","result":"completed","errors":[],"txs":[{"hash":"ABCD...","height":12345,"gas_used":150000,"code":0}]}
 {"workflow":"deploy","id":"wf_a1b2c3","step":"wait-for-bids","result":"completed","errors":[],"txs":[]}
-{"workflow":"deploy","id":"wf_a1b2c3","step":"create-lease","result":"completed","errors":[],"txs":[{"hash":"EFGH...","height":12350,"gas_used":120000,"code":0}]}
+{"workflow":"deploy","id":"wf_a1b2c3","step":"create-lease","result":"completed","errors":[],"txs":[{"hash":"EFGH...","height":12350,"gas_used":120000,"code":0}],"outputs":{"dseq":"12345","provider":"akash1provider..."}}
+{"workflow":"deploy","id":"wf_a1b2c3","step":"display-result","result":"completed","errors":[],"txs":[],"outputs":{"dseq":"12345","provider":"akash1provider...","uris":{"web":["https://example.test"]},"ready":true}}
 ```
 
 Parse with `jq`:
@@ -585,7 +603,17 @@ akt console shell 12345 web -- ls -la
 
 # Which providers can run this SDL? (public endpoint, no key required)
 akt console screen deploy.yaml
+
+# Or screen explicit resources; flags override values loaded from an SDL
+akt console screen deploy.yaml --gpu 1 --gpu-model a100
 ```
+
+Console `uact` escrow amounts are micro-USD and display as dollars. Bid prices
+reported in `uact` per block also show an estimated 30-day dollar cost using
+six-second blocks; other denoms stay explicit. `akt store export` is a local
+inspection and backup format, not a deployable SDL source. There is no separate
+`store list`: use `akt store status` for counts and freshness, or export when
+individual locally tracked records are needed.
 
 ## Roadmap
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -536,10 +536,15 @@ Console request identifiers and paging values follow the same boundary rule.
 Every DSEQ is parsed as a positive base-10 integer before an HTTP request is
 built. Deployment-list pagination rejects `skip < 0` and `limit < 1` instead
 of silently omitting those values. API-key deletion requires a non-empty UUID,
-key creation rejects a blank name, and local key creation rejects a name that
-is blank after trimming. Commands that require a terminal session, including
-an interactive Console shell with no explicit command, reject non-terminal
-stdin before any identity or network lookup can block.
+lists the account's keys before mutation, and reports an absent UUID as an
+error without sending DELETE; key creation rejects a blank name, and local key
+creation rejects a name that is blank after trimming. USD deposit inputs use
+plain fixed-point decimal syntax with at most two fractional digits; exponent
+notation, non-finite values, and sub-cent precision are rejected before any
+request.
+Commands that require a terminal session, including an interactive Console
+shell with no explicit command, reject non-terminal stdin before any identity
+or network lookup can block.
 
 Every accepted flag must affect the operation it describes. If a leaf cannot
 apply an inherited transport, snapshot, pagination, or output flag, it rejects
@@ -1317,9 +1322,12 @@ mnemonic. The selected output format applies equally to local, Ledger, and
 multisig keys.
 
 The command is non-interactive except when it must read secret material or a
-keyring passphrase. It has no confirmation prompt and therefore no `--yes`
-flag. `--no-backup` suppresses mnemonic output for unattended creation. A name
-that is empty or whitespace-only is rejected before the keyring is opened.
+keyring passphrase. It accepts `--yes` / `-y` for Cosmos CLI script
+compatibility even though it currently has no confirmation prompt. The flag
+does not authorize overwriting an existing key and cannot bypass mnemonic,
+Ledger, or keyring-passphrase input. `--no-backup` suppresses mnemonic output
+for unattended creation. A name that is empty or whitespace-only is rejected
+before the keyring is opened.
 
 When `--ledger` is selected, the command MUST pass the current Cosmos SDK
 Bech32 account-address prefix to `SaveLedgerKey`. It MUST NOT hardcode either
@@ -2024,9 +2032,11 @@ gateway request is attempted.
 
 When a protected provider operation cannot reach the gateway, its diagnostic
 includes the exact fallback `akt query provider <full-provider-address>` so the
-user can inspect current on-chain endpoint registration. The gateway's
-one-shot overall timeout remains 30 seconds; fallback guidance does not extend
-or mask that failure.
+user can inspect current on-chain endpoint registration. Provider status has a
+positive `--timeout` duration whose default is 30 seconds. The selected value
+configures the gateway's one-shot boundary itself, so values above and below 30
+seconds both take effect; fallback guidance does not extend or mask that
+failure.
 
 Provider `/status` is a public gateway endpoint. This command MUST NOT load a
 default account, open a keyring, mint a JWT, or load an mTLS certificate. It is
@@ -2040,6 +2050,7 @@ endpoint; explicitly passing it is refused instead of being silently ignored.
 | ---------------- | ------ | --------------- | ------------------------------------------------ |
 | `--provider`     | string | `""`            | Provider address; alternative to positional form |
 | `--provider-url` | string | on-chain record | Explicit provider gateway URL override           |
+| `--timeout`      | duration | `30s`          | Positive overall timeout for the status request  |
 
 All lease-, manifest-, migration-, log-, event-, and shell-scoped provider
 commands remain authenticated. Before constructing their gateway client they
@@ -2810,7 +2821,7 @@ The `akt console` group drives the Akash Console managed-wallet API (§7): deplo
 | `akt console deployment get <dseq>`                 |                                                | Deployment with leases and escrow account.                                                     |
 | `akt console deployment create <sdl-file> [deposit-usd]` | `--deposit <usd>` (alternative to positional; min 0.5) — **disabled pending feedback** (positional only, 2026-07) | Create a deployment; prints `dseq` + tx hash, the Console default `autoTopUp: {enabled: true, frequency: daily}`, and the exact command that disables it. It does not invent a deployment `state`; `deployment get` is authoritative for the later open/active transition. The deposit uses the unified cross-rail syntax (§7.4): `5`, `5usd`, or `$5` (min $0.50); coin forms like `5000000uakt` fail with the cross-rail error. The returned manifest is cached at `contexts/<name>/manifests/<dseq>.json` for `lease create`. |
 | `akt console deployment update <dseq> <sdl-file>`   |                                                | Update a deployment's SDL; closed deployments are rejected before mutation.                     |
-| `akt console deployment close <dseq>`               |                                                | Close a deployment. A 2xx must acknowledge `success: true`; a non-2xx is idempotent success only when it unambiguously reports already closed/absent. A rejection that merely contains `closed` remains an error. |
+| `akt console deployment close <dseq>`               |                                                | Close an active deployment. A preflight rejects an already-closed or absent deployment with a clear non-zero error; the shared `akt close` workflow preserves that failure. A 2xx delete must acknowledge `success: true`. |
 | `akt console deployment deposit <dseq> [amount-usd]` | `--amount <usd>` (alternative to positional; min 0.50) — **disabled pending feedback** (positional only, 2026-07) | Add funds to a non-closed deployment's escrow. The amount uses the unified cross-rail syntax (§7.4): `10`, `10usd`, or `$10`; coin forms fail with the cross-rail error. Values below $0.50 are rejected before the API call. |
 | `akt console deployment settings <dseq> [true\|false]` | `--auto-top-up true\|false` (alternative) — **disabled pending feedback** (positional only, 2026-07) | Show settings when no value is given; reject settings mutations for a closed deployment. |
 | `akt console bid list <dseq>`                       |                                                | List bids for the deployment's open orders.                                                    |
@@ -2845,7 +2856,7 @@ The `akt console` group drives the Akash Console managed-wallet API (§7): deplo
 | -------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
 | `akt console apikey list`        |                                                | List API keys (secrets are never shown).                         |
 | `akt console apikey create <name> [expires-at]` | `--name`, `--expires-at` (RFC 3339, alternatives) — **disabled pending feedback** (positional only, 2026-07) | Create a key; the secret is printed exactly once with a warning. |
-| `akt console apikey delete <id>` |                                                | Delete a key; a missing key (404) is a no-op. Pretty output acknowledges the full ID; JSON/YAML return `{id, deleted:true}`. |
+| `akt console apikey delete <id>` |                                                | Delete a key. The client first requires the UUID to appear in the account's key list, then sends DELETE. An absent key is non-zero with no DELETE or acknowledgement, even when the API's delete endpoint is idempotent. Pretty output acknowledges the full ID; JSON/YAML return `{id, deleted:true}` only after a present key's successful deletion. |
 | `akt console jwt create`         | `--ttl` (300, maximum 3600), `--scope` (csv, default `status,logs,events,shell,send-manifest,get-manifest`) | Mint a short-lived provider-scoped JWT. |
 
 **Provider gateway (live lease operations):**
@@ -2885,6 +2896,13 @@ pretty mode. Every non-streaming Console command uses the shared field-aware
 semantic renderer; pretty mode must not fall back to raw JSON. JSON and YAML
 retain the canonical wire semantics described below.
 
+After every successful Console action leaf, akt emits a `Next:` block with at
+least one runnable follow-up command on stderr. The informational channel keeps
+JSON, YAML, raw template SDL, log/event records, and shell bytes unchanged;
+`--quiet` suppresses the block. Bounded streams and shell commands emit it only
+after successful completion. Each Console leaf declares its guidance metadata,
+and command-tree verification fails when a new leaf omits it.
+
 **Console output contract:** the API's JSON field names and value types are the
 canonical structured representation. `--output json` emits that representation;
 `--output yaml` is a semantic translation of the same JSON tree, preserving raw
@@ -2907,14 +2925,13 @@ input. If both the remote command and
 structured-output rendering fail, the returned error preserves both causes so
 callers can classify either failure with `errors.Is`.
 
-Mutation acknowledgements are structured in JSON/YAML mode. Deployment close
-emits `{dseq, state, already_closed}`. `already_closed` is true only when the
-API explicitly reports the deployment already closed or absent. The API may
-return the same success envelope for an initial close and an already-closed
-no-op; in that case the field is false and does not claim that a new close
-transaction occurred. Deposit emits `{dseq, amount_usd, status}`. Template SDL
-is byte-for-byte deployable YAML in default/pretty mode; JSON/YAML mode wraps
-the exact source text as `{sdl: ...}` so comments and ordering are not lost.
+Mutation acknowledgements are structured in JSON/YAML mode. A successful
+deployment close emits `{dseq, state}` only after an active deployment's delete
+acknowledges `success: true`; an already-closed or absent deployment emits no
+success document and exits non-zero. Deposit emits
+`{dseq, amount_usd, status}`. Template SDL is byte-for-byte deployable YAML in
+default/pretty mode; JSON/YAML mode wraps the exact source text as `{sdl: ...}`
+so comments and ordering are not lost.
 
 ---
 
@@ -3130,7 +3147,7 @@ Two flags control confirmation and safety bypass behavior across the CLI. They s
 | `--yes` | `-y` | Skip interactive confirmation prompts. The operation proceeds as if the user answered "yes" to all prompts. The operation itself is unchanged. | `akt tx deployment close 12345 --yes` |
 | `--force` | | Override a safety guard that would otherwise prevent the operation. The operation may behave differently or bypass a check. | `akt context network delete mainnet --force` (deletes even if contexts reference it) |
 
-`--yes` / `-y` is **not a global flag**. It is added individually to commands that have confirmation prompts: all `tx` commands (via `AddTxFlagsToCmd()`, §3.2), workflow commands (`deploy`, `update`, `close`), and destructive context/store management commands (`context delete`, `store import --replace`). `--force` is used sparingly on specific commands where a structural safety check exists (e.g., deleting a network that is referenced by contexts). Commands should never use `--force` as a synonym for `--yes`.
+`--yes` / `-y` is **not a global flag**. It is added individually to commands that have confirmation prompts: all `tx` commands (via `AddTxFlagsToCmd()`, §3.2), workflow commands (`deploy`, `update`, `close`), and destructive context/store management commands (`context delete`, `store import --replace`). `context keys add` also accepts it as an explicit Cosmos CLI compatibility exception; because add refuses overwrites and has no confirmation prompt, the flag cannot bypass secret input or change key replacement behavior. `--force` is used sparingly on specific commands where a structural safety check exists (e.g., deleting a network that is referenced by contexts). Commands should never use `--force` as a synonym for `--yes`.
 
 ### 3.2 Transaction Flags
 
@@ -4411,10 +4428,11 @@ All requests include `Content-Type: application/json` and `x-api-key` headers.
 The client validates reusable request boundaries before constructing a URL or
 issuing HTTP: DSEQs are positive integers, pagination is non-negative with a
 positive limit, deletion IDs are UUIDs, API-key names are non-blank, deposits
-are at least $0.50, and JWT TTL is between 1 and 3600 seconds. Deployment
-update, deposit, and settings writes first read the deployment and reject a
-closed state. Close remains deliberately idempotent for terminal or absent
-deployments.
+use at most cent precision and are at least $0.50, and JWT TTL is between 1 and
+3600 seconds. API-key deletion first lists keys and rejects an absent target
+without sending DELETE. Deployment update, deposit, settings writes, and close
+first read the deployment and reject a closed state. Close also rejects an
+absent deployment; neither terminal case is reported as a successful mutation.
 
 The endpoints below cover the deployment lifecycle used by command and workflow routing (§7.4-§7.5). The client's full surface — user info, wallets, usage, provider/GPU/template catalogs, API keys, and provider-scoped JWTs — is documented per command in §2.9 and contract-tested against the vendored OpenAPI spec (`internal/console/testdata/openapi.json`).
 
@@ -4522,6 +4540,13 @@ When a workflow runs in a context with `auth-method: console-api`, the workflow 
 | Bare number | `5`, `5.50` | Error (coins require a denomination — the historical chain behavior, with cross-rail guidance) | Interpreted as USD, same as `5usd` |
 | `auto` / empty | `auto` | Chain-minimum deployment deposit, queried on chain | Error: an explicit USD deposit is required |
 
+USD and bare-number forms use the exact grammar
+`[0-9]+(\.[0-9]{1,2})?` after removing an optional leading `$` or trailing
+case-insensitive `usd`. Scientific notation (`1e0`), non-finite values,
+underscores, signs, and more than two fractional digits are invalid. Negative
+input retains a specific non-negative-amount diagnostic. Syntax and cent
+precision are validated before the rail minimum and before any API request.
+
 **Manifest handling**: The Console API's `POST /v1/deployments` returns a `manifest` field in the response. The workflow engine stores this value and passes it to `POST /v1/leases` when creating leases, instead of calling the provider's `send-manifest` endpoint directly.
 
 ### 7.5 Workflow and Command Routing
@@ -4610,7 +4635,7 @@ Status of `akt` coverage for every Akash Console capability. "Covered" means the
 | Authenticate with API key | `akt console login/logout/whoami`; per-context credential (`akt context edit --console-api-key`) | Resolution: flag > `AKT_CONSOLE_API_KEY` > per-context file (§7.1). Switching context switches Console identity. |
 | Create deployment (managed wallet) | `akt console deployment create <sdl> [deposit-usd]`; `akt deploy` in a `console-api` context | Deposit in USD (minimum $0.50), unified deposit syntax per §7.4. The manifest is cached per context for the follow-up lease. |
 | List / inspect deployments | `akt console deployment list/get` | Pagination via `--skip`/`--limit`. |
-| Update / close deployment | `akt console deployment update/close`; `akt update`, `akt close` | Close is idempotent: an already-closed deployment reports success. |
+| Update / close deployment | `akt console deployment update/close`; `akt update`, `akt close` | Update and close reject an already-closed deployment with a non-zero result; close never turns an earlier terminal state into current-command success. |
 | Escrow deposit | `akt console deployment deposit <dseq> [amount-usd]` | |
 | Auto top-up settings | `akt console deployment settings <dseq> [true\|false]` | `/v2/deployment-settings`, PATCH with POST fallback. |
 | View bids / create lease | `akt console bid list <dseq>`, `akt console lease create <dseq> [provider]` | The `akt deploy` workflow automates the bid wait and selection. |
@@ -7662,15 +7687,13 @@ auto-top-up disablement and close, and retains the final 20 seconds for
 terminal-state, exact transferred-spend, and account-total reconciliation
 observations.
 
-**Current implementation boundary (2026-08-14):** the opt-in live suite covers
-create, bid, lease, provider status, deposit, settings, update, and idempotent
-close. The repeated close runs only after the raw observer establishes terminal
-state. It must succeed through the public binary, emit the exact DSEQ, closed
-state, and an `already_closed` boolean, append one successful close action, and
-leave the deployment independently observable as closed or absent with no
-active lease. The boolean's value is not an idempotency oracle because the API
-may use the same successful response for the initial transition and the
-already-closed no-op. Its independent raw observer, exact owned escrow
+**Current implementation boundary (2026-08-18):** the opt-in live suite covers
+create, bid, lease, provider status, deposit, settings, update, and close. A
+repeated close runs only after the raw observer establishes terminal state. It
+must fail through the public binary with a clear already-closed error, emit no
+success document, append one failed close action, and leave the deployment
+independently observable as closed or absent with no active lease. Its
+independent raw observer, exact owned escrow
 `transferred` value, and signed account-total reconciliation are Console-side
 proof only. It also requires a provider-reported workload URI to
 serve a bounded non-empty 2xx response through an independent standard HTTP

--- a/SPEC.md
+++ b/SPEC.md
@@ -532,6 +532,15 @@ vote-list, or tally query first checks that the proposal exists, a failed
 preflight wraps the underlying dependency error so it remains discoverable
 with `errors.Is`.
 
+Console request identifiers and paging values follow the same boundary rule.
+Every DSEQ is parsed as a positive base-10 integer before an HTTP request is
+built. Deployment-list pagination rejects `skip < 0` and `limit < 1` instead
+of silently omitting those values. API-key deletion requires a non-empty UUID,
+key creation rejects a blank name, and local key creation rejects a name that
+is blank after trimming. Commands that require a terminal session, including
+an interactive Console shell with no explicit command, reject non-terminal
+stdin before any identity or network lookup can block.
+
 Every accepted flag must affect the operation it describes. If a leaf cannot
 apply an inherited transport, snapshot, pagination, or output flag, it rejects
 that flag before configuration or network work rather than accepting and
@@ -574,11 +583,23 @@ valid dry-run emits one JSON object per planned step with `result:"planned"`,
 empty `errors` and `txs` arrays, and one generated run ID shared by every line;
 it emits no human plan text.
 
+Deployment dry-runs also resolve the effective deposit. The Console rail
+prints the validated USD amount and enforces the $0.50 minimum. The chain rail
+prints an explicit coin unchanged, while `auto` queries the active network's
+deployment minimum; if that value cannot be resolved, planning fails rather
+than displaying an amount that execution would not use. Signer names are
+resolved to addresses before transaction simulation on every dry-run path.
+
 ### 2.0 Root Command Behavior (`akt` with no subcommand)
 
 When `akt` is invoked with no subcommand, the following flow determines what happens:
 
 1. **No config exists** (first run): The bootstrap wizard runs (`internal/bootstrap/`; glyphs per §1.11, prompt rendering per §3.9). The wizard runs only when stdin is a terminal: in headless environments it declines to bootstrap (no network fetch, no config written) and prints guidance to create a config via `akt context network create` / `akt context create`; the root command then continues to step 2 without a config. After bootstrap completes, the root command continues to step 2.
+
+Commands whose purpose is to create the missing configuration, including
+`context create` and `context network create`, suppress the generic no-config
+warning when they succeed. A successful remedy must not be followed by the
+warning it just resolved.
 
 In a terminal the wizard performs the following steps, in order. All of its output — announcements, prompts, progress, and the closing summary — goes to stderr (§3.9.2, §10.1.1); the wizard writes nothing to stdout.
 
@@ -952,6 +973,15 @@ contract; they never print group help at exit 0 or reach gas simulation.
 
 Create a new named context. A context references a network and keyring by name.
 
+The inherited per-invocation `--keyring-backend` flag is not a persistence
+setting and is rejected on `context create`. The diagnostic points to
+`akt context keyring set <keyring> <backend>`; context creation never silently
+changes a shared keyring's backend.
+
+Success prints a one-line confirmation containing the full context name,
+network (or `none`), effective auth method, and whether it became current.
+JSON and YAML expose the same fields as structured data.
+
 | Flag                  | Type   | Default     | Description                                                      |
 | --------------------- | ------ | ----------- | ---------------------------------------------------------------- |
 | `--network`           | string | `""`        | Network name to use (required; must exist)                       |
@@ -1286,6 +1316,11 @@ unless `--no-backup` was selected. Recovered keys never repeat their input
 mnemonic. The selected output format applies equally to local, Ledger, and
 multisig keys.
 
+The command is non-interactive except when it must read secret material or a
+keyring passphrase. It has no confirmation prompt and therefore no `--yes`
+flag. `--no-backup` suppresses mnemonic output for unattended creation. A name
+that is empty or whitespace-only is rejected before the keyring is opened.
+
 When `--ledger` is selected, the command MUST pass the current Cosmos SDK
 Bech32 account-address prefix to `SaveLedgerKey`. It MUST NOT hardcode either
 `cosmos` or `akash`: the SDK configuration is authoritative for the active
@@ -1387,6 +1422,14 @@ params:
     type: duration
     default: "5m"
     description: Maximum time to wait for bids
+  ready-timeout:
+    type: duration
+    default: "2m"
+    description: Maximum time to wait for deployed services to become ready
+  no-wait-active:
+    type: bool
+    default: "false"
+    description: Return after manifest submission without polling service readiness
   bid-select:
     type: bid-selection
     default: "interactive"
@@ -1600,7 +1643,7 @@ Workflows support two execution modes:
 {"workflow":"deploy","id":"wf_abc123","step":"select-bid","result":"completed","errors":[],"txs":[]}
 {"workflow":"deploy","id":"wf_abc123","step":"create-lease","result":"completed","errors":[],"txs":[{"hash":"EFGH5678...","height":12350,"gas_used":120000,"code":0}]}
 {"workflow":"deploy","id":"wf_abc123","step":"send-manifest","result":"completed","errors":[],"txs":[]}
-{"workflow":"deploy","id":"wf_abc123","step":"display-result","result":"completed","errors":[],"txs":[]}
+{"workflow":"deploy","id":"wf_abc123","step":"display-result","result":"completed","errors":[],"txs":[],"outputs":{"dseq":"12345","provider":"akash1provider...","price":"1 uact","uris":{"web":["https://example.test"]},"ready":true}}
 ```
 
 On error:
@@ -1618,6 +1661,15 @@ On error:
 | `result`   | string   | `planned` (dry-run), `completed`, `error`, or `skipped` (step skipped by its on-error policy) |
 | `errors`   | []string | Array of error messages (empty when `result` is `completed`)    |
 | `txs`      | []object | Array of raw transaction results (empty for non-tx steps)       |
+| `outputs`  | object   | Stable values produced by the step; omitted when the step produced none. Deployment completion includes the DSEQ, full provider address, selected price, service URI map, readiness state, and a Console deep link when applicable. |
+
+The final deployment step waits within a bounded interval for the selected
+lease's services to become ready. Readiness timeout preserves the deployment
+identity and recovery commands in the failed result. A successful Console
+deployment includes a browser deep link only when the configured API origin is
+the production Console service; custom origins do not receive a misleading
+production link. Pretty workflow output ends with a concise `Next` section,
+while JSON, YAML, and JSONL contain only their structured fields.
 
 **Transaction object schema (within `txs`):**
 
@@ -1773,11 +1825,12 @@ opt-out command. The chain rail does not display a Console setting.
 | `--from`           | string   | context default | Account to deploy from                                      |
 | `--deposit`        | string   | `auto`          | Initial deposit, unified syntax on both rails (see §7.4): `auto` (recommended for keyring), `5usd`/`$5` (Console), or an explicit network deposit coin |
 | `--bid-timeout`    | duration | `5m`            | Maximum time to wait for bids                               |
+| `--ready-timeout`  | duration | `2m`            | Maximum time to wait for service readiness                  |
 | `--min-bids`       | int      | `1`             | Minimum bids before selection                               |
 | `--bid-select`     | string   | `"interactive"` | Bid selection: `interactive`, `cheapest`, `provider=<addr>` |
 | `--no-wait-bids`   | bool     | `false`         | Exit after creating deployment (don't wait for bids)        |
 | `--no-wait-lease`  | bool     | `false`         | Exit after creating lease (don't send manifest)             |
-| `--no-wait-active` | bool     | `false`         | Exit after sending manifest (don't wait for active)         |
+| `--no-wait-active` | bool     | `false`         | Exit after sending manifest (don't poll service readiness)  |
 | `--label`          | string   | `""`            | User label for local store metadata                         |
 | `--note`           | string   | `""`            | User note for local store metadata                          |
 | `--yes`            | bool     | `false`         | Skip all confirmations                                      |
@@ -1968,6 +2021,12 @@ Query provider status. Supply the provider address positionally or with
 `host_uri`; `--provider-url` is an explicit override for diagnostics and
 private gateways. A provider with no on-chain host URI is refused before a
 gateway request is attempted.
+
+When a protected provider operation cannot reach the gateway, its diagnostic
+includes the exact fallback `akt query provider <full-provider-address>` so the
+user can inspect current on-chain endpoint registration. The gateway's
+one-shot overall timeout remains 30 seconds; fallback guidance does not extend
+or mask that failure.
 
 Provider `/status` is a public gateway endpoint. This command MUST NOT load a
 default account, open a keyring, mint a JWT, or load an mTLS certificate. It is
@@ -2212,6 +2271,10 @@ discoverable.
 #### `akt store export`
 
 Export the local store to YAML or JSON.
+
+This is a local inspection and backup envelope for `akt store import`. It is
+not SDL and is not accepted by `akt deploy`; use `akt query deployment` for a
+fresh chain view and an SDL source file for deployment creation.
 
 | Flag             | Type   | Default  | Description                                |
 | ---------------- | ------ | -------- | ------------------------------------------ |
@@ -2599,6 +2662,13 @@ returns 27 read-only tools. `--enable-writes` adds four chain/provider writes
 and two Console writes, for 33 tools total. A server with only one rail exposes
 only that rail's subset.
 
+Tool registration is also capability-isolated within a rail. Query tools are
+registered as soon as their read client is available. When `--enable-writes`
+is requested but no signing identity can be resolved, startup still exposes
+the read tools; signing-dependent tools are omitted and the write-capability
+diagnostic is retained for attempted write discovery. A missing optional write
+client must never make an otherwise usable read-only MCP server fail startup.
+
 **Read-only tools (up to 27 tools):**
 
 | Tool Name                      | Description                                                                |
@@ -2736,13 +2806,13 @@ The `akt console` group drives the Akash Console managed-wallet API (§7): deplo
 
 | Command                                             | Flags                                          | Description                                                                                   |
 | --------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `akt console deployment list`                       | `--skip` (0), `--limit` (20)                   | List deployments with pagination.                                                              |
+| `akt console deployment list [active\|closed]`       | `--skip` (0), `--limit` (20)                   | List deployments with validated pagination and an optional state filter. Filtering traverses bounded pages before applying the requested page window. |
 | `akt console deployment get <dseq>`                 |                                                | Deployment with leases and escrow account.                                                     |
 | `akt console deployment create <sdl-file> [deposit-usd]` | `--deposit <usd>` (alternative to positional; min 0.5) — **disabled pending feedback** (positional only, 2026-07) | Create a deployment; prints `dseq` + tx hash, the Console default `autoTopUp: {enabled: true, frequency: daily}`, and the exact command that disables it. It does not invent a deployment `state`; `deployment get` is authoritative for the later open/active transition. The deposit uses the unified cross-rail syntax (§7.4): `5`, `5usd`, or `$5` (min $0.50); coin forms like `5000000uakt` fail with the cross-rail error. The returned manifest is cached at `contexts/<name>/manifests/<dseq>.json` for `lease create`. |
-| `akt console deployment update <dseq> <sdl-file>`   |                                                | Update the deployment's SDL.                                                                   |
+| `akt console deployment update <dseq> <sdl-file>`   |                                                | Update a deployment's SDL; closed deployments are rejected before mutation.                     |
 | `akt console deployment close <dseq>`               |                                                | Close a deployment. A 2xx must acknowledge `success: true`; a non-2xx is idempotent success only when it unambiguously reports already closed/absent. A rejection that merely contains `closed` remains an error. |
-| `akt console deployment deposit <dseq> [amount-usd]` | `--amount <usd>` (alternative to positional; > 0) — **disabled pending feedback** (positional only, 2026-07) | Add funds to the deployment's escrow. The amount uses the unified cross-rail syntax (§7.4): `10`, `10usd`, or `$10`; coin forms fail with the cross-rail error. |
-| `akt console deployment settings <dseq> [true\|false]` | `--auto-top-up true\|false` (alternative) — **disabled pending feedback** (positional only, 2026-07) | Show settings when no value is given; set auto-top-up when a positional or flag value is present. |
+| `akt console deployment deposit <dseq> [amount-usd]` | `--amount <usd>` (alternative to positional; min 0.50) — **disabled pending feedback** (positional only, 2026-07) | Add funds to a non-closed deployment's escrow. The amount uses the unified cross-rail syntax (§7.4): `10`, `10usd`, or `$10`; coin forms fail with the cross-rail error. Values below $0.50 are rejected before the API call. |
+| `akt console deployment settings <dseq> [true\|false]` | `--auto-top-up true\|false` (alternative) — **disabled pending feedback** (positional only, 2026-07) | Show settings when no value is given; reject settings mutations for a closed deployment. |
 | `akt console bid list <dseq>`                       |                                                | List bids for the deployment's open orders.                                                    |
 | `akt console lease create <dseq> [provider]`        | `--gseq` (1), `--oseq` (1), `--provider` (alternative to positional) — **disabled pending feedback** (positional only, 2026-07), `--manifest <file>` | Accept a bid; the manifest defaults to the one cached by `deployment create`. |
 
@@ -2776,7 +2846,7 @@ The `akt console` group drives the Akash Console managed-wallet API (§7): deplo
 | `akt console apikey list`        |                                                | List API keys (secrets are never shown).                         |
 | `akt console apikey create <name> [expires-at]` | `--name`, `--expires-at` (RFC 3339, alternatives) — **disabled pending feedback** (positional only, 2026-07) | Create a key; the secret is printed exactly once with a warning. |
 | `akt console apikey delete <id>` |                                                | Delete a key; a missing key (404) is a no-op. Pretty output acknowledges the full ID; JSON/YAML return `{id, deleted:true}`. |
-| `akt console jwt create`         | `--ttl` (300), `--scope` (csv, default `status,logs,events,shell,send-manifest,get-manifest`) | Mint a short-lived provider-scoped JWT. |
+| `akt console jwt create`         | `--ttl` (300, maximum 3600), `--scope` (csv, default `status,logs,events,shell,send-manifest,get-manifest`) | Mint a short-lived provider-scoped JWT. |
 
 **Provider gateway (live lease operations):**
 
@@ -2802,10 +2872,18 @@ one-shot read.
 | `akt console logs <dseq> [service]`                | `--follow`, `--tail N`, `--service` (alternative) — **disabled pending feedback** (positional only, 2026-07) | Stream container logs from the lease's provider (JWT scopes `logs,status`).                    |
 | `akt console events <dseq>`                        | `--follow`                                  | Stream Kubernetes events from the lease's provider (JWT scopes `events,status`).                     |
 | `akt console status <dseq>`                        | `--watch`, `--interval` (5s)                | Live lease status from the provider gateway (JWT scope `status`); with `--watch`, snapshots are re-printed each interval until interrupted. `deployment get` remains the Console-API view. |
-| `akt console shell <dseq> <service> [-- command...]` | `--stdin`                                 | Interactive shell in a lease container, default `/bin/sh`; exec is the same operation with an explicit command (JWT scopes `shell,status`). TTY auto-detected; terminal stdin is detached from explicit commands unless `--stdin` is supplied. |
-| `akt console screen <sdl-file>`                    |                                             | Client-side bid screening: derive resources from the SDL and list the providers able to run it (public endpoint, no key needed). |
+| `akt console shell <dseq> [service] [-- command...]` | `--stdin`                                | Interactive shell in a lease container, default `/bin/sh`; when exactly one SDL service exists it is selected automatically. Multiple services require an explicit name and list the choices. Exec is the same operation with an explicit command (JWT scopes `shell,status`). |
+| `akt console screen [sdl-file]`                    | `--cpu`, `--memory`, `--storage`, `--gpu`, `--gpu-model`, `--count`, `--attribute`, `--signed-by`, `--reclamation-window` | Client-side bid screening from an SDL, resource flags, or both. Explicit flags override SDL-derived fields (public endpoint, no key needed). |
 
 Per the positional-primary convention (§3.8), every console command takes its primary value(s) positionally; the equivalent flags remain as overrides and a positional value wins when both are given. (2026-07: the flag twins marked *disabled pending feedback* above are commented out in code for the positional-only UX trial — the positional form is the only way while the trial runs; the original flag definitions are preserved in `FEEDBACK(2026-07)` comments for restoration.) Default structured reads are indented JSON, while human acknowledgements and streams use the command-specific pretty forms described below. USD values at or above one cent render with two decimals. A nonzero sub-cent value renders with up to six decimals and trailing zeros stripped; a magnitude below one millionth of a dollar renders as `$<0.000001` (or `-$<0.000001`) rather than the false `$0.00`. Zero remains `$0.00`. State-changing calls are recorded in the context's action log as `type=console` entries (§5.6). No command ever prints a Console API key, except the one-time secret from `apikey create`.
+
+Console escrow `uact` values are micro-USD: amounts render as dollars and
+per-block prices render as an estimated monthly dollar cost using six-second
+blocks (432,000 blocks per 30-day month). Other denoms remain explicit and are
+never relabeled as dollars. Empty event streams say `No recent events` in
+pretty mode. Every non-streaming Console command uses the shared field-aware
+semantic renderer; pretty mode must not fall back to raw JSON. JSON and YAML
+retain the canonical wire semantics described below.
 
 **Console output contract:** the API's JSON field names and value types are the
 canonical structured representation. `--output json` emits that representation;
@@ -3339,6 +3417,12 @@ leading address from the active context before sending a request. If the
 context has no default account, the command refuses locally and explains that
 an owner address or `default-account` is required. An empty owner is never sent
 to the chain query service because it means network-wide scope.
+
+In a Console context, omitted owner and numeric-DSEQ shorthand resolve the
+managed wallet owner lazily from authenticated Console identity and wallet
+metadata. An explicit full owner remains authoritative and triggers no owner
+lookup. The resolved full address is then used by the same deployment and
+market query filters as a keyring context.
 
 #### 3.8.5 Per-Command Filter Scope
 
@@ -4298,6 +4382,14 @@ in depth.
 ### 7.3 Endpoints
 
 All requests include `Content-Type: application/json` and `x-api-key` headers.
+
+The client validates reusable request boundaries before constructing a URL or
+issuing HTTP: DSEQs are positive integers, pagination is non-negative with a
+positive limit, deletion IDs are UUIDs, API-key names are non-blank, deposits
+are at least $0.50, and JWT TTL is between 1 and 3600 seconds. Deployment
+update, deposit, and settings writes first read the deployment and reject a
+closed state. Close remains deliberately idempotent for terminal or absent
+deployments.
 
 The endpoints below cover the deployment lifecycle used by command and workflow routing (§7.4-§7.5). The client's full surface — user info, wallets, usage, provider/GPU/template catalogs, API keys, and provider-scoped JWTs — is documented per command in §2.9 and contract-tested against the vendored OpenAPI spec (`internal/console/testdata/openapi.json`).
 

--- a/e2e/console_live_mutation_helpers_test.go
+++ b/e2e/console_live_mutation_helpers_test.go
@@ -2144,16 +2144,18 @@ func (tracker *consoleResourceTracker) cleanup() {
 			}
 		}
 
-		closeDeadline, ok := consoleBoundedDeadline(mutationCtx, time.Now().Add(10*time.Second))
-		if !ok {
-			tracker.t.Errorf("Console cleanup had no time left to close %s", dseq)
-			continue
-		}
-		closeCtx, cancelClose := context.WithDeadline(mutationCtx, closeDeadline)
-		result := runConsoleAkt(closeCtx, tracker.t, tracker.home, "console", "deployment", "close", dseq)
-		cancelClose()
-		if result.Exit != 0 || result.Err != nil || result.CredentialLeak || result.StdoutTruncated || result.StderrTruncated {
-			tracker.t.Errorf("Console cleanup close %s failed (%s)", dseq, consoleCommandDiagnostic(result))
+		if !terminal {
+			closeDeadline, ok := consoleBoundedDeadline(mutationCtx, time.Now().Add(10*time.Second))
+			if !ok {
+				tracker.t.Errorf("Console cleanup had no time left to close %s", dseq)
+				continue
+			}
+			closeCtx, cancelClose := context.WithDeadline(mutationCtx, closeDeadline)
+			result := runConsoleAkt(closeCtx, tracker.t, tracker.home, "console", "deployment", "close", dseq)
+			cancelClose()
+			if result.Exit != 0 || result.Err != nil || result.CredentialLeak || result.StdoutTruncated || result.StderrTruncated {
+				tracker.t.Errorf("Console cleanup close %s failed (%s)", dseq, consoleCommandDiagnostic(result))
+			}
 		}
 	}
 

--- a/e2e/console_live_mutation_test.go
+++ b/e2e/console_live_mutation_test.go
@@ -639,17 +639,16 @@ func TestConsoleLiveManagedWalletLifecycle(t *testing.T) {
 	assertConsoleActions(t, home, contextName, dseq, expectedActions...)
 
 	var closed struct {
-		DSeq          consoleFlexibleID `json:"dseq"`
-		State         string            `json:"state"`
-		AlreadyClosed *bool             `json:"already_closed"`
+		DSeq  consoleFlexibleID `json:"dseq"`
+		State string            `json:"state"`
 	}
 	requireConsoleJSON(t,
 		runConsoleAkt(lifecycleCtx, t, home, "console", "deployment", "close", dseq),
 		"akt console deployment close",
 		&closed,
 	)
-	if closed.DSeq.String() != dseq || closed.State != "closed" || closed.AlreadyClosed == nil || *closed.AlreadyClosed {
-		t.Fatalf("first close acknowledgement did not report dseq=%s state=closed already_closed=false", dseq)
+	if closed.DSeq.String() != dseq || closed.State != "closed" {
+		t.Fatalf("first close acknowledgement did not report dseq=%s state=closed", dseq)
 	}
 	expectedActions = append(expectedActions, "close-deployment")
 	assertConsoleActions(t, home, contextName, dseq, expectedActions...)
@@ -662,29 +661,28 @@ func TestConsoleLiveManagedWalletLifecycle(t *testing.T) {
 	cancelTerminal()
 	assertConsoleActions(t, home, contextName, dseq, expectedActions...)
 
-	// The public command promises idempotent close. Exercise the terminal
-	// transition again and require another successful mutation audit record.
-	var closedAgain struct {
-		DSeq          consoleFlexibleID `json:"dseq"`
-		State         string            `json:"state"`
-		AlreadyClosed *bool             `json:"already_closed"`
+	// A repeated close did not perform a mutation, so it must fail without a
+	// success document and must record the failed attempt truthfully.
+	repeatedClose := runConsoleAkt(lifecycleCtx, t, home, "console", "deployment", "close", dseq)
+	if repeatedClose.Exit == 0 || repeatedClose.Err == nil || repeatedClose.CredentialLeak {
+		t.Fatalf("repeated close did not fail closed without disclosure (%s)", consoleCommandDiagnostic(repeatedClose))
 	}
-	requireConsoleJSON(t,
-		runConsoleAkt(lifecycleCtx, t, home, "console", "deployment", "close", dseq),
-		"akt console deployment close (idempotent repeat)",
-		&closedAgain,
-	)
-	if closedAgain.DSeq.String() != dseq || closedAgain.State != "closed" || closedAgain.AlreadyClosed == nil {
-		t.Fatalf("repeated close acknowledgement did not report dseq=%s state=closed with an already_closed boolean", dseq)
+	if strings.TrimSpace(repeatedClose.Stdout) != "" || !strings.Contains(strings.ToLower(repeatedClose.Stderr), "already closed") {
+		t.Fatalf("repeated close output was not a clear error without a success document (%s)", consoleCommandDiagnostic(repeatedClose))
 	}
-	expectedActions = append(expectedActions, "close-deployment")
-	assertConsoleActions(t, home, contextName, dseq, expectedActions...)
+	closeEntries, err := readConsoleActions(home, contextName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(closeEntries) != len(expectedActions)+1 {
+		t.Fatalf("repeated close action log has %d entries, want %d", len(closeEntries), len(expectedActions)+1)
+	}
+	failedClose := closeEntries[0]
+	if failedClose.Type != "console" || failedClose.Action != "close-deployment" || failedClose.Status != "failed" || failedClose.DSeq != dseqNumber || !strings.Contains(strings.ToLower(failedClose.Error), "already closed") {
+		t.Fatalf("repeated close action = %s, want failed already-closed attempt", consoleActionSummary(failedClose))
+	}
+	actionBaselineCount := len(expectedActions) + 1
 
-	// Console intentionally returns the same success envelope when its backend
-	// observes an already-closed deployment and performs no transaction. The
-	// CLI therefore cannot infer prior state from a 200 response; the second
-	// successful command plus the action log and independent terminal-state
-	// observation below are the idempotency proof.
 	if err := waitForConsoleTerminalState(lifecycleCtx, observer, dseq); err != nil {
 		t.Fatalf("repeated close lost terminal state for dseq %s: %v", dseq, err)
 	}
@@ -732,7 +730,7 @@ func TestConsoleLiveManagedWalletLifecycle(t *testing.T) {
 	}
 	childSecret := childKey.APIKey
 	t.Cleanup(func() { assertConsoleSecretAbsent(t, home, contextName, childSecret) })
-	assertConsoleActionTail(t, home, contextName, len(expectedActions), "create-api-key")
+	assertConsoleActionTail(t, home, contextName, actionBaselineCount, "create-api-key")
 
 	keyObserveCtx, cancelKeyObserve := context.WithTimeout(lifecycleCtx, 15*time.Second)
 	var observedKeys []consoleAPIKeyObservation
@@ -790,7 +788,7 @@ func TestConsoleLiveManagedWalletLifecycle(t *testing.T) {
 	if deletedKey.ID != childKey.ID || !deletedKey.Deleted {
 		t.Fatalf("API-key delete acknowledgement = id %q deleted %t, want exact ID and true", deletedKey.ID, deletedKey.Deleted)
 	}
-	assertConsoleActionTail(t, home, contextName, len(expectedActions), "create-api-key", "delete-api-key")
+	assertConsoleActionTail(t, home, contextName, actionBaselineCount, "create-api-key", "delete-api-key")
 
 	keyDeleteCtx, cancelKeyDelete := context.WithTimeout(lifecycleCtx, 15*time.Second)
 	err = waitForConsoleCondition(keyDeleteCtx, time.Second, func() (bool, string, error) {
@@ -815,19 +813,24 @@ func TestConsoleLiveManagedWalletLifecycle(t *testing.T) {
 		t.Fatal("akt console apikey list did not return to the independent baseline")
 	}
 
-	var deletedAgain struct {
-		ID      string `json:"id"`
-		Deleted bool   `json:"deleted"`
+	repeatedDelete := runConsoleAkt(lifecycleCtx, t, home, "console", "apikey", "delete", childKey.ID)
+	if repeatedDelete.Exit == 0 || repeatedDelete.Err == nil || repeatedDelete.CredentialLeak {
+		t.Fatalf("repeated API-key delete did not fail closed without disclosure (%s)", consoleCommandDiagnostic(repeatedDelete))
 	}
-	requireConsoleJSON(t,
-		runConsoleAkt(lifecycleCtx, t, home, "console", "apikey", "delete", childKey.ID),
-		"akt console apikey delete (idempotent repeat)",
-		&deletedAgain,
-	)
-	if deletedAgain.ID != childKey.ID || !deletedAgain.Deleted {
-		t.Fatalf("repeated API-key delete acknowledgement = id %q deleted %t, want exact ID and true", deletedAgain.ID, deletedAgain.Deleted)
+	if strings.TrimSpace(repeatedDelete.Stdout) != "" || !strings.Contains(strings.ToLower(repeatedDelete.Stderr), "not found") {
+		t.Fatalf("repeated API-key delete output was not a clear error without a success document (%s)", consoleCommandDiagnostic(repeatedDelete))
 	}
-	assertConsoleActionTail(t, home, contextName, len(expectedActions), "create-api-key", "delete-api-key", "delete-api-key")
+	keyEntries, err := readConsoleActions(home, contextName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keyEntries) != actionBaselineCount+3 {
+		t.Fatalf("repeated API-key delete action log has %d entries, want %d", len(keyEntries), actionBaselineCount+3)
+	}
+	failedDelete := keyEntries[0]
+	if failedDelete.Type != "console" || failedDelete.Action != "delete-api-key" || failedDelete.Status != "failed" || failedDelete.DSeq != 0 || !strings.Contains(strings.ToLower(failedDelete.Error), "not found") {
+		t.Fatalf("repeated API-key delete action = %s, want failed not-found attempt", consoleActionSummary(failedDelete))
+	}
 
 	if username, err := childObserver.username(lifecycleCtx); err == nil || username != "" {
 		t.Fatalf("revoked child API key remained usable through the independent observer: username_present=%t error=%v", username != "", err)

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.143.0
 	github.com/golang-jwt/jwt/v5 v5.2.3
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/mark3labs/mcp-go v0.48.0
 	github.com/pkg/errors v0.9.1
@@ -179,7 +180,6 @@ require (
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect

--- a/internal/cli/chain/bank_tx.go
+++ b/internal/cli/chain/bank_tx.go
@@ -45,7 +45,6 @@ Note, this command has two way of being executed:
        send [from_key_or_address] [to_address] [amount]
      - sender address|key is taken from --from flag. In this case command takes 2 arguments.
        send [to_address] [amount] --from=address|key"
-When using '--dry-run' a key name cannot be used, only a bech32 address.
 `,
 		Args: cobra.RangeArgs(2, 3),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -108,7 +107,7 @@ By default, sends the [amount] to each address of the list.
 Using the '--split' flag, the [amount] is split equally between the addresses.
 Note, the '--from' flag is ignored as it is implied from [from_key_or_address] and
 separate addresses with space.
-When using '--dry-run' a key name cannot be used, only a bech32 address.`,
+Key names and bech32 addresses are both accepted for --dry-run.`,
 		Example: fmt.Sprintf("%s tx bank multi-send akash1... akash1... akash1... akash1... 10stake", version.AppName),
 		Args:    cobra.MinimumNArgs(4),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/chain/cctx.go
+++ b/internal/cli/chain/cctx.go
@@ -104,7 +104,7 @@ func resolveDefaultAccountAddress(cctx sdkclient.Context) (string, error) {
 
 	from := strings.TrimSpace(cctx.From)
 	if from == "" {
-		return "", nil
+		return resolveTransportDefaultOwner(cctx)
 	}
 
 	if addr, err := sdk.AccAddressFromBech32(from); err == nil {
@@ -121,6 +121,27 @@ func resolveDefaultAccountAddress(cctx sdkclient.Context) (string, error) {
 	}
 
 	return addr.String(), nil
+}
+
+func resolveTransportDefaultOwner(cctx sdkclient.Context) (string, error) {
+	if cctx.CmdContext == nil {
+		return "", nil
+	}
+	resolver, ok := cctx.CmdContext.Value(ContextTypeDefaultOwnerResolver).(DefaultOwnerResolver)
+	if !ok || resolver == nil {
+		return "", nil
+	}
+
+	address, err := resolver(cctx.CmdContext)
+	if err != nil {
+		return "", err
+	}
+	parsed, err := sdk.AccAddressFromBech32(strings.TrimSpace(address))
+	if err != nil {
+		return "", fmt.Errorf("resolve transport default owner: invalid wallet address %q: %w", address, err)
+	}
+
+	return parsed.String(), nil
 }
 
 // defaultOwnerForQueryArg resolves the default account only for numeric
@@ -390,7 +411,14 @@ func ReadTxCommandFlags(cctx sdkclient.Context, flagSet *pflag.FlagSet, diagnost
 		if flagSet.Changed(flagdefs.FlagFrom) || from == "" {
 			from, _ = flagSet.GetString(flagdefs.FlagFrom)
 		}
-		fromAddr, fromName, keyType, err := sdkclient.GetFromFields(cctx, cctx.Keyring, from)
+		lookupContext := cctx
+		if cctx.Simulate {
+			// The Cosmos helper intentionally refuses key names once simulation
+			// is set. Resolve the name at this boundary first, then retain the
+			// original simulation context for transaction execution.
+			lookupContext = cctx.WithSimulation(false)
+		}
+		fromAddr, fromName, keyType, err := sdkclient.GetFromFields(lookupContext, cctx.Keyring, from)
 		if err != nil {
 			return cctx, err
 		}

--- a/internal/cli/chain/context.go
+++ b/internal/cli/chain/context.go
@@ -20,13 +20,18 @@ const (
 type ContextType string
 
 const (
-	ContextTypeClient         = ContextType("context-client")
-	ContextTypeQueryClient    = ContextType("context-query-client")
-	ContextTypeAddressCodec   = ContextType("address-codec")
-	ContextTypeValidatorCodec = ContextType("validator-codec")
-	ContextTypeRPCURI         = ContextType("rpc-uri")
-	ContextTypeRPCClient      = ContextType("rpc-client")
+	ContextTypeClient               = ContextType("context-client")
+	ContextTypeQueryClient          = ContextType("context-query-client")
+	ContextTypeAddressCodec         = ContextType("address-codec")
+	ContextTypeValidatorCodec       = ContextType("validator-codec")
+	ContextTypeRPCURI               = ContextType("rpc-uri")
+	ContextTypeRPCClient            = ContextType("rpc-client")
+	ContextTypeDefaultOwnerResolver = ContextType("default-owner-resolver")
 )
+
+// DefaultOwnerResolver lazily supplies an account address for query filters
+// when the active transport owns the wallet instead of a local keyring.
+type DefaultOwnerResolver func(context.Context) (string, error)
 
 var ErrContextValueNotSet = errors.New("context does not have value set")
 

--- a/internal/cli/chain/default_account_test.go
+++ b/internal/cli/chain/default_account_test.go
@@ -52,6 +52,28 @@ func TestDefaultOwnerResolutionUsesTransportResolverLazily(t *testing.T) {
 	require.ErrorIs(t, err, resolverErr)
 }
 
+func TestTransportDefaultOwnerResolverBoundaryFailures(t *testing.T) {
+	t.Run("missing resolver", func(t *testing.T) {
+		owner, err := resolveTransportDefaultOwner(
+			sdkclient.Context{}.WithCmdContext(context.Background()),
+		)
+		require.NoError(t, err)
+		require.Empty(t, owner)
+	})
+
+	t.Run("invalid resolver address", func(t *testing.T) {
+		ctx := context.WithValue(
+			context.Background(),
+			ContextTypeDefaultOwnerResolver,
+			DefaultOwnerResolver(func(context.Context) (string, error) {
+				return "not-a-wallet", nil
+			}),
+		)
+		_, err := resolveTransportDefaultOwner(sdkclient.Context{}.WithCmdContext(ctx))
+		require.ErrorContains(t, err, "invalid wallet address")
+	})
+}
+
 func (k *keyLookupCounter) Key(uid string) (*sdkkeyring.Record, error) {
 	k.lookups++
 	return k.Keyring.Key(uid)

--- a/internal/cli/chain/default_account_test.go
+++ b/internal/cli/chain/default_account_test.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
 	aktcodec "pkg.akt.dev/akt/internal/codec"
@@ -14,6 +17,39 @@ import (
 type keyLookupCounter struct {
 	sdkkeyring.Keyring
 	lookups int
+}
+
+func TestDefaultOwnerResolutionUsesTransportResolverLazily(t *testing.T) {
+	want := sdk.AccAddress([]byte("01234567890123456789")).String()
+	calls := 0
+	ctx := context.WithValue(
+		context.Background(),
+		ContextTypeDefaultOwnerResolver,
+		DefaultOwnerResolver(func(context.Context) (string, error) {
+			calls++
+			return want, nil
+		}),
+	)
+	cctx := sdkclient.Context{}.WithCmdContext(ctx)
+
+	owner, err := resolveDefaultAccountAddress(cctx)
+	require.NoError(t, err)
+	require.Equal(t, want, owner)
+	require.Equal(t, 1, calls)
+
+	owner, err = defaultOwnerForQueryArg(cctx, []string{want})
+	require.NoError(t, err)
+	require.Empty(t, owner)
+	require.Equal(t, 1, calls, "an explicit owner must bypass the transport resolver")
+
+	resolverErr := errors.New("wallet unavailable")
+	cctx = cctx.WithCmdContext(context.WithValue(
+		context.Background(),
+		ContextTypeDefaultOwnerResolver,
+		DefaultOwnerResolver(func(context.Context) (string, error) { return "", resolverErr }),
+	))
+	_, err = resolveDefaultAccountAddress(cctx)
+	require.ErrorIs(t, err, resolverErr)
 }
 
 func (k *keyLookupCounter) Key(uid string) (*sdkkeyring.Record, error) {

--- a/internal/cli/chain/tx_boundary_test.go
+++ b/internal/cli/chain/tx_boundary_test.go
@@ -141,6 +141,42 @@ func TestReadTxFlagsRejectsUnresolvedPreselectedSigner(t *testing.T) {
 	}
 }
 
+func TestReadTxFlagsResolveNamedSignerBeforeSimulation(t *testing.T) {
+	kr := aktkeyring.NewInMemory(aktcodec.MakeEncodingConfig().Codec)
+	record, _, err := kr.NewMnemonic(
+		"e2e",
+		sdkkeyring.English,
+		"m/44'/118'/0'/0/0",
+		"",
+		aktkeyring.DefaultAlgo(),
+	)
+	if err != nil {
+		t.Fatalf("create signer: %v", err)
+	}
+	want, err := record.GetAddress()
+	if err != nil {
+		t.Fatalf("signer address: %v", err)
+	}
+
+	cmd := txFlagCommand()
+	if err := cmd.Flags().Set(flagdefs.FlagDryRun, "true"); err != nil {
+		t.Fatal(err)
+	}
+	cctx := sdkclient.Context{}.
+		WithCmdContext(context.Background()).
+		WithHomeDir(t.TempDir()).
+		WithKeyring(kr).
+		WithFrom("e2e")
+
+	got, err := ReadTxCommandFlags(cctx, cmd.Flags(), io.Discard)
+	if err != nil {
+		t.Fatalf("resolve dry-run signer: %v", err)
+	}
+	if !got.Simulate || got.FromName != "e2e" || !got.GetFromAddress().Equals(want) {
+		t.Fatalf("dry-run signer = simulate:%t name:%q address:%s, want true/e2e/%s", got.Simulate, got.FromName, got.GetFromAddress(), want)
+	}
+}
+
 func TestCanonicalTransportAndAuxFlagsReachClientContext(t *testing.T) {
 	t.Run("gRPC", func(t *testing.T) {
 		cmd := &cobra.Command{Use: "query"}

--- a/internal/cli/console/apikey.go
+++ b/internal/cli/console/apikey.go
@@ -111,7 +111,7 @@ func apikeyCreateCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 func apikeyDeleteCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 	return &cobra.Command{
 		Use:     "delete <id>",
-		Short:   "Delete an API key by ID (already-absent is a no-op)",
+		Short:   "Delete an API key by ID",
 		Args:    cobra.ExactArgs(1),
 		Example: `  akt console apikey delete 0b8052e2-...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -120,7 +120,6 @@ func apikeyDeleteCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 				return err
 			}
 
-			// DeleteAPIKey treats 404 as a no-op.
 			if err := cl.DeleteAPIKey(cmd.Context(), args[0]); err != nil {
 				return fmt.Errorf("delete API key %s: %w", args[0], err)
 			}

--- a/internal/cli/console/apikey.go
+++ b/internal/cli/console/apikey.go
@@ -9,6 +9,7 @@ import (
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 
+	consoleapi "pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
 )
 
@@ -132,8 +133,9 @@ func apikeyDeleteCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 	}
 }
 
-// defaultJWTScope mirrors the Console reference CLI's default lease scopes.
-var defaultJWTScope = []string{"status", "logs", "events", "shell", "send-manifest", "get-manifest"}
+func defaultJWTScope() []string {
+	return []string{"status", "logs", "events", "shell", "send-manifest", "get-manifest"}
+}
 
 func jwtCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
@@ -154,13 +156,13 @@ func jwtCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 			}
 
 			ttl, _ := cmd.Flags().GetInt(flagdefs.FlagTTL)
-			if ttl <= 0 {
-				return fmt.Errorf("--ttl must be a positive number of seconds, got %d", ttl)
+			if ttl < 1 || ttl > consoleapi.MaxJWTTTLSeconds {
+				return fmt.Errorf("--ttl must be between 1 and %d seconds, got %d", consoleapi.MaxJWTTTLSeconds, ttl)
 			}
 
 			scopeCSV, _ := cmd.Flags().GetString(flagdefs.FlagScope)
 
-			scope := defaultJWTScope
+			scope := defaultJWTScope()
 			if scopeCSV != "" {
 				scope = nil
 				for _, s := range strings.Split(scopeCSV, ",") {
@@ -186,8 +188,8 @@ func jwtCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 		},
 	}
 
-	create.Flags().Int(flagdefs.FlagTTL, 300, "Token lifetime in seconds")
-	create.Flags().String(flagdefs.FlagScope, "", "Comma-separated scopes (default: "+strings.Join(defaultJWTScope, ",")+")")
+	create.Flags().Int(flagdefs.FlagTTL, 300, fmt.Sprintf("Token lifetime in seconds (maximum %d)", consoleapi.MaxJWTTTLSeconds))
+	create.Flags().String(flagdefs.FlagScope, "", "Comma-separated scopes (default: "+strings.Join(defaultJWTScope(), ",")+")")
 
 	cmd.AddCommand(create)
 

--- a/internal/cli/console/commands.go
+++ b/internal/cli/console/commands.go
@@ -8,9 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	flagdefs "pkg.akt.dev/akt/internal/flags"
 
@@ -281,15 +284,14 @@ func resolveContextFromCmd(cmd *cobra.Command, m *aktctx.Manager) (*aktctx.Conte
 	return m.Resolve(cliutil.SelectedContextName(cmd, m))
 }
 
-// printJSON renders v in the format --output asks for and writes it to the
-// command's output.
-//
-// It used to marshal JSON unconditionally, so `-o yaml` returned JSON with
-// exit 0 on every command in this group and a YAML consumer silently parsed
-// the wrong format. Table stays JSON: the console payloads are nested API
-// objects rather than rows, and there is no column layout to render them as.
+// printJSON preserves Console's JSON semantics for structured formats and
+// renders the same semantic tree as readable key/value sections in pretty
+// mode.
 func printJSON(cmd *cobra.Command, v interface{}) error {
 	format := output.FormatFromCmd(cmd)
+	if format == output.FormatTable {
+		return printConsolePretty(cmd, v)
+	}
 	if format != output.FormatYAML {
 		format = output.FormatJSON
 	}
@@ -299,6 +301,171 @@ func printJSON(cmd *cobra.Command, v interface{}) error {
 	}
 
 	return nil
+}
+
+func printConsolePretty(cmd *cobra.Command, value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal pretty output: %w", err)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(payload)))
+	decoder.UseNumber()
+	var semantic any
+	if err := decoder.Decode(&semantic); err != nil {
+		return fmt.Errorf("decode pretty output: %w", err)
+	}
+
+	var rendered strings.Builder
+	renderConsoleValue(&rendered, semantic, 0, "")
+	if rendered.Len() == 0 {
+		rendered.WriteString("No data.\n")
+	} else if !strings.HasSuffix(rendered.String(), "\n") {
+		rendered.WriteByte('\n')
+	}
+
+	return printConsoleText(cmd, rendered.String())
+}
+
+func renderConsoleValue(out *strings.Builder, value any, indent int, parent string) {
+	if display, ok := consoleCoinDisplay(value, parent); ok {
+		out.WriteString(display)
+		return
+	}
+
+	switch value := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			item := value[key]
+			writeConsoleIndent(out, indent)
+			out.WriteString(humanConsoleLabel(key))
+			out.WriteString(":")
+			if isConsoleScalar(item) {
+				out.WriteByte(' ')
+				renderConsoleValue(out, item, indent, key)
+				out.WriteByte('\n')
+				continue
+			}
+			if display, ok := consoleCoinDisplay(item, key); ok {
+				out.WriteByte(' ')
+				out.WriteString(display)
+				out.WriteByte('\n')
+				continue
+			}
+			out.WriteByte('\n')
+			renderConsoleValue(out, item, indent+2, key)
+		}
+	case []any:
+		if len(value) == 0 {
+			writeConsoleIndent(out, indent)
+			out.WriteString("none\n")
+			return
+		}
+		for _, item := range value {
+			writeConsoleIndent(out, indent)
+			out.WriteString("- ")
+			if isConsoleScalar(item) {
+				renderConsoleValue(out, item, indent+2, parent)
+				out.WriteByte('\n')
+				continue
+			}
+			if display, ok := consoleCoinDisplay(item, parent); ok {
+				out.WriteString(display)
+				out.WriteByte('\n')
+				continue
+			}
+			out.WriteByte('\n')
+			renderConsoleValue(out, item, indent+2, parent)
+		}
+	case nil:
+		out.WriteString("none")
+	case string:
+		if value == "" {
+			out.WriteString("none")
+		} else {
+			out.WriteString(value)
+		}
+	case json.Number:
+		out.WriteString(value.String())
+	default:
+		fmt.Fprint(out, value)
+	}
+}
+
+func consoleCoinDisplay(value any, parent string) (string, bool) {
+	coin, ok := value.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	denom, denomOK := coin["denom"].(string)
+	amountValue, amountOK := coin["amount"]
+	if !denomOK || !amountOK {
+		return "", false
+	}
+	amount := fmt.Sprint(amountValue)
+	if !strings.EqualFold(denom, "uact") {
+		return amount + " " + denom, true
+	}
+	rat, ok := new(big.Rat).SetString(amount)
+	if !ok {
+		return amount + " " + denom, true
+	}
+	rat.Quo(rat, big.NewRat(1_000_000, 1))
+	if strings.EqualFold(parent, "price") {
+		rat.Mul(rat, big.NewRat(432_000, 1))
+	}
+	usd, _ := rat.Float64()
+	display := formatUSD(usd)
+	if strings.EqualFold(parent, "price") {
+		display += "/month"
+	}
+
+	return display, true
+}
+
+func isConsoleScalar(value any) bool {
+	if _, ok := consoleCoinDisplay(value, ""); ok {
+		return true
+	}
+	switch value.(type) {
+	case nil, string, json.Number, bool, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func writeConsoleIndent(out *strings.Builder, spaces int) {
+	out.WriteString(strings.Repeat(" ", spaces))
+}
+
+func humanConsoleLabel(key string) string {
+	var label strings.Builder
+	var previous rune
+	for i, current := range key {
+		switch {
+		case current == '_' || current == '-':
+			label.WriteByte(' ')
+		case i > 0 && unicode.IsUpper(current) && unicode.IsLower(previous):
+			label.WriteByte(' ')
+			label.WriteRune(current)
+		default:
+			label.WriteRune(current)
+		}
+		previous = current
+	}
+	text := label.String()
+	if text == "" {
+		return text
+	}
+	runes := []rune(text)
+	runes[0] = unicode.ToUpper(runes[0])
+
+	return string(runes)
 }
 
 // printRawJSON re-indents a raw JSON document and writes it to the command's

--- a/internal/cli/console/commands.go
+++ b/internal/cli/console/commands.go
@@ -28,6 +28,8 @@ import (
 	"pkg.akt.dev/akt/internal/output"
 )
 
+const consoleNextAnnotation = "akt.console.next"
+
 func Commands(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "console",
@@ -67,8 +69,79 @@ func Commands(mgrFn func() *aktctx.Manager) *cobra.Command {
 		requireConsole(statusCmd(mgrFn)),
 		requireConsole(shellCmd(mgrFn)),
 	)
+	annotateConsoleNextSteps(cmd)
 
 	return cmd
+}
+
+func annotateConsoleNextSteps(cmd *cobra.Command) {
+	children := cmd.Commands()
+	if len(children) == 0 {
+		if cmd.Run != nil || cmd.RunE != nil {
+			if cmd.Annotations == nil {
+				cmd.Annotations = map[string]string{}
+			}
+			cmd.Annotations[consoleNextAnnotation] = consoleNextSuggestion(cmd)
+		}
+		return
+	}
+
+	for _, child := range children {
+		annotateConsoleNextSteps(child)
+	}
+}
+
+func consoleNextSuggestion(cmd *cobra.Command) string {
+	path := cmd.CommandPath()
+	switch {
+	case path == "console login":
+		return "akt console whoami"
+	case path == "console logout":
+		return "akt console login"
+	case path == "console whoami":
+		return "akt console deployment list active"
+	case strings.HasPrefix(path, "console deployment "),
+		strings.HasPrefix(path, "console bid "),
+		strings.HasPrefix(path, "console lease "),
+		path == "console logs",
+		path == "console events",
+		path == "console status",
+		path == "console shell":
+		return "akt console deployment list active"
+	case strings.HasPrefix(path, "console wallet "):
+		return "akt console usage"
+	case path == "console usage":
+		return "akt console wallet balance"
+	case strings.HasPrefix(path, "console apikey "):
+		return "akt console apikey list"
+	case strings.HasPrefix(path, "console jwt "):
+		return "akt console whoami"
+	case strings.HasPrefix(path, "console template "):
+		return "akt console template list"
+	case strings.HasPrefix(path, "console provider "), path == "console gpu", path == "console screen":
+		return "akt console provider list"
+	default:
+		return "akt console --help"
+	}
+}
+
+// PrintNextStep writes a successful Console leaf's follow-up guidance to the
+// informational channel. The application root calls it after closing the
+// action log; commands outside the Console subtree have no annotation and are
+// unchanged.
+func PrintNextStep(cmd *cobra.Command) error {
+	if cliutil.IsQuiet(cmd) {
+		return nil
+	}
+	next := strings.TrimSpace(cmd.Annotations[consoleNextAnnotation])
+	if next == "" {
+		return nil
+	}
+
+	checked := output.NewCheckedWriter(cmd.ErrOrStderr())
+	_, err := fmt.Fprintf(checked, "Next:\n  %s\n", next)
+
+	return checked.Complete(err)
 }
 
 // requireConsole tags a command as needing the console capability so the

--- a/internal/cli/console/commands.go
+++ b/internal/cli/console/commands.go
@@ -304,14 +304,20 @@ func printJSON(cmd *cobra.Command, v interface{}) error {
 }
 
 func printConsolePretty(cmd *cobra.Command, value any) error {
+	return printConsolePrettyWithDecoder(cmd, value, decodeConsoleSemantic)
+}
+
+func printConsolePrettyWithDecoder(
+	cmd *cobra.Command,
+	value any,
+	decode func([]byte) (any, error),
+) error {
 	payload, err := json.Marshal(value)
 	if err != nil {
 		return fmt.Errorf("marshal pretty output: %w", err)
 	}
-	decoder := json.NewDecoder(strings.NewReader(string(payload)))
-	decoder.UseNumber()
-	var semantic any
-	if err := decoder.Decode(&semantic); err != nil {
+	semantic, err := decode(payload)
+	if err != nil {
 		return fmt.Errorf("decode pretty output: %w", err)
 	}
 
@@ -324,6 +330,17 @@ func printConsolePretty(cmd *cobra.Command, value any) error {
 	}
 
 	return printConsoleText(cmd, rendered.String())
+}
+
+func decodeConsoleSemantic(payload []byte) (any, error) {
+	decoder := json.NewDecoder(strings.NewReader(string(payload)))
+	decoder.UseNumber()
+	var semantic any
+	if err := decoder.Decode(&semantic); err != nil {
+		return nil, err
+	}
+
+	return semantic, nil
 }
 
 func renderConsoleValue(out *strings.Builder, value any, indent int, parent string) {
@@ -350,12 +367,6 @@ func renderConsoleValue(out *strings.Builder, value any, indent int, parent stri
 				out.WriteByte('\n')
 				continue
 			}
-			if display, ok := consoleCoinDisplay(item, key); ok {
-				out.WriteByte(' ')
-				out.WriteString(display)
-				out.WriteByte('\n')
-				continue
-			}
 			out.WriteByte('\n')
 			renderConsoleValue(out, item, indent+2, key)
 		}
@@ -370,11 +381,6 @@ func renderConsoleValue(out *strings.Builder, value any, indent int, parent stri
 			out.WriteString("- ")
 			if isConsoleScalar(item) {
 				renderConsoleValue(out, item, indent+2, parent)
-				out.WriteByte('\n')
-				continue
-			}
-			if display, ok := consoleCoinDisplay(item, parent); ok {
-				out.WriteString(display)
 				out.WriteByte('\n')
 				continue
 			}

--- a/internal/cli/console/commands_test.go
+++ b/internal/cli/console/commands_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
+	consoleapi "pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
 	"pkg.akt.dev/akt/internal/output"
 )
@@ -54,12 +55,21 @@ func newTestManager(t *testing.T) *aktctx.Manager {
 }
 
 // execConsole runs `akt console <args...>` against the given manager,
-// pointing the client at srvURL when non-empty, and returns combined output.
+// pointing the client at srvURL when non-empty, and returns stdout.
 func execConsole(t *testing.T, m *aktctx.Manager, srvURL string, args ...string) (string, error) {
 	return execConsoleContext(context.Background(), t, m, srvURL, args...)
 }
 
 func execConsoleContext(ctx context.Context, t *testing.T, m *aktctx.Manager, srvURL string, args ...string) (string, error) {
+	stdout, stderr, err := execConsoleContextStreams(ctx, t, m, srvURL, args...)
+	if err != nil {
+		return stdout + stderr, err
+	}
+
+	return stdout, err
+}
+
+func execConsoleContextStreams(ctx context.Context, t *testing.T, m *aktctx.Manager, srvURL string, args ...string) (string, string, error) {
 	t.Helper()
 
 	// Neutralize any ambient key so tests only see what they configure.
@@ -70,9 +80,9 @@ func execConsoleContext(ctx context.Context, t *testing.T, m *aktctx.Manager, sr
 	cmd.PersistentFlags().String(flagdefs.FlagContext, "", "Active context name")
 	cmd.SetContext(ctx)
 
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
 
 	prefix := make([]string, 0, 4)
 	if srvURL != "" {
@@ -93,7 +103,7 @@ func execConsoleContext(ctx context.Context, t *testing.T, m *aktctx.Manager, sr
 
 	err := cmd.Execute()
 
-	return buf.String(), err
+	return stdout.String(), stderr.String(), err
 }
 
 func decodeStructuredOutput(t *testing.T, format, raw string) any {
@@ -135,6 +145,124 @@ func decodeStructuredMap(t *testing.T, format, raw string) map[string]any {
 	}
 
 	return object
+}
+
+func TestEveryConsoleActionDeclaresNextStep(t *testing.T) {
+	const annotation = "akt.console.next"
+	root := Commands(func() *aktctx.Manager { return nil })
+
+	var missing []string
+	var walk func(*cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		children := cmd.Commands()
+		if len(children) == 0 {
+			if (cmd.RunE != nil || cmd.Run != nil) && strings.TrimSpace(cmd.Annotations[annotation]) == "" {
+				missing = append(missing, cmd.CommandPath())
+			}
+			return
+		}
+		for _, child := range children {
+			walk(child)
+		}
+	}
+	walk(root)
+
+	if len(missing) != 0 {
+		t.Fatalf("Console action leaves without next-step guidance: %s", strings.Join(missing, ", "))
+	}
+}
+
+func TestConsoleNextSuggestionHasSafeFallback(t *testing.T) {
+	if got := consoleNextSuggestion(&cobra.Command{Use: "future-action"}); got != "akt console --help" {
+		t.Fatalf("fallback next step = %q", got)
+	}
+}
+
+func TestConsoleNextStepUsesInformationalChannel(t *testing.T) {
+	m := newTestManager(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/user/me" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		writeJSON(t, w, `{"data":{"username":"alice"}}`)
+	}))
+	defer srv.Close()
+
+	run := func(quiet bool) (string, string, error) {
+		cmd := Commands(func() *aktctx.Manager { return m })
+		cmd.PersistentPostRunE = func(executed *cobra.Command, _ []string) error {
+			return PrintNextStep(executed)
+		}
+		cmd.PersistentFlags().VarP(output.NewFormatFlag("pretty"), flagdefs.FlagOutput, "o", "Output format: pretty, json, yaml")
+		cmd.PersistentFlags().Bool(flagdefs.FlagQuiet, false, "Suppress informational output")
+		var stdout, stderr bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		args := []string{"--console-api-url", srv.URL, "--output", "json"}
+		if quiet {
+			args = append(args, "--quiet")
+		}
+		args = append(args, "login", "sekrit")
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		return stdout.String(), stderr.String(), err
+	}
+
+	stdout, stderr, err := run(false)
+	if err != nil {
+		t.Fatalf("console login: %v", err)
+	}
+	if !json.Valid([]byte(stdout)) {
+		t.Fatalf("structured stdout was contaminated: %q", stdout)
+	}
+	if !strings.Contains(stderr, "Next:\n") || !strings.Contains(stderr, "akt console whoami") {
+		t.Fatalf("next-step stderr = %q", stderr)
+	}
+
+	_, stderr, err = run(true)
+	if err != nil {
+		t.Fatalf("quiet console login: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("quiet console login stderr = %q, want empty", stderr)
+	}
+}
+
+func TestConsoleTreeLeavesPostRunOwnershipToAncestor(t *testing.T) {
+	previous := cobra.EnableTraverseRunHooks
+	cobra.EnableTraverseRunHooks = true
+	t.Cleanup(func() { cobra.EnableTraverseRunHooks = previous })
+
+	m := newTestManager(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/user/me" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		writeJSON(t, w, `{"data":{"username":"alice"}}`)
+	}))
+	defer srv.Close()
+
+	ancestorRuns := 0
+	root := &cobra.Command{
+		Use: "akt",
+		PersistentPostRunE: func(executed *cobra.Command, _ []string) error {
+			ancestorRuns++
+			return PrintNextStep(executed)
+		},
+	}
+	root.PersistentFlags().VarP(output.NewFormatFlag("pretty"), flagdefs.FlagOutput, "o", "Output format")
+	root.PersistentFlags().Bool(flagdefs.FlagQuiet, false, "Suppress informational output")
+	root.AddCommand(Commands(func() *aktctx.Manager { return m }))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"console", "--console-api-url", srv.URL, "login", "sekrit"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("console login: %v", err)
+	}
+	if ancestorRuns != 1 {
+		t.Fatalf("ancestor persistent post-run calls = %d, want 1", ancestorRuns)
+	}
 }
 
 func writeJSON(t *testing.T, w http.ResponseWriter, body string) {
@@ -578,7 +706,7 @@ func TestDeploymentGetYAMLPreservesJSONSemantics(t *testing.T) {
 	}
 }
 
-func TestDeploymentCloseAlreadyClosedExitsClean(t *testing.T) {
+func TestDeploymentCloseAlreadyClosedExitsNonZero(t *testing.T) {
 	m := newTestManager(t)
 	if err := aktctx.SetConsoleAPIKey(m.Root(), "prod", "sekrit"); err != nil {
 		t.Fatalf("SetConsoleAPIKey: %v", err)
@@ -586,20 +714,19 @@ func TestDeploymentCloseAlreadyClosedExitsClean(t *testing.T) {
 
 	// The Console API answers 404 for an already-closed deployment.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/v1/deployments/42" {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/deployments/42" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
 
-	out, err := execConsole(t, m, srv.URL, "--output", "pretty", "deployment", "close", "42")
-	if err != nil {
-		t.Fatalf("close of an already-closed deployment must succeed, got %v", err)
+	stdout, _, err := execConsoleContextStreams(context.Background(), t, m, srv.URL, "--output", "pretty", "deployment", "close", "42")
+	if !errors.Is(err, consoleapi.ErrAlreadyClosed) {
+		t.Fatalf("close of an already-closed deployment error = %v, want ErrAlreadyClosed", err)
 	}
-
-	if !strings.Contains(out, "already closed") {
-		t.Errorf("output should report the no-op, got %q", out)
+	if strings.Contains(stdout, "Deployment 42 closed") || strings.Contains(stdout, `"state":"closed"`) {
+		t.Errorf("already-closed close emitted a success acknowledgement %q", stdout)
 	}
 }
 
@@ -673,10 +800,14 @@ func TestPlainConsoleCommandsPropagateOutputFailures(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests[r.Method+" "+r.URL.Path]++
 		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/api-keys":
+			writeJSON(t, w, `{"data":[{"id":"11111111-1111-1111-1111-111111111111","name":"ci"}]}`)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/api-keys/11111111-1111-1111-1111-111111111111":
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/777":
+			writeJSON(t, w, `{"data":{"deployment":{"id":{"dseq":"777"},"state":"active"}}}`)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/deployments/777":
-			w.WriteHeader(http.StatusNotFound)
+			writeJSON(t, w, `{"data":{"success":true}}`)
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/templates/tpl-1":
 			writeJSON(t, w, `{"data":{"id":"tpl-1","name":"web","deploy":"services: {}\\n"}}`)
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/bids"):
@@ -705,7 +836,7 @@ func TestPlainConsoleCommandsPropagateOutputFailures(t *testing.T) {
 		{name: "raw template SDL", args: []string{"template", "sdl", "tpl-1"}},
 		{name: "empty bid result", args: []string{"bid", "list", "12345"}},
 		{name: "empty bid screening result", args: []string{"screen", sdlPath}},
-		{name: "already closed deployment result", args: []string{"deployment", "close", "777"}},
+		{name: "deployment close result", args: []string{"deployment", "close", "777"}},
 	}
 
 	failures := []struct {

--- a/internal/cli/console/commands_test.go
+++ b/internal/cli/console/commands_test.go
@@ -74,9 +74,21 @@ func execConsoleContext(ctx context.Context, t *testing.T, m *aktctx.Manager, sr
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
 
+	prefix := make([]string, 0, 4)
 	if srvURL != "" {
-		args = append(args, "--console-api-url", srvURL)
+		prefix = append(prefix, "--console-api-url", srvURL)
 	}
+	hasOutput := false
+	for _, arg := range args {
+		if arg == "--output" || arg == "-o" || strings.HasPrefix(arg, "--output=") {
+			hasOutput = true
+			break
+		}
+	}
+	if !hasOutput {
+		prefix = append(prefix, "--output", "json")
+	}
+	args = append(prefix, args...)
 	cmd.SetArgs(args)
 
 	err := cmd.Execute()
@@ -293,7 +305,7 @@ func executeConsoleWithOutput(
 	cmd.SetOut(out)
 	cmd.SetErr(io.Discard)
 	if srvURL != "" {
-		args = append(args, "--console-api-url", srvURL)
+		args = append([]string{"--console-api-url", srvURL}, args...)
 	}
 	cmd.SetArgs(args)
 
@@ -581,7 +593,7 @@ func TestDeploymentCloseAlreadyClosedExitsClean(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	out, err := execConsole(t, m, srv.URL, "deployment", "close", "42")
+	out, err := execConsole(t, m, srv.URL, "--output", "pretty", "deployment", "close", "42")
 	if err != nil {
 		t.Fatalf("close of an already-closed deployment must succeed, got %v", err)
 	}
@@ -629,7 +641,7 @@ func TestTemplateSDLPrintsRawSDL(t *testing.T) {
 	defer srv.Close()
 
 	// Public endpoint: no key configured anywhere.
-	out, err := execConsole(t, m, srv.URL, "template", "sdl", "tpl-1")
+	out, err := execConsole(t, m, srv.URL, "--output", "pretty", "template", "sdl", "tpl-1")
 	if err != nil {
 		t.Fatalf("template sdl: %v", err)
 	}
@@ -661,7 +673,7 @@ func TestPlainConsoleCommandsPropagateOutputFailures(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests[r.Method+" "+r.URL.Path]++
 		switch {
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/api-keys/key-1":
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/api-keys/11111111-1111-1111-1111-111111111111":
 			w.WriteHeader(http.StatusNotFound)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/deployments/777":
 			w.WriteHeader(http.StatusNotFound)
@@ -689,7 +701,7 @@ func TestPlainConsoleCommandsPropagateOutputFailures(t *testing.T) {
 		name string
 		args []string
 	}{
-		{name: "API key delete result", args: []string{"apikey", "delete", "key-1"}},
+		{name: "API key delete result", args: []string{"apikey", "delete", "11111111-1111-1111-1111-111111111111"}},
 		{name: "raw template SDL", args: []string{"template", "sdl", "tpl-1"}},
 		{name: "empty bid result", args: []string{"bid", "list", "12345"}},
 		{name: "empty bid screening result", args: []string{"screen", sdlPath}},
@@ -719,7 +731,7 @@ func TestPlainConsoleCommandsPropagateOutputFailures(t *testing.T) {
 	}
 
 	for _, request := range []string{
-		http.MethodDelete + " /v1/api-keys/key-1",
+		http.MethodDelete + " /v1/api-keys/11111111-1111-1111-1111-111111111111",
 		http.MethodDelete + " /v1/deployments/777",
 	} {
 		if requests[request] != len(failures) {
@@ -754,8 +766,8 @@ func TestJWTCreatePrintsToken(t *testing.T) {
 		if body.Data.TTL != 300 {
 			t.Errorf("default ttl = %d, want 300", body.Data.TTL)
 		}
-		if len(body.Data.Leases.Scope) != len(defaultJWTScope) {
-			t.Errorf("default scope = %v, want %v", body.Data.Leases.Scope, defaultJWTScope)
+		if len(body.Data.Leases.Scope) != len(defaultJWTScope()) {
+			t.Errorf("default scope = %v, want %v", body.Data.Leases.Scope, defaultJWTScope())
 		}
 
 		writeJSON(t, w, `{"data":{"token":"tok-abc123"}}`)

--- a/internal/cli/console/deployment.go
+++ b/internal/cli/console/deployment.go
@@ -162,6 +162,13 @@ func deploymentGetCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 }
 
 func deploymentCreateCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
+	return deploymentCreateCmdWithTerminal(mgrFn, term.IsTerminal)
+}
+
+func deploymentCreateCmdWithTerminal(
+	mgrFn func() *aktctx.Manager,
+	isTerminal func(int) bool,
+) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <sdl-file> [deposit-usd]",
 		Short: "Create a deployment (managed wallet signs server-side)",
@@ -195,7 +202,7 @@ func deploymentCreateCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			}
 			skipConfirmation, _ := cmd.Flags().GetBool(flagdefs.FlagSkipConfirmation)
 			if err := confirmDeploymentCreate(cmd,
-				!skipConfirmation && term.IsTerminal(int(os.Stdin.Fd())), args[0], deposit); err != nil {
+				!skipConfirmation && isTerminal(int(os.Stdin.Fd())), args[0], deposit); err != nil {
 				return err
 			}
 

--- a/internal/cli/console/deployment.go
+++ b/internal/cli/console/deployment.go
@@ -1,18 +1,21 @@
 package console
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	flagdefs "pkg.akt.dev/akt/internal/flags"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"pkg.akt.dev/akt/internal/cliutil"
 	"pkg.akt.dev/akt/internal/console"
@@ -43,6 +46,34 @@ func parseConsoleUSD(arg string) (float64, error) {
 	return dep.USD, nil
 }
 
+func confirmDeploymentCreate(cmd *cobra.Command, prompt bool, path string, deposit float64) error {
+	if !prompt {
+		return nil
+	}
+	if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Create deployment from %s with a %s deposit? [y/N] ", path, formatUSD(deposit)); err != nil {
+		return err
+	}
+	answer, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && strings.TrimSpace(answer) == "" {
+		return fmt.Errorf("read deployment confirmation: %w", err)
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("deployment creation cancelled")
+	}
+
+	return nil
+}
+
+func addNegativePositionalHint(cmd *cobra.Command, positional string) {
+	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		if strings.Contains(err.Error(), "unknown shorthand flag") {
+			return fmt.Errorf("%w; if %s begins with '-', place `--` before the positional value", err, positional)
+		}
+		return err
+	})
+}
+
 func deploymentCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deployment",
@@ -67,11 +98,19 @@ func deploymentCmds(mgrFn func() *aktctx.Manager) *cobra.Command {
 
 func deploymentListCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "list",
+		Use:     "list [active|closed]",
 		Short:   "List deployments",
-		Args:    cobra.NoArgs,
-		Example: `  akt console deployment list --limit 10`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args:    cobra.MaximumNArgs(1),
+		Example: `  akt console deployment list active --limit 10`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			state := ""
+			if len(args) == 1 {
+				state = strings.ToLower(strings.TrimSpace(args[0]))
+				if state != "active" && state != "closed" {
+					return fmt.Errorf("deployment state must be active or closed, got %q", args[0])
+				}
+			}
+
 			cl, _, err := clientFromCmd(cmd, mgrFn, true)
 			if err != nil {
 				return err
@@ -80,7 +119,12 @@ func deploymentListCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			skip, _ := cmd.Flags().GetInt(flagdefs.FlagSkip)
 			limit, _ := cmd.Flags().GetInt(flagdefs.FlagLimit)
 
-			list, err := cl.ListDeployments(cmd.Context(), skip, limit)
+			var list *console.DeploymentList
+			if state == "" {
+				list, err = cl.ListDeployments(cmd.Context(), skip, limit)
+			} else {
+				list, err = cl.ListDeploymentsByState(cmd.Context(), state, skip, limit)
+			}
 			if err != nil {
 				return fmt.Errorf("list deployments: %w", err)
 			}
@@ -148,6 +192,11 @@ func deploymentCreateCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			// NOTE: internal/workflow/adapters/console.go carries a private
 			if deposit < transport.MinConsoleDepositUSD {
 				return fmt.Errorf("deposit must be at least %s (got %s): pass it as the [deposit-usd] argument", formatUSD(transport.MinConsoleDepositUSD), formatUSD(deposit))
+			}
+			skipConfirmation, _ := cmd.Flags().GetBool(flagdefs.FlagSkipConfirmation)
+			if err := confirmDeploymentCreate(cmd,
+				!skipConfirmation && term.IsTerminal(int(os.Stdin.Fd())), args[0], deposit); err != nil {
+				return err
 			}
 
 			sdl, err := os.ReadFile(args[0])
@@ -217,6 +266,8 @@ func deploymentCreateCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 	// (use the positional form instead). Restore by uncommenting if users
 	// ask for the flag form back.
 	// cmd.Flags().Float64("deposit", 0, "Deposit amount in USD (minimum 0.5); alternative to the positional argument")
+	cmd.Flags().BoolP(flagdefs.FlagSkipConfirmation, "y", false, "Skip the deployment creation confirmation")
+	addNegativePositionalHint(cmd, "deposit-usd")
 
 	return cmd
 }
@@ -345,8 +396,8 @@ func deploymentDepositCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 					return err
 				}
 			}
-			if amount <= 0 {
-				return fmt.Errorf("amount must be a positive USD amount (got %s): pass it as the [amount-usd] argument", formatUSD(amount))
+			if amount < transport.MinConsoleDepositUSD {
+				return fmt.Errorf("amount must be at least %s (got %s): pass it as the [amount-usd] argument", formatUSD(transport.MinConsoleDepositUSD), formatUSD(amount))
 			}
 
 			if err := cl.Deposit(cmd.Context(), args[0], amount); err != nil {
@@ -368,6 +419,7 @@ func deploymentDepositCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 	// (use the positional form instead). Restore by uncommenting if users
 	// ask for the flag form back.
 	// cmd.Flags().Float64("amount", 0, "Amount to add in USD; alternative to the positional argument")
+	addNegativePositionalHint(cmd, "amount-usd")
 
 	return cmd
 }
@@ -415,10 +467,6 @@ func deploymentSettingsCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			// enabled on deployments that do not exist and on deployments
 			// belonging to other accounts. Resolve the deployment first, which
 			// is the 404 the sibling `deployment get` already returns.
-			if _, err := cl.GetDeployment(cmd.Context(), args[0]); err != nil {
-				return fmt.Errorf("deployment %s: %w", args[0], err)
-			}
-
 			if len(args) > 1 {
 				settings, err := cl.SetDeploymentAutoTopUp(cmd.Context(), args[0], enabled)
 				if err != nil {
@@ -426,6 +474,10 @@ func deploymentSettingsCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 				}
 
 				return printJSON(cmd, renderSettings(settings))
+			}
+
+			if _, err := cl.GetDeployment(cmd.Context(), args[0]); err != nil {
+				return fmt.Errorf("deployment %s: %w", args[0], err)
 			}
 
 			settings, err := cl.GetDeploymentSettings(cmd.Context(), args[0])

--- a/internal/cli/console/deployment.go
+++ b/internal/cli/console/deployment.go
@@ -309,7 +309,7 @@ func deploymentUpdateCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 func deploymentCloseCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 	return &cobra.Command{
 		Use:     "close <dseq>",
-		Short:   "Close a deployment (idempotent: already-closed is a no-op)",
+		Short:   "Close an active deployment",
 		Args:    cobra.ExactArgs(1),
 		Example: `  akt console deployment close 12345`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -319,15 +319,12 @@ func deploymentCloseCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			}
 
 			err = cl.CloseDeployment(cmd.Context(), args[0])
-			alreadyClosed := false
-			pretty := fmt.Sprintf("Deployment %s closed.", args[0])
-			switch {
-			case err == nil:
-			case errors.Is(err, console.ErrAlreadyClosed):
-				alreadyClosed = true
-				pretty = fmt.Sprintf("Deployment %s already closed.", args[0])
-
-			default:
+			if err != nil {
+				if errors.Is(err, console.ErrAlreadyClosed) {
+					if convergeErr := convergeClosedDeployment(cmd, rc, args[0]); convergeErr != nil && !cliutil.IsQuiet(cmd) {
+						fmt.Fprintf(cmd.ErrOrStderr(), "warning: the local store was not updated: %v\n", convergeErr)
+					}
+				}
 				return fmt.Errorf("close deployment %s: %w", args[0], err)
 			}
 
@@ -335,11 +332,10 @@ func deploymentCloseCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 				fmt.Fprintf(cmd.ErrOrStderr(), "warning: the local store was not updated: %v\n", err)
 			}
 
-			return printConsoleResult(cmd, pretty, struct {
-				DSeq          string `json:"dseq"`
-				State         string `json:"state"`
-				AlreadyClosed bool   `json:"already_closed"`
-			}{args[0], "closed", alreadyClosed})
+			return printConsoleResult(cmd, fmt.Sprintf("Deployment %s closed.", args[0]), struct {
+				DSeq  string `json:"dseq"`
+				State string `json:"state"`
+			}{args[0], "closed"})
 		},
 	}
 }

--- a/internal/cli/console/deployment_test.go
+++ b/internal/cli/console/deployment_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	aktctx "pkg.akt.dev/akt/internal/context"
+	flagdefs "pkg.akt.dev/akt/internal/flags"
 	sstore "pkg.akt.dev/akt/internal/store"
 	"pkg.akt.dev/akt/internal/store/bbolt"
 )
@@ -34,6 +35,96 @@ func TestConfirmDeploymentCreateDefaultsToNo(t *testing.T) {
 	cmd.SetIn(strings.NewReader("yes\n"))
 	require.NoError(t, confirmDeploymentCreate(cmd, true, "deploy.yaml", 5))
 	require.NoError(t, confirmDeploymentCreate(cmd, false, "deploy.yaml", 5))
+}
+
+func TestConfirmDeploymentCreateReportsPromptAndReadFailures(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetErr(consoleOutputErrorWriter{err: assert.AnError})
+	cmd.SetIn(strings.NewReader("yes\n"))
+	require.ErrorIs(t, confirmDeploymentCreate(cmd, true, "deploy.yaml", 5), assert.AnError)
+
+	cmd.SetErr(io.Discard)
+	cmd.SetIn(strings.NewReader(""))
+	require.ErrorContains(t, confirmDeploymentCreate(cmd, true, "deploy.yaml", 5), "read deployment confirmation")
+}
+
+func TestDeploymentCreateReturnsInteractiveCancellation(t *testing.T) {
+	cmd := deploymentCreateCmdWithTerminal(func() *aktctx.Manager { return nil }, func(int) bool { return true })
+	cmd.Flags().String(flagdefs.FlagConsoleAPIKey, "sekrit", "")
+	cmd.SetIn(strings.NewReader("no\n"))
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"deploy.yaml", "5"})
+
+	require.ErrorContains(t, cmd.Execute(), "deployment creation cancelled")
+}
+
+func TestNegativePositionalHintCoversMatchingAndOrdinaryFlagErrors(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "negative shorthand", arg: "-1", want: "place `--` before"},
+		{name: "ordinary flag", arg: "--unknown", want: "unknown flag"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "deposit [amount]", RunE: func(*cobra.Command, []string) error { return nil }}
+			addNegativePositionalHint(cmd, "amount")
+			cmd.SetArgs([]string{test.arg})
+			_, err := cmd.ExecuteC()
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestDeploymentListStateCommandValidationAndFiltering(t *testing.T) {
+	m := newAuthedManager(t)
+	if _, err := execConsole(t, m, "", "deployment", "list", "pending"); err == nil {
+		t.Fatal("invalid deployment state did not fail")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"data":{"deployments":[{"deployment":{"id":{"dseq":"42"},"state":"active"}}],"pagination":{"hasMore":false}}}`)
+	}))
+	defer srv.Close()
+
+	out, err := execConsole(t, m, srv.URL, "deployment", "list", "active", "--limit", "1")
+	require.NoError(t, err)
+	assert.Contains(t, out, "42")
+}
+
+func TestDeploymentSettingsReadPreflightsDeployment(t *testing.T) {
+	m := newAuthedManager(t)
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/v1/deployments/42":
+			writeJSON(t, w, `{"data":{"deployment":{"id":{"dseq":"42"},"state":"active"}}}`)
+		case "/v2/deployment-settings/42":
+			writeJSON(t, w, `{"data":{"dseq":"42","autoTopUpEnabled":true}}`)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := execConsole(t, m, srv.URL, "deployment", "settings", "42")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/v1/deployments/42", "/v2/deployment-settings/42"}, paths)
+}
+
+func TestDeploymentSettingsReadReturnsDeploymentPreflightFailure(t *testing.T) {
+	m := newAuthedManager(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/deployments/404", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := execConsole(t, m, srv.URL, "deployment", "settings", "404")
+	require.ErrorContains(t, err, "deployment 404")
 }
 
 const validConsoleDeploymentSDL = `version: "2.0"

--- a/internal/cli/console/deployment_test.go
+++ b/internal/cli/console/deployment_test.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -12,10 +13,28 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	aktctx "pkg.akt.dev/akt/internal/context"
 	sstore "pkg.akt.dev/akt/internal/store"
 	"pkg.akt.dev/akt/internal/store/bbolt"
 )
+
+func TestConfirmDeploymentCreateDefaultsToNo(t *testing.T) {
+	cmd := &cobra.Command{}
+	var diagnostics bytes.Buffer
+	cmd.SetErr(&diagnostics)
+
+	cmd.SetIn(strings.NewReader("\n"))
+	require.ErrorContains(t, confirmDeploymentCreate(cmd, true, "deploy.yaml", 5), "cancelled")
+	assert.Contains(t, diagnostics.String(), "Create deployment")
+
+	cmd.SetIn(strings.NewReader("yes\n"))
+	require.NoError(t, confirmDeploymentCreate(cmd, true, "deploy.yaml", 5))
+	require.NoError(t, confirmDeploymentCreate(cmd, false, "deploy.yaml", 5))
+}
 
 const validConsoleDeploymentSDL = `version: "2.0"
 services:
@@ -408,9 +427,9 @@ func TestDeploymentCloseDoesNotGuessBetweenLocalOwners(t *testing.T) {
 	}
 }
 
-// TestDeploymentListZeroFlagValues pins that legitimately-zero flag values
-// are not mis-reported as errors: --skip 0 is forwarded and --limit 0 falls
-// back to the server default page size (the API requires limit >= 1).
+// TestDeploymentListZeroFlagValues pins that skip may be zero but the API's
+// one-based page size may not. Both are rejected before a malformed request
+// can reach Console.
 func TestDeploymentListZeroFlagValues(t *testing.T) {
 	m := newTestManager(t)
 	if err := aktctx.SetConsoleAPIKey(m.Root(), "prod", "sekrit"); err != nil {
@@ -424,15 +443,12 @@ func TestDeploymentListZeroFlagValues(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := execConsole(t, m, srv.URL, "deployment", "list", "--skip", "0", "--limit", "0"); err != nil {
-		t.Fatalf("deployment list with zero flag values must succeed, got %v", err)
+	if _, err := execConsole(t, m, srv.URL, "deployment", "list", "--skip", "0", "--limit", "0"); err == nil {
+		t.Fatal("deployment list with a zero limit must fail")
 	}
 
-	if gotQuery.Get("skip") != "0" {
-		t.Errorf("skip=0 must be forwarded, got query %v", gotQuery)
-	}
-	if _, present := gotQuery["limit"]; present {
-		t.Errorf("limit=0 must be omitted so the server default applies, got query %v", gotQuery)
+	if gotQuery != nil {
+		t.Errorf("invalid pagination reached Console with query %v", gotQuery)
 	}
 }
 

--- a/internal/cli/console/deployment_test.go
+++ b/internal/cli/console/deployment_test.go
@@ -3,6 +3,8 @@ package console
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	consoleapi "pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
 	flagdefs "pkg.akt.dev/akt/internal/flags"
 	sstore "pkg.akt.dev/akt/internal/store"
@@ -341,50 +344,42 @@ func TestDeploymentDepositStructuredAcknowledgement(t *testing.T) {
 }
 
 func TestDeploymentCloseStructuredAcknowledgement(t *testing.T) {
-	for _, tc := range []struct {
-		name          string
-		status        int
-		alreadyClosed bool
-	}{
-		{name: "closed", status: http.StatusOK},
-		{name: "already closed", status: http.StatusNotFound, alreadyClosed: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			m := newTestManager(t)
-			if err := aktctx.SetConsoleAPIKey(m.Root(), "prod", "sekrit"); err != nil {
-				t.Fatalf("SetConsoleAPIKey: %v", err)
+	m := newTestManager(t)
+	if err := aktctx.SetConsoleAPIKey(m.Root(), "prod", "sekrit"); err != nil {
+		t.Fatalf("SetConsoleAPIKey: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/deployments/42" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Method == http.MethodGet {
+			writeJSON(t, w, `{"data":{"deployment":{"id":{"dseq":"42"},"state":"active"}}}`)
+			return
+		}
+		if r.Method != http.MethodDelete {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		writeJSON(t, w, `{"data":{"success":true}}`)
+	}))
+	defer srv.Close()
+
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			out, err := execConsole(t, m, srv.URL, "deployment", "close", "42", "-o", format)
+			if err != nil {
+				t.Fatalf("close -o %s: %v", format, err)
 			}
 
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodDelete || r.URL.Path != "/v1/deployments/42" {
-					t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
-				}
-				if tc.status == http.StatusOK {
-					writeJSON(t, w, `{"data":{"success":true}}`)
-					return
-				}
-				w.WriteHeader(tc.status)
-			}))
-			defer srv.Close()
-
-			for _, format := range []string{"json", "yaml"} {
-				t.Run(format, func(t *testing.T) {
-					out, err := execConsole(t, m, srv.URL, "deployment", "close", "42", "-o", format)
-					if err != nil {
-						t.Fatalf("close -o %s: %v", format, err)
-					}
-
-					got := decodeStructuredMap(t, format, out)
-					if got["dseq"] != "42" || got["state"] != "closed" || got["already_closed"] != tc.alreadyClosed {
-						t.Errorf("close acknowledgement = %#v, want dseq=42 state=closed already_closed=%v", got, tc.alreadyClosed)
-					}
-				})
+			got := decodeStructuredMap(t, format, out)
+			if len(got) != 2 || got["dseq"] != "42" || got["state"] != "closed" {
+				t.Errorf("close acknowledgement = %#v, want dseq=42 state=closed", got)
 			}
 		})
 	}
 }
 
-func TestDeploymentCloseRepeatedSuccessDoesNotInventPriorState(t *testing.T) {
+func TestDeploymentCloseRepeatedAttemptFailsWithoutSecondDelete(t *testing.T) {
 	m := newTestManager(t)
 	if err := aktctx.SetConsoleAPIKey(m.Root(), "prod", "sekrit"); err != nil {
 		t.Fatalf("SetConsoleAPIKey: %v", err)
@@ -392,29 +387,36 @@ func TestDeploymentCloseRepeatedSuccessDoesNotInventPriorState(t *testing.T) {
 
 	var deletes atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/v1/deployments/42" {
+		if r.URL.Path != "/v1/deployments/42" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Method == http.MethodGet {
+			state := "active"
+			if deletes.Load() > 0 {
+				state = "closed"
+			}
+			fmt.Fprintf(w, `{"data":{"deployment":{"id":{"dseq":"42"},"state":%q}}}`, state)
+			return
 		}
 		deletes.Add(1)
 		writeJSON(t, w, `{"data":{"success":true}}`)
 	}))
 	defer srv.Close()
 
-	for attempt := 1; attempt <= 2; attempt++ {
-		out, err := execConsole(t, m, srv.URL, "deployment", "close", "42", "-o", "json")
-		if err != nil {
-			t.Fatalf("close attempt %d: %v", attempt, err)
-		}
-
-		got := decodeStructuredMap(t, "json", out)
-		alreadyClosed, isBool := got["already_closed"].(bool)
-		if len(got) != 3 || got["dseq"] != "42" || got["state"] != "closed" || !isBool || alreadyClosed {
-			t.Errorf("close attempt %d acknowledgement = %#v, want dseq=42 state=closed already_closed=false", attempt, got)
-		}
+	out, err := execConsole(t, m, srv.URL, "deployment", "close", "42", "-o", "json")
+	if err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	got := decodeStructuredMap(t, "json", out)
+	if len(got) != 2 || got["dseq"] != "42" || got["state"] != "closed" {
+		t.Errorf("first close acknowledgement = %#v", got)
+	}
+	if _, err := execConsole(t, m, srv.URL, "deployment", "close", "42", "-o", "json"); !errors.Is(err, consoleapi.ErrAlreadyClosed) {
+		t.Fatalf("second close = %v, want ErrAlreadyClosed", err)
 	}
 
-	if got := deletes.Load(); got != 2 {
-		t.Fatalf("DELETE requests = %d, want 2", got)
+	if got := deletes.Load(); got != 1 {
+		t.Fatalf("DELETE requests = %d, want 1", got)
 	}
 }
 
@@ -442,6 +444,10 @@ func TestDeploymentCloseConvergesUniqueLocalDeploymentAndLeases(t *testing.T) {
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/42" {
+			writeJSON(t, w, `{"data":{"deployment":{"id":{"dseq":"42"},"state":"active"}}}`)
+			return
+		}
 		if r.Method != http.MethodDelete || r.URL.Path != "/v1/deployments/42" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -492,17 +498,21 @@ func TestDeploymentCloseDoesNotGuessBetweenLocalOwners(t *testing.T) {
 		t.Fatalf("close seed store: %v", err)
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			writeJSON(t, w, `{"data":{"deployment":{"id":{"dseq":"42"},"state":"active"}}}`)
+			return
+		}
 		writeJSON(t, w, `{"data":{"success":true}}`)
 	}))
 	defer srv.Close()
 
-	out, err := execConsole(t, m, srv.URL, "deployment", "close", "42")
+	_, stderr, err := execConsoleContextStreams(context.Background(), t, m, srv.URL, "deployment", "close", "42")
 	if err != nil {
 		t.Fatalf("deployment close: %v", err)
 	}
-	if !strings.Contains(out, "multiple local owners") {
-		t.Errorf("ambiguous local close did not warn:\n%s", out)
+	if !strings.Contains(stderr, "multiple local owners") {
+		t.Errorf("ambiguous local close did not warn:\n%s", stderr)
 	}
 
 	s, err = bbolt.OpenContext(ctx, m.Root(), "prod")
@@ -515,6 +525,46 @@ func TestDeploymentCloseDoesNotGuessBetweenLocalOwners(t *testing.T) {
 		if getErr != nil || dep == nil || dep.State != "active" {
 			t.Fatalf("ambiguous close changed %s: %+v, err %v", owner, dep, getErr)
 		}
+	}
+}
+
+func TestDeploymentCloseAlreadyClosedWarnsWhenLocalStateIsAmbiguous(t *testing.T) {
+	m := newTestManager(t)
+	if err := aktctx.SetConsoleAPIKey(m.Root(), "prod", "sekrit"); err != nil {
+		t.Fatalf("SetConsoleAPIKey: %v", err)
+	}
+
+	ctx := context.Background()
+	s, err := bbolt.OpenContext(ctx, m.Root(), "prod")
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	for _, owner := range []string{
+		"akash1zn43lmk4dmvcjmfhtaqk4wa9zpuru3xy0kzupu",
+		"akash1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5jepelx",
+	} {
+		if err := s.PutDeployment(ctx, &sstore.DeploymentRecord{Owner: owner, DSeq: 42, State: "active"}); err != nil {
+			t.Fatalf("PutDeployment: %v", err)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seed store: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/deployments/42" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, stderr, err := execConsoleContextStreams(ctx, t, m, srv.URL, "deployment", "close", "42")
+	if !errors.Is(err, consoleapi.ErrAlreadyClosed) {
+		t.Fatalf("deployment close error = %v, want ErrAlreadyClosed", err)
+	}
+	if !strings.Contains(stderr, "multiple local owners") {
+		t.Fatalf("already-closed local convergence warning = %q", stderr)
 	}
 }
 

--- a/internal/cli/console/deployment_update_semantic_test.go
+++ b/internal/cli/console/deployment_update_semantic_test.go
@@ -38,8 +38,15 @@ func TestDeploymentUpdateUsesExactSDLAndReturnsUpdatedIdentity(t *testing.T) {
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
-		if r.Method != http.MethodPut || r.URL.EscapedPath() != "/v1/deployments/555" {
-			t.Errorf("request = %s %s, want PUT /v1/deployments/555", r.Method, r.URL.EscapedPath())
+		if r.URL.EscapedPath() != "/v1/deployments/555" {
+			t.Errorf("request path = %s, want /v1/deployments/555", r.URL.EscapedPath())
+		}
+		if r.Method == http.MethodGet {
+			writeJSON(t, w, `{"data":{"deployment":{"id":{"owner":"akash1owner","dseq":"555"},"state":"active"},"leases":[]}}`)
+			return
+		}
+		if r.Method != http.MethodPut {
+			t.Errorf("request method = %s, want GET or PUT", r.Method)
 		}
 		if got := r.Header.Get("x-api-key"); got != "sekrit" {
 			t.Errorf("x-api-key = %q, want configured credential", got)
@@ -64,8 +71,8 @@ func TestDeploymentUpdateUsesExactSDLAndReturnsUpdatedIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("deployment update: %v", err)
 	}
-	if requests != 1 {
-		t.Fatalf("requests = %d, want exactly one update", requests)
+	if requests != 2 {
+		t.Fatalf("requests = %d, want one preflight and one update", requests)
 	}
 
 	got := decodeStructuredMap(t, "json", out)

--- a/internal/cli/console/gateway.go
+++ b/internal/cli/console/gateway.go
@@ -294,27 +294,51 @@ func eventsCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 				return err
 			}
 
-			events, err := gw.LeaseEvents(ctx, lid, "", follow)
-			if err != nil {
-				return aktprovider.GatewayError("stream lease events", err)
-			}
-
-			count := 0
-			if err := aktprovider.ConsumeStream(ctx, "event", events.Stream, events.OnClose, follow,
-				func(event rest.LeaseEvent) error {
-					count++
-					return printLeaseEvent(cmd, event)
-				}); err != nil {
-				return err
-			}
-
-			return printEmptyEvents(cmd, count, follow)
+			return streamLeaseEvents(ctx, cmd, gw, lid, follow)
 		},
 	}
 
 	cmd.Flags().BoolP(flagdefs.FlagFollow, "f", false, "Follow event output")
 
 	return cmd
+}
+
+type leaseEventsClient interface {
+	LeaseEvents(context.Context, mtypes.LeaseID, string, bool) (*rest.LeaseKubeEvents, error)
+}
+
+func streamLeaseEvents(
+	ctx context.Context,
+	cmd *cobra.Command,
+	client leaseEventsClient,
+	lid mtypes.LeaseID,
+	follow bool,
+) error {
+	events, err := client.LeaseEvents(ctx, lid, "", follow)
+	if err != nil {
+		return aktprovider.GatewayError("stream lease events", err)
+	}
+
+	return consumeLeaseEvents(ctx, cmd, events.Stream, events.OnClose, follow)
+}
+
+func consumeLeaseEvents(
+	ctx context.Context,
+	cmd *cobra.Command,
+	stream <-chan rest.LeaseEvent,
+	onClose <-chan string,
+	follow bool,
+) error {
+	count := 0
+	if err := aktprovider.ConsumeStream(ctx, "event", stream, onClose, follow,
+		func(event rest.LeaseEvent) error {
+			count++
+			return printLeaseEvent(cmd, event)
+		}); err != nil {
+		return err
+	}
+
+	return printEmptyEvents(cmd, count, follow)
 }
 
 func statusCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
@@ -631,9 +655,13 @@ func screeningRequestFromCmd(cmd *cobra.Command, args []string) (*console.BidScr
 		raw = json.RawMessage(`[{
 			"resource":{"id":1,"cpu":{"units":{"val":"1000"}},"memory":{"quantity":{"val":"536870912"}},"gpu":{"units":{"val":"0"}},"storage":[{"name":"default","quantity":{"val":"1073741824"}}],"endpoints":[]},
 			"count":1,"price":{"denom":"uact","amount":"0"}
-		}]`)
+			}]`)
 	}
 
+	return screeningRequestFromResources(cmd, args, raw)
+}
+
+func screeningRequestFromResources(cmd *cobra.Command, args []string, raw json.RawMessage) (*console.BidScreeningRequest, error) {
 	var units []map[string]any
 	if err := json.Unmarshal(raw, &units); err != nil {
 		return nil, fmt.Errorf("decode screening resources: %w", err)
@@ -687,10 +715,9 @@ func screeningRequestFromCmd(cmd *cobra.Command, args []string) (*console.BidScr
 			unit["count"] = count
 		}
 	}
-	raw, err = json.Marshal(units)
-	if err != nil {
-		return nil, fmt.Errorf("encode screening resources: %w", err)
-	}
+	// The tree above contains only JSON maps, slices, strings, and integers.
+	// Those values cannot fail JSON encoding after the successful decode.
+	raw, _ = json.Marshal(units)
 
 	attributes, _ := cmd.Flags().GetStringArray("attribute")
 	requirements := console.BidScreeningRequirements{}

--- a/internal/cli/console/gateway.go
+++ b/internal/cli/console/gateway.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	mtypes "pkg.akt.dev/go/node/market/v1"
 	attrv1 "pkg.akt.dev/go/node/types/attributes/v1"
@@ -297,10 +299,16 @@ func eventsCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 				return aktprovider.GatewayError("stream lease events", err)
 			}
 
-			return aktprovider.ConsumeStream(ctx, "event", events.Stream, events.OnClose, follow,
+			count := 0
+			if err := aktprovider.ConsumeStream(ctx, "event", events.Stream, events.OnClose, follow,
 				func(event rest.LeaseEvent) error {
+					count++
 					return printLeaseEvent(cmd, event)
-				})
+				}); err != nil {
+				return err
+			}
+
+			return printEmptyEvents(cmd, count, follow)
 		},
 	}
 
@@ -420,14 +428,14 @@ func shellCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 
 func shellCmdWithRunner(mgrFn func() *aktctx.Manager, run consoleLeaseShellRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "shell <dseq> <service> [-- command...]",
+		Use:   "shell <dseq> [service] [-- command...]",
 		Short: "Open a shell or run a command in a lease container",
 		Long: "Open an interactive shell (default command /bin/sh) or run an explicit command in a " +
 			"container of a Console-managed deployment, connecting to the provider gateway with a " +
 			"short-lived Console-minted JWT — no wallet involved. exec is the same operation as " +
 			"shell with an explicit command: `akt console shell <dseq> <svc> -- <cmd>`. A TTY is " +
 			"allocated automatically when stdin is a terminal.",
-		Args: cobra.MinimumNArgs(2),
+		Args: cobra.MinimumNArgs(1),
 		Example: `  # Interactive shell (defaults to /bin/sh)
   akt console shell 12345 web
 
@@ -439,19 +447,40 @@ func shellCmdWithRunner(mgrFn func() *aktctx.Manager, run consoleLeaseShellRunne
 		RunE: func(cmd *cobra.Command, args []string) error {
 			shellCtx, cancelShell := context.WithCancel(cmd.Context())
 			defer cancelShell()
-			interactive := len(args) == 2
+			dash := cmd.ArgsLenAtDash()
+			service := ""
+			var command []string
+			switch {
+			case dash >= 0:
+				if dash > 1 {
+					service = args[1]
+				}
+				command = args[dash:]
+			case len(args) > 1:
+				service = args[1]
+				command = args[2:]
+			}
+
+			interactive := len(command) == 0
 			if err := output.ValidateShellOutput(cmd, interactive); err != nil {
 				return err
 			}
+			if interactive && !term.IsTerminal(int(os.Stdin.Fd())) {
+				return fmt.Errorf("interactive shell requires a terminal; non-interactive stdin must provide an explicit command after `--`")
+			}
 
-			cl, _, err := clientFromCmd(cmd, mgrFn, true)
+			cl, rc, err := clientFromCmd(cmd, mgrFn, true)
 			if err != nil {
 				return err
 			}
 
-			dseq, service := args[0], args[1]
-
-			command := args[2:]
+			dseq := args[0]
+			if service == "" {
+				service, err = defaultShellService(rc, dseq)
+				if err != nil {
+					return err
+				}
+			}
 			if len(command) == 0 {
 				command = []string{"/bin/sh"}
 			}
@@ -485,32 +514,78 @@ func shellCmdWithRunner(mgrFn func() *aktctx.Manager, run consoleLeaseShellRunne
 	return cmd
 }
 
+func defaultShellService(rc *aktctx.Context, dseq string) (string, error) {
+	if rc == nil {
+		return "", fmt.Errorf("service is required without an active context")
+	}
+	raw, err := console.LoadManifest(rc.Root, rc.Name, dseq)
+	if err != nil {
+		return "", fmt.Errorf("resolve shell service for deployment %s: %w; pass the service explicitly", dseq, err)
+	}
+	names, err := manifestServiceNames(raw)
+	if err != nil {
+		return "", fmt.Errorf("resolve shell service for deployment %s: %w", dseq, err)
+	}
+	switch len(names) {
+	case 0:
+		return "", fmt.Errorf("deployment %s manifest contains no services", dseq)
+	case 1:
+		return names[0], nil
+	default:
+		return "", fmt.Errorf("deployment %s has multiple services (%s); pass one explicitly", dseq, strings.Join(names, ", "))
+	}
+}
+
+func manifestServiceNames(raw string) ([]string, error) {
+	var groups []struct {
+		Services []struct {
+			Name string `json:"name"`
+		} `json:"services"`
+	}
+	if err := json.Unmarshal([]byte(raw), &groups); err != nil {
+		return nil, fmt.Errorf("decode cached manifest: %w", err)
+	}
+	unique := make(map[string]struct{})
+	for _, group := range groups {
+		for _, service := range group.Services {
+			if name := strings.TrimSpace(service.Name); name != "" {
+				unique[name] = struct{}{}
+			}
+		}
+	}
+	names := make([]string, 0, len(unique))
+	for name := range unique {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names, nil
+}
+
 // --- bid screening ------------------------------------------------------------
 
 func screenCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
-	return &cobra.Command{
-		Use:   "screen <sdl-file>",
+	cmd := &cobra.Command{
+		Use:   "screen [sdl-file]",
 		Short: "List providers able to run an SDL (bid screening)",
-		Long: "Ask the Console API which providers can satisfy an SDL's resource requirements " +
-			"before creating a deployment. Resources are derived from the SDL client-side; the " +
-			"endpoint is public, so no API key is needed.",
-		Args:    cobra.ExactArgs(1),
-		Example: `  akt console screen deploy.yaml`,
+		Long: "Ask the Console API which providers can satisfy resource requirements before " +
+			"creating a deployment. Start from an SDL, resource flags, or both; explicit flags " +
+			"override SDL-derived values. The endpoint is public, so no API key is needed.",
+		Args: cobra.MaximumNArgs(1),
+		Example: `  akt console screen deploy.yaml
+  akt console screen --cpu 2 --memory 4Gi --gpu 1 --gpu-model a100`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, _, err := clientFromCmd(cmd, mgrFn, false)
 			if err != nil {
 				return err
 			}
 
-			resources, err := screeningResourcesFromSDL(args[0])
+			req, err := screeningRequestFromCmd(cmd, args)
 			if err != nil {
 				return err
 			}
 
-			providers, err := cl.ScreenBids(cmd.Context(), &console.BidScreeningRequest{
-				Resources: resources,
-				Timezone:  screeningTimezone(),
-			})
+			providers, err := cl.ScreenBids(cmd.Context(), req)
 			if err != nil {
 				return fmt.Errorf("screen providers: %w", err)
 			}
@@ -522,6 +597,142 @@ func screenCmd(mgrFn func() *aktctx.Manager) *cobra.Command {
 			return printJSON(cmd, providers)
 		},
 	}
+
+	cmd.Flags().String("cpu", "1", "CPU quantity (for example 500m or 2)")
+	cmd.Flags().String("memory", "512Mi", "Memory quantity")
+	cmd.Flags().String("storage", "1Gi", "Ephemeral storage quantity")
+	cmd.Flags().Uint32("gpu", 0, "GPU count")
+	cmd.Flags().String("gpu-model", "", "Required GPU model attribute")
+	cmd.Flags().Int("count", 1, "Number of identical resource units")
+	cmd.Flags().StringArray("attribute", nil, "Required provider attribute key=value (repeatable)")
+	cmd.Flags().StringSlice("signed-by", nil, "Accept providers audited by any listed address")
+	cmd.Flags().Int64("reclamation-window", 0, "Minimum provider reclamation window in seconds")
+
+	return cmd
+}
+
+func screeningRequestFromCmd(cmd *cobra.Command, args []string) (*console.BidScreeningRequest, error) {
+	resourceFlags := []string{"cpu", "memory", "storage", "gpu", "gpu-model", "count"}
+	hasResourceFlag := false
+	for _, name := range resourceFlags {
+		hasResourceFlag = hasResourceFlag || cmd.Flags().Changed(name)
+	}
+
+	var raw json.RawMessage
+	var err error
+	if len(args) == 1 {
+		raw, err = screeningResourcesFromSDL(args[0])
+		if err != nil {
+			return nil, err
+		}
+	} else if !hasResourceFlag {
+		return nil, fmt.Errorf("provide an SDL file or at least one resource flag (--cpu, --memory, --storage, --gpu, --gpu-model, --count)")
+	} else {
+		raw = json.RawMessage(`[{
+			"resource":{"id":1,"cpu":{"units":{"val":"1000"}},"memory":{"quantity":{"val":"536870912"}},"gpu":{"units":{"val":"0"}},"storage":[{"name":"default","quantity":{"val":"1073741824"}}],"endpoints":[]},
+			"count":1,"price":{"denom":"uact","amount":"0"}
+		}]`)
+	}
+
+	var units []map[string]any
+	if err := json.Unmarshal(raw, &units); err != nil {
+		return nil, fmt.Errorf("decode screening resources: %w", err)
+	}
+	for _, unit := range units {
+		resourceValue, ok := unit["resource"].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("screening resource omitted its resource object")
+		}
+		if cmd.Flags().Changed("cpu") || len(args) == 0 {
+			value, _ := cmd.Flags().GetString("cpu")
+			parsed, err := screeningQuantity(value, true)
+			if err != nil {
+				return nil, fmt.Errorf("--cpu: %w", err)
+			}
+			resourceValue["cpu"] = map[string]any{"units": map[string]any{"val": parsed}}
+		}
+		if cmd.Flags().Changed("memory") || len(args) == 0 {
+			value, _ := cmd.Flags().GetString("memory")
+			parsed, err := screeningQuantity(value, false)
+			if err != nil {
+				return nil, fmt.Errorf("--memory: %w", err)
+			}
+			resourceValue["memory"] = map[string]any{"quantity": map[string]any{"val": parsed}}
+		}
+		if cmd.Flags().Changed("storage") || len(args) == 0 {
+			value, _ := cmd.Flags().GetString("storage")
+			parsed, err := screeningQuantity(value, false)
+			if err != nil {
+				return nil, fmt.Errorf("--storage: %w", err)
+			}
+			resourceValue["storage"] = []any{map[string]any{"name": "default", "quantity": map[string]any{"val": parsed}}}
+		}
+		if cmd.Flags().Changed("gpu") || cmd.Flags().Changed("gpu-model") || len(args) == 0 {
+			gpu, _ := cmd.Flags().GetUint32("gpu")
+			model, _ := cmd.Flags().GetString("gpu-model")
+			if model != "" && gpu == 0 {
+				gpu = 1
+			}
+			gpuValue := map[string]any{"units": map[string]any{"val": strconv.FormatUint(uint64(gpu), 10)}}
+			if model != "" {
+				gpuValue["attributes"] = []any{map[string]any{"key": "vendor/nvidia/model", "value": model}}
+			}
+			resourceValue["gpu"] = gpuValue
+		}
+		if cmd.Flags().Changed("count") || len(args) == 0 {
+			count, _ := cmd.Flags().GetInt("count")
+			if count < 1 {
+				return nil, fmt.Errorf("--count must be greater than zero")
+			}
+			unit["count"] = count
+		}
+	}
+	raw, err = json.Marshal(units)
+	if err != nil {
+		return nil, fmt.Errorf("encode screening resources: %w", err)
+	}
+
+	attributes, _ := cmd.Flags().GetStringArray("attribute")
+	requirements := console.BidScreeningRequirements{}
+	for _, item := range attributes {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok || strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("--attribute must use key=value, got %q", item)
+		}
+		requirements.Attributes = append(requirements.Attributes, console.Attribute{Key: strings.TrimSpace(key), Value: strings.TrimSpace(value)})
+	}
+	requirements.SignedBy.AnyOf, _ = cmd.Flags().GetStringSlice("signed-by")
+
+	reclamation, _ := cmd.Flags().GetInt64("reclamation-window")
+	if reclamation < 0 {
+		return nil, fmt.Errorf("--reclamation-window must be non-negative")
+	}
+	var reclamationRaw json.RawMessage
+	if cmd.Flags().Changed("reclamation-window") {
+		reclamationRaw = json.RawMessage(strconv.FormatInt(reclamation, 10))
+	}
+
+	return &console.BidScreeningRequest{
+		Requirements:      requirements,
+		Resources:         raw,
+		Timezone:          screeningTimezone(),
+		ReclamationWindow: reclamationRaw,
+	}, nil
+}
+
+func screeningQuantity(value string, cpu bool) (string, error) {
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return "", err
+	}
+	if quantity.Sign() <= 0 {
+		return "", fmt.Errorf("quantity must be greater than zero")
+	}
+	if cpu {
+		return strconv.FormatInt(quantity.MilliValue(), 10), nil
+	}
+
+	return strconv.FormatInt(quantity.Value(), 10), nil
 }
 
 // screeningTimezone returns the local IANA zone name for bid screening. The
@@ -665,4 +876,12 @@ func printLeaseEvent(cmd *cobra.Command, event rest.LeaseEvent) error {
 		event.Type, event.Object.Kind, event.Object.Name, event.Reason, event.Note)
 
 	return output.PrintStreamRecord(cmd, event, pretty)
+}
+
+func printEmptyEvents(cmd *cobra.Command, count int, follow bool) error {
+	if count == 0 && !follow && output.FormatFromCmd(cmd) == output.FormatTable {
+		return printConsoleText(cmd, "No recent events\n")
+	}
+
+	return nil
 }

--- a/internal/cli/console/gateway_test.go
+++ b/internal/cli/console/gateway_test.go
@@ -25,6 +25,7 @@ import (
 
 	"pkg.akt.dev/akt/internal/actionlog"
 	"pkg.akt.dev/akt/internal/cliutil"
+	aktconsole "pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
 	"pkg.akt.dev/akt/internal/output"
 	aktprovider "pkg.akt.dev/akt/internal/provider"
@@ -637,6 +638,70 @@ func TestPrintEmptyEventsOnlyInBoundedPrettyMode(t *testing.T) {
 	}
 }
 
+func TestConsumeLeaseEventsCountsAndPrintsRecords(t *testing.T) {
+	cmd, buf := streamOutputCommand(t, "pretty")
+	stream := make(chan rest.LeaseEvent, 1)
+	closed := make(chan string)
+	stream <- rest.LeaseEvent{Type: "Normal", Reason: "Started", Note: "ready"}
+	close(stream)
+	close(closed)
+
+	if err := consumeLeaseEvents(context.Background(), cmd, stream, closed, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Started: ready") || strings.Contains(got, "No recent events") {
+		t.Fatalf("event output = %q", got)
+	}
+}
+
+func TestConsumeLeaseEventsReturnsOutputFailure(t *testing.T) {
+	cmd, _ := streamOutputCommand(t, "pretty")
+	cmd.SetOut(consoleOutputErrorWriter{err: errors.New("write failed")})
+	stream := make(chan rest.LeaseEvent, 1)
+	closed := make(chan string)
+	stream <- rest.LeaseEvent{Type: "Normal", Reason: "Started", Note: "ready"}
+	close(stream)
+	close(closed)
+
+	if err := consumeLeaseEvents(context.Background(), cmd, stream, closed, false); err == nil {
+		t.Fatal("event output failure was not returned")
+	}
+}
+
+type staticLeaseEventsClient struct {
+	result *rest.LeaseKubeEvents
+	err    error
+}
+
+func (client staticLeaseEventsClient) LeaseEvents(
+	context.Context,
+	mtypes.LeaseID,
+	string,
+	bool,
+) (*rest.LeaseKubeEvents, error) {
+	return client.result, client.err
+}
+
+func TestStreamLeaseEventsConsumesProviderResult(t *testing.T) {
+	cmd, buf := streamOutputCommand(t, "pretty")
+	stream := make(chan rest.LeaseEvent, 1)
+	closed := make(chan string)
+	stream <- rest.LeaseEvent{Type: "Normal", Reason: "Started", Note: "ready"}
+	close(stream)
+	close(closed)
+	client := staticLeaseEventsClient{result: &rest.LeaseKubeEvents{Stream: stream, OnClose: closed}}
+
+	if err := streamLeaseEvents(context.Background(), cmd, client, mtypes.LeaseID{DSeq: 42}, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Started: ready") {
+		t.Fatalf("event output = %q", buf.String())
+	}
+	if err := streamLeaseEvents(context.Background(), cmd, staticLeaseEventsClient{err: errors.New("open failed")}, mtypes.LeaseID{}, false); err == nil {
+		t.Fatal("event stream setup failure was not returned")
+	}
+}
+
 func streamOutputCommand(t *testing.T, format string) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 
@@ -684,6 +749,14 @@ func TestShellWithoutCommandRejectsNonTerminalBeforeContextResolution(t *testing
 	}
 }
 
+func TestShellWithoutServiceReturnsManifestSelectionFailure(t *testing.T) {
+	m := newAuthedManager(t)
+	_, err := execConsole(t, m, "", "shell", "777", "--", "echo", "ok")
+	if err == nil || !strings.Contains(err.Error(), "load manifest") {
+		t.Fatalf("shell error = %v, want manifest load guidance", err)
+	}
+}
+
 func TestManifestServiceNames(t *testing.T) {
 	names, err := manifestServiceNames(`[{"name":"group","services":[{"name":"worker"},{"name":"web"}]}]`)
 	if err != nil {
@@ -691,6 +764,44 @@ func TestManifestServiceNames(t *testing.T) {
 	}
 	if got := strings.Join(names, ","); got != "web,worker" {
 		t.Fatalf("services = %q", got)
+	}
+}
+
+func TestDefaultShellServiceCoversManifestBoundaries(t *testing.T) {
+	if _, err := defaultShellService(nil, "1"); err == nil {
+		t.Fatal("nil context did not fail")
+	}
+
+	rc := &aktctx.Context{Root: t.TempDir(), Name: "prod"}
+	if _, err := defaultShellService(rc, "1"); err == nil {
+		t.Fatal("missing manifest did not fail")
+	}
+
+	for dseq, manifest := range map[string]string{
+		"2": `{`,
+		"3": `[{"services":[]}]`,
+		"4": `[{"services":[{"name":"web"}]}]`,
+		"5": `[{"services":[{"name":"web"},{"name":"worker"}]}]`,
+	} {
+		if err := aktconsole.SaveManifest(rc.Root, rc.Name, dseq, manifest); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := defaultShellService(rc, "2"); err == nil {
+		t.Fatal("malformed manifest did not fail")
+	}
+	if _, err := defaultShellService(rc, "3"); err == nil {
+		t.Fatal("empty manifest did not fail")
+	}
+	if got, err := defaultShellService(rc, "4"); err != nil || got != "web" {
+		t.Fatalf("single service = %q, %v", got, err)
+	}
+	if _, err := defaultShellService(rc, "5"); err == nil || !strings.Contains(err.Error(), "web, worker") {
+		t.Fatalf("multiple-service error = %v", err)
+	}
+
+	if _, err := manifestServiceNames(`{`); err == nil {
+		t.Fatal("malformed manifest service list did not fail")
 	}
 }
 
@@ -730,6 +841,64 @@ func TestScreeningRequestSupportsResourceFlagsWithoutSDL(t *testing.T) {
 	}
 	if string(req.ReclamationWindow) != "600" {
 		t.Fatalf("reclamation window = %s", req.ReclamationWindow)
+	}
+}
+
+func TestScreeningRequestValidationEdges(t *testing.T) {
+	newCmd := func() *cobra.Command { return screenCmd(func() *aktctx.Manager { return nil }) }
+
+	if _, err := screeningRequestFromCmd(newCmd(), nil); err == nil {
+		t.Fatal("missing SDL and resource flags did not fail")
+	}
+	if _, err := screeningRequestFromCmd(newCmd(), []string{filepath.Join(t.TempDir(), "missing.yaml")}); err == nil {
+		t.Fatal("missing SDL did not fail")
+	}
+	if _, err := screeningRequestFromResources(newCmd(), nil, json.RawMessage(`{`)); err == nil {
+		t.Fatal("malformed resource JSON did not fail")
+	}
+	if _, err := screeningRequestFromResources(newCmd(), nil, json.RawMessage(`[{"resource":null}]`)); err == nil {
+		t.Fatal("missing resource object did not fail")
+	}
+
+	tests := []struct {
+		name  string
+		flag  string
+		value string
+		want  string
+	}{
+		{name: "cpu", flag: "cpu", value: "0", want: "greater than zero"},
+		{name: "memory", flag: "memory", value: "bad", want: "--memory"},
+		{name: "storage", flag: "storage", value: "0", want: "greater than zero"},
+		{name: "count", flag: "count", value: "0", want: "greater than zero"},
+		{name: "attribute", flag: "attribute", value: "missing-separator", want: "key=value"},
+		{name: "reclamation", flag: "reclamation-window", value: "-1", want: "non-negative"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := newCmd()
+			if err := cmd.Flags().Set("cpu", "1"); err != nil {
+				t.Fatal(err)
+			}
+			if err := cmd.Flags().Set(test.flag, test.value); err != nil {
+				t.Fatal(err)
+			}
+			_, err := screeningRequestFromCmd(cmd, nil)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("screening error = %v, want %q", err, test.want)
+			}
+		})
+	}
+
+	cmd := newCmd()
+	if err := cmd.Flags().Set("gpu-model", "a100"); err != nil {
+		t.Fatal(err)
+	}
+	req, err := screeningRequestFromCmd(cmd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(req.Resources), `"val":"1"`) {
+		t.Fatalf("GPU model did not imply one GPU: %s", req.Resources)
 	}
 }
 

--- a/internal/cli/console/gateway_test.go
+++ b/internal/cli/console/gateway_test.go
@@ -608,6 +608,35 @@ func TestPrintLeaseEventStructured(t *testing.T) {
 	}
 }
 
+func TestPrintEmptyEventsOnlyInBoundedPrettyMode(t *testing.T) {
+	cmd, buf := streamOutputCommand(t, "pretty")
+	if err := printEmptyEvents(cmd, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "No recent events\n" {
+		t.Fatalf("empty events = %q", got)
+	}
+
+	for _, test := range []struct {
+		format string
+		count  int
+		follow bool
+	}{
+		{format: "json"},
+		{format: "yaml"},
+		{format: "pretty", count: 1},
+		{format: "pretty", follow: true},
+	} {
+		cmd, buf := streamOutputCommand(t, test.format)
+		if err := printEmptyEvents(cmd, test.count, test.follow); err != nil {
+			t.Fatal(err)
+		}
+		if got := buf.String(); got != "" {
+			t.Fatalf("unexpected empty-event output = %q", got)
+		}
+	}
+}
+
 func streamOutputCommand(t *testing.T, format string) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 
@@ -634,6 +663,73 @@ func TestShellRejectsStructuredInteractiveModeBeforeContextResolution(t *testing
 	}
 	if resolved {
 		t.Fatal("structured interactive shell resolved context before refusal")
+	}
+}
+
+func TestShellWithoutCommandRejectsNonTerminalBeforeContextResolution(t *testing.T) {
+	resolved := false
+	cmd := shellCmd(func() *aktctx.Manager {
+		resolved = true
+		return nil
+	})
+	cmd.Flags().String(flagdefs.FlagOutput, "pretty", "")
+	cmd.SetArgs([]string{"12345"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "non-interactive stdin") {
+		t.Fatalf("shell error = %v", err)
+	}
+	if resolved {
+		t.Fatal("non-terminal shell resolved context before refusal")
+	}
+}
+
+func TestManifestServiceNames(t *testing.T) {
+	names, err := manifestServiceNames(`[{"name":"group","services":[{"name":"worker"},{"name":"web"}]}]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(names, ","); got != "web,worker" {
+		t.Fatalf("services = %q", got)
+	}
+}
+
+func TestScreeningRequestSupportsResourceFlagsWithoutSDL(t *testing.T) {
+	cmd := screenCmd(func() *aktctx.Manager { return nil })
+	for flag, value := range map[string]string{
+		"cpu": "250m", "memory": "2Gi", "storage": "10Gi", "gpu": "1",
+		"gpu-model": "a100", "count": "2", "attribute": "region=us-west",
+		"signed-by": "akash1auditor", "reclamation-window": "600",
+	} {
+		if err := cmd.Flags().Set(flag, value); err != nil {
+			t.Fatalf("set --%s: %v", flag, err)
+		}
+	}
+
+	req, err := screeningRequestFromCmd(cmd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var units []map[string]any
+	if err := json.Unmarshal(req.Resources, &units); err != nil {
+		t.Fatal(err)
+	}
+	if len(units) != 1 || units[0]["count"] != float64(2) {
+		t.Fatalf("screening units = %#v", units)
+	}
+	resource := units[0]["resource"].(map[string]any)
+	cpu := resource["cpu"].(map[string]any)["units"].(map[string]any)["val"]
+	if cpu != "250" {
+		t.Fatalf("cpu = %#v, want 250 millicpu", cpu)
+	}
+	if len(req.Requirements.Attributes) != 1 || req.Requirements.Attributes[0].Key != "region" {
+		t.Fatalf("requirements = %#v", req.Requirements)
+	}
+	if strings.Join(req.Requirements.SignedBy.AnyOf, ",") != "akash1auditor" {
+		t.Fatalf("signed by = %#v", req.Requirements.SignedBy)
+	}
+	if string(req.ReclamationWindow) != "600" {
+		t.Fatalf("reclamation window = %s", req.ReclamationWindow)
 	}
 }
 

--- a/internal/cli/console/money_test.go
+++ b/internal/cli/console/money_test.go
@@ -3,6 +3,7 @@ package console
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,12 @@ import (
 	aktctx "pkg.akt.dev/akt/internal/context"
 	flagdefs "pkg.akt.dev/akt/internal/flags"
 )
+
+type failingPrettyMarshaler struct{}
+
+func (failingPrettyMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("marshal failed")
+}
 
 // newAuthedManager returns a manager whose "prod" context already carries a
 // Console API key, for the authenticated command surface.
@@ -131,6 +138,70 @@ func TestConsolePrettyRendererUsesHumanMoneySemantics(t *testing.T) {
 	}
 	if strings.Contains(rendered, "{") {
 		t.Fatalf("pretty output fell back to raw JSON: %q", rendered)
+	}
+}
+
+func TestConsolePrettyRendererCoversSemanticShapesAndFailures(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(flagdefs.FlagOutput, "pretty", "")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := printConsolePretty(cmd, failingPrettyMarshaler{}); err == nil {
+		t.Fatal("unsupported JSON value did not fail")
+	}
+	if _, err := decodeConsoleSemantic([]byte(`{`)); err == nil {
+		t.Fatal("invalid semantic JSON did not fail")
+	}
+	if err := printConsolePrettyWithDecoder(cmd, map[string]any{"ok": true}, func([]byte) (any, error) {
+		return nil, errors.New("decode failed")
+	}); err == nil || !strings.Contains(err.Error(), "decode pretty output") {
+		t.Fatalf("decoder failure = %v", err)
+	}
+
+	if err := printConsolePretty(cmd, map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != "No data.\n" {
+		t.Fatalf("empty pretty output = %q", got)
+	}
+
+	out.Reset()
+	if err := printConsolePretty(cmd, "value"); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != "value\n" {
+		t.Fatalf("scalar pretty output = %q", got)
+	}
+
+	var rendered strings.Builder
+	renderConsoleValue(&rendered, map[string]any{
+		"boolValue": true,
+		"emptyList": []any{},
+		"items": []any{
+			"text",
+			map[string]any{"denom": "uakt", "amount": "25"},
+			map[string]any{"nested": nil},
+		},
+		"malformedCoin": map[string]any{"denom": "uact", "amount": "not-a-number"},
+		"missingAmount": map[string]any{"denom": "uact"},
+		"nothing":       nil,
+		"snake_key":     "",
+	}, 0, "")
+	text := rendered.String()
+	for _, want := range []string{"Bool Value: true", "none", "25 uakt", "not-a-number uact", "Snake key: none"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("semantic render %q missing %q", text, want)
+		}
+	}
+
+	rendered.Reset()
+	renderConsoleValue(&rendered, map[string]any{"denom": "uact", "amount": "1000000"}, 0, "")
+	if got := rendered.String(); got != "$1.00" {
+		t.Fatalf("root coin = %q", got)
+	}
+	if got := humanConsoleLabel(""); got != "" {
+		t.Fatalf("empty label = %q", got)
 	}
 }
 

--- a/internal/cli/console/money_test.go
+++ b/internal/cli/console/money_test.go
@@ -714,37 +714,40 @@ func TestAPIKeyCreateShowsSecretOnceWithWarning(t *testing.T) {
 	}
 }
 
-// TestAPIKeyDeleteIsIdempotent covers the delete no-op: the client maps 404 to
-// success, so re-running a delete script must not fail.
-func TestAPIKeyDeleteIsIdempotent(t *testing.T) {
+func TestAPIKeyDeleteMissingResourceDoesNotReportSuccess(t *testing.T) {
 	m := newAuthedManager(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Errorf("unexpected method %s", r.Method)
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/api-keys" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
-		w.WriteHeader(http.StatusNotFound)
+		writeJSON(t, w, `{"data":[]}`)
 	}))
 	defer srv.Close()
 
 	const id = "11111111-1111-1111-1111-111111111111"
 	out, err := execConsole(t, m, srv.URL, "--output", "pretty", "apikey", "delete", id)
-	if err != nil {
-		t.Fatalf("deleting an absent key must be a no-op, got %v", err)
+	if !errors.Is(err, console.ErrNotFound) {
+		t.Fatalf("deleting an absent key error = %v, want ErrNotFound", err)
 	}
-	if !strings.Contains(out, id+" deleted") {
-		t.Errorf("unexpected output %q", out)
+	if strings.Contains(out, "deleted") {
+		t.Errorf("absent API key emitted false success output %q", out)
 	}
 }
 
-func TestAPIKeyDeleteStructuredAcknowledgement(t *testing.T) {
+func TestAPIKeyDeleteStructuredAcknowledgementRequiresDeletion(t *testing.T) {
 	m := newAuthedManager(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/v1/api-keys/11111111-1111-1111-1111-111111111111" {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/api-keys":
+			writeJSON(t, w, `{"data":[{"id":"11111111-1111-1111-1111-111111111111","name":"ci"}]}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/api-keys/11111111-1111-1111-1111-111111111111":
+			w.WriteHeader(http.StatusNoContent)
+		default:
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
 		}
-		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
 
@@ -753,7 +756,7 @@ func TestAPIKeyDeleteStructuredAcknowledgement(t *testing.T) {
 			const id = "11111111-1111-1111-1111-111111111111"
 			out, err := execConsole(t, m, srv.URL, "--output", format, "apikey", "delete", id)
 			if err != nil {
-				t.Fatalf("delete absent API key: %v", err)
+				t.Fatalf("delete API key: %v", err)
 			}
 			got := decodeStructuredOutput(t, format, out)
 			want := map[string]any{"id": id, "deleted": true}

--- a/internal/cli/console/money_test.go
+++ b/internal/cli/console/money_test.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,9 +12,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"pkg.akt.dev/akt/internal/capability"
 	"pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
+	flagdefs "pkg.akt.dev/akt/internal/flags"
 )
 
 // newAuthedManager returns a manager whose "prod" context already carries a
@@ -99,6 +103,34 @@ func TestFormatUSDPreservesSubCentValues(t *testing.T) {
 		if got := formatUSD(tt.value); got != tt.want {
 			t.Errorf("formatUSD(%g) = %q, want %q", tt.value, got, tt.want)
 		}
+	}
+}
+
+func TestConsolePrettyRendererUsesHumanMoneySemantics(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(flagdefs.FlagOutput, "pretty", "")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	detail := console.DeploymentDetail{
+		Deployment: console.Deployment{ID: console.DeploymentID{Owner: "akash1owner", DSeq: "42"}, State: "active"},
+		Leases: []console.Lease{{
+			ID:    console.LeaseID{Provider: "akash1provider", DSeq: "42"},
+			Price: &console.Price{Denom: "uact", Amount: "1"},
+		}},
+		EscrowAccount: json.RawMessage(`{"state":{"funds":{"denom":"uact","amount":"500000"}}}`),
+	}
+	if err := printJSON(cmd, detail); err != nil {
+		t.Fatal(err)
+	}
+	rendered := out.String()
+	for _, want := range []string{"akash1owner", "akash1provider", "$0.50", "$0.43/month"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("pretty output %q missing %q", rendered, want)
+		}
+	}
+	if strings.Contains(rendered, "{") {
+		t.Fatalf("pretty output fell back to raw JSON: %q", rendered)
 	}
 }
 
@@ -309,7 +341,7 @@ func TestDepositRejectsNonPositiveAmount(t *testing.T) {
 			t.Errorf("%v must be rejected", arg)
 			continue
 		}
-		if !strings.Contains(err.Error(), "positive USD amount") {
+		if !strings.Contains(err.Error(), "at least $0.50") {
 			t.Errorf("%v: unexpected error %v", arg, err)
 		}
 	}
@@ -624,11 +656,12 @@ func TestAPIKeyDeleteIsIdempotent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	out, err := execConsole(t, m, srv.URL, "apikey", "delete", "key-1")
+	const id = "11111111-1111-1111-1111-111111111111"
+	out, err := execConsole(t, m, srv.URL, "--output", "pretty", "apikey", "delete", id)
 	if err != nil {
 		t.Fatalf("deleting an absent key must be a no-op, got %v", err)
 	}
-	if !strings.Contains(out, "key-1 deleted") {
+	if !strings.Contains(out, id+" deleted") {
 		t.Errorf("unexpected output %q", out)
 	}
 }
@@ -637,7 +670,7 @@ func TestAPIKeyDeleteStructuredAcknowledgement(t *testing.T) {
 	m := newAuthedManager(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/v1/api-keys/key-1" {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/api-keys/11111111-1111-1111-1111-111111111111" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -646,12 +679,13 @@ func TestAPIKeyDeleteStructuredAcknowledgement(t *testing.T) {
 
 	for _, format := range []string{"json", "yaml"} {
 		t.Run(format, func(t *testing.T) {
-			out, err := execConsole(t, m, srv.URL, "--output", format, "apikey", "delete", "key-1")
+			const id = "11111111-1111-1111-1111-111111111111"
+			out, err := execConsole(t, m, srv.URL, "--output", format, "apikey", "delete", id)
 			if err != nil {
 				t.Fatalf("delete absent API key: %v", err)
 			}
 			got := decodeStructuredOutput(t, format, out)
-			want := map[string]any{"id": "key-1", "deleted": true}
+			want := map[string]any{"id": id, "deleted": true}
 			if !reflect.DeepEqual(got, want) {
 				t.Fatalf("structured delete output = %#v, want %#v", got, want)
 			}

--- a/internal/cli/console_owner_resolver_test.go
+++ b/internal/cli/console_owner_resolver_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chaincli "pkg.akt.dev/akt/internal/cli/chain"
+	aktctx "pkg.akt.dev/akt/internal/context"
+)
+
+func TestConsoleDefaultOwnerResolverUsesManagedWallet(t *testing.T) {
+	const address = "akash1gnz8venxvenxvenxvenxvenxvenxvenx4m3e0y"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/user/me":
+			_, _ = w.Write([]byte(`{"data":{"id":"user-1"}}`))
+		case "/v1/wallets":
+			if got := r.URL.Query().Get("userId"); got != "user-1" {
+				t.Errorf("wallet userId = %q, want user-1", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"address":"` + address + `","denom":"uact"}]}`))
+		default:
+			t.Errorf("unexpected request %s", r.URL.RequestURI())
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := withConsoleDefaultOwnerResolver(context.Background(), &aktctx.Context{
+		ConsoleAPIURL: srv.URL,
+		ConsoleAPIKey: "secret",
+	})
+	resolver, ok := ctx.Value(chaincli.ContextTypeDefaultOwnerResolver).(chaincli.DefaultOwnerResolver)
+	if !ok {
+		t.Fatal("Console owner resolver was not attached")
+	}
+	got, err := resolver(ctx)
+	if err != nil {
+		t.Fatalf("resolve managed wallet: %v", err)
+	}
+	if got != address {
+		t.Fatalf("managed wallet = %q, want %q", got, address)
+	}
+}

--- a/internal/cli/console_owner_resolver_test.go
+++ b/internal/cli/console_owner_resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	chaincli "pkg.akt.dev/akt/internal/cli/chain"
@@ -43,5 +44,66 @@ func TestConsoleDefaultOwnerResolverUsesManagedWallet(t *testing.T) {
 	}
 	if got != address {
 		t.Fatalf("managed wallet = %q, want %q", got, address)
+	}
+}
+
+func TestConsoleDefaultOwnerResolverReportsBoundaryFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    string
+	}{
+		{
+			name: "user request",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "offline", http.StatusBadGateway)
+			},
+			want: "managed wallet user",
+		},
+		{
+			name: "missing user id",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"data":{"id":""}}`))
+			},
+			want: "omitted user ID",
+		},
+		{
+			name: "wallet request",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v1/user/me" {
+					_, _ = w.Write([]byte(`{"data":{"id":"user-1"}}`))
+					return
+				}
+				http.Error(w, "offline", http.StatusBadGateway)
+			},
+			want: "managed wallets",
+		},
+		{
+			name: "no wallet address",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v1/user/me" {
+					_, _ = w.Write([]byte(`{"data":{"id":"user-1"}}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"data":[{"address":" "}]}`))
+			},
+			want: "no managed wallet address",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(test.handler)
+			defer srv.Close()
+			ctx := withConsoleDefaultOwnerResolver(context.Background(), &aktctx.Context{
+				ConsoleAPIURL: srv.URL,
+				ConsoleAPIKey: "secret",
+			})
+			resolver := ctx.Value(chaincli.ContextTypeDefaultOwnerResolver).(chaincli.DefaultOwnerResolver)
+			_, err := resolver(ctx)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("resolver error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }

--- a/internal/cli/context/commands.go
+++ b/internal/cli/context/commands.go
@@ -91,6 +91,10 @@ func createCmd(mgr func() *aktctx.Manager) *cobra.Command {
   # Create a testnet context with a specific keyring
   akt context create staging --network testnet --keyring test-keyring --default-account testaccount`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed(flagdefs.FlagKeyringBackend) {
+				return fmt.Errorf("--keyring-backend applies only to this invocation and cannot be persisted by context create; use `akt context keyring set <keyring> <backend>`")
+			}
+
 			m := mgr()
 			name := args[0]
 
@@ -154,7 +158,34 @@ func createCmd(mgr func() *aktctx.Manager) *cobra.Command {
 				})
 			}
 
-			return nil
+			effectiveAuth := authMethod
+			if effectiveAuth == "" {
+				effectiveAuth = aktctx.AuthMethodKeyring
+			}
+			effectiveNetwork := network
+			if effectiveNetwork == "" {
+				effectiveNetwork = "none"
+			}
+			result := struct {
+				Name       string `json:"name" yaml:"name"`
+				Network    string `json:"network" yaml:"network"`
+				AuthMethod string `json:"auth_method" yaml:"auth-method"`
+				Current    bool   `json:"current" yaml:"current"`
+			}{name, effectiveNetwork, effectiveAuth, setCurrent}
+			if format := output.FormatFromCmd(cmd); format != output.FormatTable {
+				return output.Fprint(cmd.OutOrStdout(), format, result)
+			}
+
+			checked := output.NewCheckedWriter(cmd.OutOrStdout())
+			_, err := fmt.Fprintf(
+				checked,
+				"Context %q created (network: %s, auth-method: %s, current: %t).\n",
+				name,
+				effectiveNetwork,
+				effectiveAuth,
+				setCurrent,
+			)
+			return checked.Complete(err)
 		},
 	}
 

--- a/internal/cli/context/commands_test.go
+++ b/internal/cli/context/commands_test.go
@@ -97,6 +97,38 @@ func TestCreateRequiresNetworkUnlessConsole(t *testing.T) {
 	}
 }
 
+func TestCreatePrintsEffectiveContextConfirmation(t *testing.T) {
+	m := newTestManager(t)
+	cmd := createCmd(func() *aktctx.Manager { return m })
+	out := runOutput(t, cmd, "prod", "--network", "mainnet", "--set-current")
+	for _, want := range []string{`Context "prod" created`, "network: mainnet", "auth-method: keyring", "current: true"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("create confirmation %q missing %q", out, want)
+		}
+	}
+}
+
+func TestCreateRejectsInvocationKeyringBackendOverride(t *testing.T) {
+	m := newTestManager(t)
+	root := Commands(func() *aktctx.Manager { return m }, func() (sdkkeyring.Keyring, error) {
+		return nil, errors.New("keyring must not open")
+	})
+	root.PersistentFlags().String(flagdefs.FlagKeyringBackend, "", "")
+
+	err := runErr(t, root,
+		"--"+flagdefs.FlagKeyringBackend, "file",
+		"create", "prod", "--network", "mainnet",
+	)
+	for _, want := range []string{"--keyring-backend", "akt context keyring set"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("create override error = %q, want %q", err, want)
+		}
+	}
+	if m.GetContext("prod") != nil {
+		t.Fatal("rejected context create mutated configuration")
+	}
+}
+
 // TestCreateStoresConsoleKeyOutsideConfig pins SPEC §7.1: the key passed to
 // `context create --console-api-key` lands in the per-context credential file
 // with 0600, and never in config.yaml or the action log.

--- a/internal/cli/gating_test.go
+++ b/internal/cli/gating_test.go
@@ -250,8 +250,8 @@ func TestLocalIdentityModes(t *testing.T) {
 		t.Errorf("read-only mcp mode = %v, want on demand", got)
 	}
 	require.NoError(t, mcp.Flags().Set(flagdefs.FlagEnableWrites, "true"))
-	if got := localIdentityMode(mcp); got != aktclient.LocalIdentityRequired {
-		t.Errorf("write-enabled mcp mode = %v, want required", got)
+	if got := localIdentityMode(mcp); got != aktclient.LocalIdentityOnDemand {
+		t.Errorf("write-enabled mcp mode = %v, want on demand", got)
 	}
 
 	provider := &cobra.Command{Use: "provider"}

--- a/internal/cli/keys/commands.go
+++ b/internal/cli/keys/commands.go
@@ -159,12 +159,15 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error), recorder Recorder) *c
   # Add a Ledger key
   akt context keys add alice --ledger`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+			if name == "" {
+				return fmt.Errorf("key name must not be blank")
+			}
+
 			kr, err := getKeyring()
 			if err != nil {
 				return err
 			}
-
-			name := args[0]
 
 			// Check if key already exists.
 			if _, err := kr.Key(name); err == nil {

--- a/internal/cli/keys/commands.go
+++ b/internal/cli/keys/commands.go
@@ -157,7 +157,10 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error), recorder Recorder) *c
   akt context keys add alice --recover
 
   # Add a Ledger key
-  akt context keys add alice --ledger`,
+  akt context keys add alice --ledger
+
+  # Scripted creation without printing the mnemonic
+  akt context keys add ci --yes --no-backup`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := strings.TrimSpace(args[0])
 			if name == "" {
@@ -303,6 +306,7 @@ func addCmd(getKeyring func() (sdkkeyring.Keyring, error), recorder Recorder) *c
 
 	cmd.Flags().Bool(flagdefs.FlagRecover, false, "Recover key from existing mnemonic")
 	cmd.Flags().Bool(flagdefs.FlagNoBackup, false, "Don't print mnemonic after creation")
+	cmd.Flags().BoolP(flagdefs.FlagSkipConfirmation, "y", false, "Skip confirmation prompts (accepted for Cosmos CLI compatibility; key add never overwrites)")
 	cmd.Flags().BoolP(flagdefs.FlagInteractive, "i", false, "Interactive BIP39 passphrase prompt")
 	cmd.Flags().Bool(flagdefs.FlagUseLedger, false, "Use Ledger hardware wallet")
 	cmd.Flags().Uint32(flagdefs.FlagCoinType, 118, "BIP44 coin type")

--- a/internal/cli/keys/commands_test.go
+++ b/internal/cli/keys/commands_test.go
@@ -161,6 +161,24 @@ func TestKeysAddRejectsBlankNameBeforeOpeningKeyring(t *testing.T) {
 	}
 }
 
+func TestKeysAddAcceptsYesCompatibilityFlag(t *testing.T) {
+	for _, flag := range []string{"--yes", "-y"} {
+		t.Run(flag, func(t *testing.T) {
+			kr := aktkeyring.NewInMemory(aktcodec.MakeEncodingConfig().Codec)
+			out, err := runKeysCommand(t, kr, "add", "scripted", flag, "--no-backup")
+			if err != nil {
+				t.Fatalf("keys add %s: %v", flag, err)
+			}
+			if strings.Contains(out, "mnemonic") {
+				t.Fatalf("keys add %s repeated backup material: %q", flag, out)
+			}
+			if _, err := kr.Key("scripted"); err != nil {
+				t.Fatalf("keys add %s did not create the key: %v", flag, err)
+			}
+		})
+	}
+}
+
 func TestKeysAddReadsCanonicalMultisigThreshold(t *testing.T) {
 	kr := testKeyring(t)
 	if _, _, err := kr.NewMnemonic(

--- a/internal/cli/keys/commands_test.go
+++ b/internal/cli/keys/commands_test.go
@@ -144,6 +144,23 @@ func TestKeysAddLedgerUsesConfiguredAccountPrefix(t *testing.T) {
 	}
 }
 
+func TestKeysAddRejectsBlankNameBeforeOpeningKeyring(t *testing.T) {
+	opened := false
+	cmd := Commands(func() (sdkkeyring.Keyring, error) {
+		opened = true
+		return nil, errors.New("keyring must not open")
+	}, nil)
+	cmd.SetArgs([]string{"add", "   "})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "name must not be blank") {
+		t.Fatalf("blank-name error = %v", err)
+	}
+	if opened {
+		t.Fatal("blank name opened the keyring")
+	}
+}
+
 func TestKeysAddReadsCanonicalMultisigThreshold(t *testing.T) {
 	kr := testKeyring(t)
 	if _, _, err := kr.NewMnemonic(

--- a/internal/cli/mcp_actionlog_test.go
+++ b/internal/cli/mcp_actionlog_test.go
@@ -23,12 +23,14 @@ func TestConsoleClientForCarriesMCPActionLog(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":{"deployments":[],"pagination":{"skip":0,"limit":10,"hasMore":false}}}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/42":
 			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"42"}},"leases":[],"escrow_account":{"state":{"funds":[{"denom":"uact","amount":"1000000"}],"transferred":[]}}}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/41":
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"41"},"state":"active"}}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/44":
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"44"},"state":"active"}}}`))
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/deployments/41":
 			_, _ = w.Write([]byte(`{"data":{"success":true}}`))
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/deployments/44":
 			_, _ = w.Write([]byte(`{"data":{"success":true}}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/42":
-			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"42"}},"leases":[],"escrow_account":{"state":{"funds":[{"denom":"uact","amount":"1000000"}],"transferred":[]}}}}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/deposit-deployment":
 			w.WriteHeader(http.StatusConflict)
 			_, _ = w.Write([]byte(`{"error":"deployment is settling"}`))

--- a/internal/cli/provider/commands.go
+++ b/internal/cli/provider/commands.go
@@ -99,7 +99,7 @@ func statusCmd() *cobra.Command {
 
 			status, err := cl.Status(ctx)
 			if err != nil {
-				return aktprovider.GatewayError("query provider status", err)
+				return aktprovider.GatewayErrorForProvider("query provider status", providerAddr.String(), err)
 			}
 
 			return printJSON(cmd, status)

--- a/internal/cli/provider/commands.go
+++ b/internal/cli/provider/commands.go
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 }
 
 func statusCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "status [provider-addr]",
 		Short: "Query provider status",
 		Long:  "Query the live status of a provider including cluster capacity, active leases, and bid engine status.",
@@ -83,6 +83,10 @@ func statusCmd() *cobra.Command {
   akt provider status --provider akash1...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			timeout, _ := cmd.Flags().GetDuration(flagdefs.FlagTimeout)
+			if timeout <= 0 {
+				return fmt.Errorf("--timeout must be greater than zero")
+			}
 			if cmd.Flags().Changed(flagdefs.FlagAuthType) {
 				return fmt.Errorf("--auth-type does not apply to public provider status")
 			}
@@ -92,7 +96,12 @@ func statusCmd() *cobra.Command {
 				return err
 			}
 
-			cl, err := aktprovider.NewPublicGatewayClient(ctx, providerAddr, providerURL)
+			cl, err := aktprovider.NewPublicGatewayClient(
+				ctx,
+				providerAddr,
+				providerURL,
+				aktprovider.WithOneShotTimeout(timeout),
+			)
 			if err != nil {
 				return err
 			}
@@ -105,6 +114,10 @@ func statusCmd() *cobra.Command {
 			return printJSON(cmd, status)
 		},
 	}
+
+	cmd.Flags().Duration(flagdefs.FlagTimeout, 30*time.Second, "Maximum time to wait for the provider status response")
+
+	return cmd
 }
 
 func leaseStatusCmd() *cobra.Command {

--- a/internal/cli/provider/commands_test.go
+++ b/internal/cli/provider/commands_test.go
@@ -6,10 +6,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -545,6 +548,61 @@ func TestStatusUsesPublicGatewayWithoutWallet(t *testing.T) {
 	}
 	if requests != 1 {
 		t.Fatalf("provider status requests = %d, want 1", requests)
+	}
+}
+
+func TestStatusTimeoutConfiguresGatewayBoundary(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	root := Commands()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"status", testProviderAddr,
+		"--provider-url", srv.URL,
+		"--timeout", "40ms",
+	})
+
+	started := time.Now()
+	err := root.Execute()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("provider status timeout error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("provider status timeout took %s, want the configured deadline", elapsed)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("provider status requests = %d, want 1", got)
+	}
+}
+
+func TestStatusRejectsNonPositiveTimeoutBeforeNetwork(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer srv.Close()
+
+	root := Commands()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"status", testProviderAddr,
+		"--provider-url", srv.URL,
+		"--timeout", "0s",
+	})
+
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--timeout must be greater than zero") {
+		t.Fatalf("provider status timeout error = %v", err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("invalid timeout made %d requests, want 0", got)
 	}
 }
 

--- a/internal/cli/provider/commands_test.go
+++ b/internal/cli/provider/commands_test.go
@@ -565,6 +565,23 @@ func TestStatusRejectsAuthenticationFlag(t *testing.T) {
 	}
 }
 
+func TestStatusFailureIncludesExactChainFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "offline", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	const provider = "akash1errud3wyc0pvrs9lh67mewa6hxut0d44pfj6vh"
+	root := Commands()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"status", provider, "--provider-url", srv.URL})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "akt query provider "+provider) {
+		t.Fatalf("provider status error = %v", err)
+	}
+}
+
 func TestAuthenticatedGatewayRequiresDefaultAccountBeforeRequest(t *testing.T) {
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -35,6 +36,7 @@ import (
 	aktclient "pkg.akt.dev/akt/internal/client"
 	"pkg.akt.dev/akt/internal/cliutil"
 	aktcodec "pkg.akt.dev/akt/internal/codec"
+	aktconsole "pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
 	"pkg.akt.dev/akt/internal/glyphs"
 	aktkeyring "pkg.akt.dev/akt/internal/keyring"
@@ -281,6 +283,9 @@ the deployment is created.`,
 				applyTransactionDefaults(cmd, rc)
 				if err := applyProviderDefaults(cmd, rc); err != nil {
 					return err
+				}
+				if rc.AuthMethod == aktctx.AuthMethodConsoleAPI && rc.ConsoleAPIKey != "" {
+					cmd.SetContext(withConsoleDefaultOwnerResolver(cmd.Context(), rc))
 				}
 			}
 			if resolved && cmd.Flags().Lookup(flagdefs.FlagOffline) != nil {
@@ -620,6 +625,10 @@ func requiresConfig(cmd *cobra.Command) bool {
 	// a network fetch before linting a local file would be backwards.
 	case strings.HasPrefix(path, "akt sdl"):
 		return false
+	// These are the explicit remedies for missing configuration. Running a
+	// bootstrap warning before them makes a successful creation look failed.
+	case path == "akt context create", path == "akt context network create":
+		return false
 	}
 
 	return true
@@ -682,13 +691,10 @@ func localIdentityMode(cmd *cobra.Command) aktclient.LocalIdentityMode {
 			return aktclient.LocalIdentityOnDemand
 		}
 		return aktclient.LocalIdentityRequired
-	// MCP reads defer identity until an owner-defaulting tool is invoked.
-	// Explicitly enabling writes opts a keyring context into eager resolution;
-	// MustResolveAndInit keeps Console-only contexts keyring-free.
+	// MCP reads defer identity until an owner-defaulting tool is invoked. Write
+	// registration is additive: an account that does not exist on-chain yet
+	// must not prevent the server from exposing healthy read-only tools.
 	case strings.HasPrefix(path, "akt mcp"):
-		if boolFlag(cmd, "enable-writes") {
-			return aktclient.LocalIdentityRequired
-		}
 		return aktclient.LocalIdentityOnDemand
 	// Unsigned construction and simulation accept a bech32 signer without a
 	// local key. A signer name resolves through the deferred keyring later.
@@ -704,6 +710,32 @@ func localIdentityMode(cmd *cobra.Command) aktclient.LocalIdentityMode {
 	}
 
 	return aktclient.LocalIdentityRequired
+}
+
+func withConsoleDefaultOwnerResolver(ctx context.Context, rc *aktctx.Context) context.Context {
+	resolver := chaincli.DefaultOwnerResolver(func(callCtx context.Context) (string, error) {
+		cl := aktconsole.New(rc.ConsoleAPIURL, rc.ConsoleAPIKey)
+		user, err := cl.GetUser(callCtx)
+		if err != nil {
+			return "", fmt.Errorf("resolve Console managed wallet user: %w", err)
+		}
+		if strings.TrimSpace(user.ID) == "" {
+			return "", errors.New("resolve Console managed wallet user: response omitted user ID")
+		}
+		wallets, err := cl.ListWallets(callCtx, user.ID)
+		if err != nil {
+			return "", fmt.Errorf("resolve Console managed wallets: %w", err)
+		}
+		for _, wallet := range wallets {
+			if address := strings.TrimSpace(wallet.Address); address != "" {
+				return address, nil
+			}
+		}
+
+		return "", errors.New("Console account has no managed wallet address")
+	})
+
+	return context.WithValue(ctx, chaincli.ContextTypeDefaultOwnerResolver, resolver)
 }
 
 // rawTxAuthError is the execution boundary between raw Cosmos/Akash

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -732,7 +732,7 @@ func withConsoleDefaultOwnerResolver(ctx context.Context, rc *aktctx.Context) co
 			}
 		}
 
-		return "", errors.New("Console account has no managed wallet address")
+		return "", errors.New("console account has no managed wallet address")
 	})
 
 	return context.WithValue(ctx, chaincli.ContextTypeDefaultOwnerResolver, resolver)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -381,9 +381,11 @@ the deployment is created.`,
 		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
 			// Close the action logger opened in PersistentPreRunE (SPEC §5.6).
 			if l := cliutil.ActionLogFromContext(cmd.Context()); l != nil {
-				return l.Close()
+				if err := l.Close(); err != nil {
+					return err
+				}
 			}
-			return nil
+			return cliconsole.PrintNextStep(cmd)
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cli/root_boundaries_test.go
+++ b/internal/cli/root_boundaries_test.go
@@ -20,9 +20,16 @@ import (
 func TestRootConfigurationBoundaries(t *testing.T) {
 	root := &cobra.Command{Use: "akt"}
 
-	for _, name := range []string{"version", "completion", "monitor", "mcp", "sdl"} {
-		cmd := &cobra.Command{Use: name}
-		root.AddCommand(cmd)
+	for _, name := range []string{"version", "completion", "monitor", "mcp", "sdl", "context create", "context network create"} {
+		parts := strings.Split(name, " ")
+		cmd := &cobra.Command{Use: parts[len(parts)-1]}
+		if len(parts) == 1 {
+			root.AddCommand(cmd)
+		} else {
+			parent := &cobra.Command{Use: parts[0]}
+			root.AddCommand(parent)
+			parent.AddCommand(cmd)
+		}
 		if requiresConfig(cmd) {
 			t.Errorf("%s unexpectedly requires bootstrap configuration", name)
 		}
@@ -171,6 +178,17 @@ func TestLocalIdentityDryRunsDoNotOpenSigningKeyrings(t *testing.T) {
 	root.AddCommand(workflow)
 	if got := localIdentityMode(workflow); got != aktclient.LocalIdentityNone {
 		t.Fatalf("workflow dry-run identity mode = %v, want none", got)
+	}
+}
+
+func TestMCPWriteOptInKeepsIdentityOnDemand(t *testing.T) {
+	root := &cobra.Command{Use: "akt"}
+	mcpCmd := &cobra.Command{Use: "mcp"}
+	mcpCmd.Flags().Bool("enable-writes", true, "")
+	root.AddCommand(mcpCmd)
+
+	if got := localIdentityMode(mcpCmd); got != aktclient.LocalIdentityOnDemand {
+		t.Fatalf("MCP write identity mode = %v, want on demand", got)
 	}
 }
 

--- a/internal/cli/root_boundaries_test.go
+++ b/internal/cli/root_boundaries_test.go
@@ -4,7 +4,9 @@ import (
 	flagdefs "pkg.akt.dev/akt/internal/flags"
 
 	"bytes"
+	"context"
 	"encoding/json"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -12,10 +14,29 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"pkg.akt.dev/akt/internal/actionlog"
 	aktclient "pkg.akt.dev/akt/internal/client"
+	"pkg.akt.dev/akt/internal/cliutil"
 	aktctx "pkg.akt.dev/akt/internal/context"
 	"pkg.akt.dev/akt/internal/output"
 )
+
+func TestRootPostRunReportsActionLogCloseFailure(t *testing.T) {
+	logger, err := actionlog.Open(filepath.Join(t.TempDir(), "actions.log"))
+	if err != nil {
+		t.Fatalf("open action log: %v", err)
+	}
+	if err := logger.Close(); err != nil {
+		t.Fatalf("close action log: %v", err)
+	}
+
+	root := NewRootCmd(BuildInfo{})
+	root.SetContext(cliutil.WithActionLog(context.Background(), logger))
+	err = root.PersistentPostRunE(root, nil)
+	if err == nil || !strings.Contains(err.Error(), "file already closed") {
+		t.Fatalf("root post-run error = %v, want action-log close failure", err)
+	}
+}
 
 func TestRootConfigurationBoundaries(t *testing.T) {
 	root := &cobra.Command{Use: "akt"}

--- a/internal/cli/root_context_selection_test.go
+++ b/internal/cli/root_context_selection_test.go
@@ -113,11 +113,18 @@ func TestRootActionLogUsesSelectedContext(t *testing.T) {
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/v1/deployments/42" {
+		if r.URL.Path != "/v1/deployments/42" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		if got := r.Header.Get("x-api-key"); got != "staging-key" {
 			t.Errorf("x-api-key = %q, want staging-key", got)
+		}
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"42"},"state":"active"}}}`))
+			return
+		}
+		if r.Method != http.MethodDelete {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		_, _ = w.Write([]byte(`{"data":{"success":true}}`))
 	}))

--- a/internal/cli/workflow/commands.go
+++ b/internal/cli/workflow/commands.go
@@ -118,14 +118,7 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 				if rc == nil || rc.AuthMethod == aktctx.AuthMethodConsoleAPI || depositFlag == nil {
 					return nil
 				}
-				parsed, parseErr := transport.ParseDeposit(depositFlag.Value.String())
-				if parseErr != nil {
-					// RunE owns the user-facing deposit validation. PreRunE only
-					// decides whether an otherwise-valid auto value needs a query
-					// client before planning.
-					return nil //nolint:nilerr // the parsing error is returned by RunE
-				}
-				if !parsed.Auto {
+				if !chainDryRunNeedsDepositQuery(depositFlag.Value.String()) {
 					return nil
 				}
 
@@ -295,6 +288,11 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 	return cmd
 }
 
+func chainDryRunNeedsDepositQuery(raw string) bool {
+	parsed, err := transport.ParseDeposit(raw)
+	return err == nil && parsed.Auto
+}
+
 func resolveDryRunParams(
 	cmd *cobra.Command,
 	params map[string]any,
@@ -462,11 +460,7 @@ func executeWorkflow(
 	engine := wf.NewEngine(registry, logger)
 
 	state, runErr := engine.Run(cmd.Context(), rtDef, account, params)
-	if runErr == nil {
-		if readinessErr := enrichDeployCompletion(cmd.Context(), state, rc, consoleClient, providerCl); readinessErr != nil {
-			runErr = readinessErr
-		}
-	}
+	runErr = enrichSuccessfulDeploy(cmd.Context(), state, rc, consoleClient, providerCl, runErr)
 	recovery := deployRecoveryAdvice(state, runErr)
 
 	// Record the outcome locally before reporting it (SPEC §6.6). A one-shot
@@ -491,6 +485,21 @@ func executeWorkflow(
 	}
 
 	return renderErr
+}
+
+func enrichSuccessfulDeploy(
+	ctx context.Context,
+	state *wf.RunState,
+	rc *aktctx.Context,
+	cc *console.Client,
+	provider steps.ProviderClient,
+	runErr error,
+) error {
+	if runErr != nil {
+		return runErr
+	}
+
+	return enrichDeployCompletion(ctx, state, rc, cc, provider)
 }
 
 type deploymentServiceStatus struct {

--- a/internal/cli/workflow/commands.go
+++ b/internal/cli/workflow/commands.go
@@ -119,7 +119,13 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 					return nil
 				}
 				parsed, parseErr := transport.ParseDeposit(depositFlag.Value.String())
-				if parseErr != nil || !parsed.Auto {
+				if parseErr != nil {
+					// RunE owns the user-facing deposit validation. PreRunE only
+					// decides whether an otherwise-valid auto value needs a query
+					// client before planning.
+					return nil //nolint:nilerr // the parsing error is returned by RunE
+				}
+				if !parsed.Auto {
 					return nil
 				}
 
@@ -569,7 +575,7 @@ func enrichDeployCompletion(
 	var fetch readinessFetcher
 	if rc.AuthMethod == aktctx.AuthMethodConsoleAPI {
 		if cc == nil {
-			return errors.New("Console readiness client is unavailable")
+			return errors.New("console readiness client is unavailable")
 		}
 		fetch = func(callCtx context.Context) (json.RawMessage, error) {
 			detail, getErr := cc.GetDeployment(callCtx, strconv.FormatUint(dseq, 10))
@@ -623,7 +629,7 @@ func mergeCompletionOutput(state *wf.RunState, completion map[string]any) {
 
 func consoleRuntimeStatus(detail *console.DeploymentDetail) (json.RawMessage, error) {
 	if detail == nil {
-		return nil, errors.New("Console deployment status is empty")
+		return nil, errors.New("console deployment status is empty")
 	}
 	services := make(map[string]json.RawMessage)
 	for _, lease := range detail.Leases {
@@ -824,7 +830,7 @@ func printPlan(out io.Writer, rtDef *wf.WorkflowDef, params map[string]any, rail
 		} else if step.Msg != "" {
 			fmt.Fprintf(&rendered, " -> %s", step.Msg)
 		}
-		if step.Action != "" && !(rail == transport.KindConsole && step.Type == wf.StepProvider) {
+		if step.Action != "" && (rail != transport.KindConsole || step.Type != wf.StepProvider) {
 			fmt.Fprintf(&rendered, " -> %s", step.Action)
 		}
 		if step.OnError != "" {

--- a/internal/cli/workflow/commands.go
+++ b/internal/cli/workflow/commands.go
@@ -4,6 +4,7 @@
 package workflow
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,6 +28,7 @@ import (
 	"pkg.akt.dev/akt/internal/output"
 	"pkg.akt.dev/akt/internal/transport"
 	wf "pkg.akt.dev/akt/internal/workflow"
+	"pkg.akt.dev/akt/internal/workflow/adapters"
 	"pkg.akt.dev/akt/internal/workflow/builtin"
 	"pkg.akt.dev/akt/internal/workflow/steps"
 )
@@ -108,9 +110,20 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 			capability.AnnotationKey: string(capability.ChainTx) + "|" + string(capability.Console),
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			// Dry runs never need clients.
+			// Dry runs only discover a read client when the chain rail must
+			// resolve an auto deposit from live deployment parameters.
 			if dryRun, _ := cmd.Flags().GetBool(flagdefs.FlagDryRun); dryRun {
-				return nil
+				rc := resolveContext(mgrFn, ctxNameFn)
+				depositFlag := cmd.Flags().Lookup(flagdefs.FlagDeposit)
+				if rc == nil || rc.AuthMethod == aktctx.AuthMethodConsoleAPI || depositFlag == nil {
+					return nil
+				}
+				parsed, parseErr := transport.ParseDeposit(depositFlag.Value.String())
+				if parseErr != nil || !parsed.Auto {
+					return nil
+				}
+
+				return chaincli.QueryPersistentPreRunE(cmd, args)
 			}
 
 			// Chain client discovery only applies when running under the
@@ -207,11 +220,15 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 			jsonl := outputFormat(cmd) == outputJSONL
 
 			if dryRun {
+				params, err = resolveDryRunParams(cmd, params, mgrFn, ctxNameFn)
+				if err != nil {
+					return err
+				}
 				if jsonl {
-					return emitDryRunJSONL(out, rtDef)
+					return emitDryRunJSONL(out, rtDef, params)
 				}
 
-				if err := printPlan(out, rtDef, params); err != nil {
+				if err := printPlan(out, rtDef, params, workflowRail(mgrFn, ctxNameFn)); err != nil {
 					return err
 				}
 				return writeWorkflowReport(out, "\nDry run — no transactions broadcast.\n", "dry-run")
@@ -220,7 +237,7 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 			// During execution, keep stdout pure in JSONL mode; other modes
 			// retain the human plan before step results.
 			if !jsonl {
-				if err := printPlan(out, rtDef, params); err != nil {
+				if err := printPlan(out, rtDef, params, workflowRail(mgrFn, ctxNameFn)); err != nil {
 					return err
 				}
 			}
@@ -272,6 +289,59 @@ func commandFromDef(def *wf.WorkflowDef, homeFn func() string, ctxNameFn func() 
 	return cmd
 }
 
+func resolveDryRunParams(
+	cmd *cobra.Command,
+	params map[string]any,
+	mgrFn func() *aktctx.Manager,
+	ctxNameFn func() string,
+) (map[string]any, error) {
+	raw, ok := params[flagdefs.FlagDeposit].(string)
+	if !ok {
+		return params, nil
+	}
+	rc := resolveContext(mgrFn, ctxNameFn)
+	if rc == nil {
+		// Preserve the deprecated standalone Commands API, which intentionally
+		// has no rail. Production commands always have a resolved manager.
+		return params, nil
+	}
+
+	parsed, err := transport.ParseDeposit(raw)
+	if err != nil {
+		return nil, err
+	}
+	resolved := ""
+	if rc.AuthMethod == aktctx.AuthMethodConsoleAPI {
+		resolved, err = parsed.RailValue(transport.KindConsole)
+		if err == nil && parsed.Auto {
+			err = fmt.Errorf("deposit %q: console-api deployments require an explicit USD amount of at least $%.2f", raw, transport.MinConsoleDepositUSD)
+		}
+		if err == nil && parsed.USD < transport.MinConsoleDepositUSD {
+			err = fmt.Errorf("deposit must be at least $%.2f on the Console rail (got $%.2f)", transport.MinConsoleDepositUSD, parsed.USD)
+		}
+	} else {
+		resolved, err = parsed.RailValue(transport.KindChain)
+		if err == nil && parsed.Auto {
+			cl, clientErr := chaincli.LightClientFromContext(cmd.Context())
+			if clientErr != nil {
+				return nil, fmt.Errorf("resolve chain auto deposit: %w", clientErr)
+			}
+			resolved, err = adapters.ResolveChainDepositValue(cmd.Context(), cl, resolved)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	copyParams := make(map[string]any, len(params))
+	for key, value := range params {
+		copyParams[key] = value
+	}
+	copyParams[flagdefs.FlagDeposit] = resolved
+
+	return copyParams, nil
+}
+
 func sortedParamNames(params map[string]wf.ParamDef) []string {
 	names := make([]string, 0, len(params))
 	for name := range params {
@@ -308,8 +378,9 @@ func executeWorkflow(
 	}
 
 	var (
-		chainCl    steps.ChainClient
-		providerCl steps.ProviderClient
+		chainCl       steps.ChainClient
+		providerCl    steps.ProviderClient
+		consoleClient *console.Client
 	)
 
 	account := rc.DefaultAccount
@@ -325,6 +396,7 @@ func executeWorkflow(
 
 		cc := console.New(rc.ConsoleAPIURL, rc.ConsoleAPIKey).
 			WithActionLog(cliutil.ActionLogFromContext(cmd.Context()))
+		consoleClient = cc
 
 		// Chain queries still go directly to the chain when a client is
 		// available (SPEC §7.4); otherwise the console transport falls back
@@ -384,6 +456,11 @@ func executeWorkflow(
 	engine := wf.NewEngine(registry, logger)
 
 	state, runErr := engine.Run(cmd.Context(), rtDef, account, params)
+	if runErr == nil {
+		if readinessErr := enrichDeployCompletion(cmd.Context(), state, rc, consoleClient, providerCl); readinessErr != nil {
+			runErr = readinessErr
+		}
+	}
 	recovery := deployRecoveryAdvice(state, runErr)
 
 	// Record the outcome locally before reporting it (SPEC §6.6). A one-shot
@@ -408,6 +485,222 @@ func executeWorkflow(
 	}
 
 	return renderErr
+}
+
+type deploymentServiceStatus struct {
+	Available int      `json:"available"`
+	Total     int      `json:"total"`
+	URIs      []string `json:"uris"`
+}
+
+type deploymentRuntimeStatus struct {
+	Services map[string]deploymentServiceStatus `json:"services"`
+}
+
+type readinessFetcher func(context.Context) (json.RawMessage, error)
+
+func enrichDeployCompletion(
+	ctx context.Context,
+	state *wf.RunState,
+	rc *aktctx.Context,
+	cc *console.Client,
+	provider steps.ProviderClient,
+) error {
+	if state == nil || state.Workflow != "deploy" || rc == nil {
+		return nil
+	}
+	readyTimeoutValue, hasReadiness := state.Params["ready-timeout"]
+	if !hasReadiness {
+		// A user workflow named deploy is allowed to define another lifecycle.
+		return nil
+	}
+	created := state.Steps["create-deployment"]
+	if created == nil {
+		return errors.New("prepare deployment readiness: create-deployment result is missing")
+	}
+	dseq, err := workflowOutputUint64(created.Output, "dseq")
+	if err != nil {
+		return fmt.Errorf("prepare deployment readiness: %w", err)
+	}
+	providerAddress := workflowOutputString(state.Steps["create-lease"], "provider")
+	if providerAddress == "" {
+		providerAddress = workflowOutputString(state.Steps["select-bid"], "provider")
+	}
+
+	completion := map[string]any{
+		"dseq":     strconv.FormatUint(dseq, 10),
+		"provider": providerAddress,
+		"ready":    false,
+	}
+	if price := state.StepOutput("select-bid", "price"); price != nil {
+		completion["price"] = price
+	}
+	if rc.AuthMethod == aktctx.AuthMethodConsoleAPI {
+		completion["auto_top_up"] = "daily"
+		if cc != nil {
+			if link := cc.DeploymentURL(strconv.FormatUint(dseq, 10)); link != "" {
+				completion["console_url"] = link
+			}
+		}
+	}
+
+	noWait, _ := state.Params["no-wait-active"].(bool)
+	if noWait {
+		completion["readiness"] = "not-waited"
+		mergeCompletionOutput(state, completion)
+		state.SetStepResult("wait-for-ready", &wf.StepResult{
+			Name:   "wait-for-ready",
+			Type:   wf.StepWait,
+			Status: "skipped",
+			Output: completion,
+		})
+		return nil
+	}
+
+	timeoutText, ok := readyTimeoutValue.(string)
+	if !ok {
+		return fmt.Errorf("invalid ready-timeout %v", readyTimeoutValue)
+	}
+	timeout, err := time.ParseDuration(timeoutText)
+	if err != nil || timeout <= 0 {
+		return fmt.Errorf("invalid ready-timeout %q", timeoutText)
+	}
+
+	var fetch readinessFetcher
+	if rc.AuthMethod == aktctx.AuthMethodConsoleAPI {
+		if cc == nil {
+			return errors.New("Console readiness client is unavailable")
+		}
+		fetch = func(callCtx context.Context) (json.RawMessage, error) {
+			detail, getErr := cc.GetDeployment(callCtx, strconv.FormatUint(dseq, 10))
+			if getErr != nil {
+				return nil, getErr
+			}
+
+			return consoleRuntimeStatus(detail)
+		}
+	} else {
+		if provider == nil || providerAddress == "" {
+			return errors.New("provider readiness client or selected provider is unavailable")
+		}
+		fetch = func(callCtx context.Context) (json.RawMessage, error) {
+			return provider.LeaseStatus(callCtx, providerAddress, dseq)
+		}
+	}
+
+	uris, raw, readinessErr := waitForDeploymentReadiness(ctx, timeout, fetch)
+	completion["uris"] = uris
+	completion["ready"] = readinessErr == nil
+	mergeCompletionOutput(state, completion)
+	result := &wf.StepResult{
+		Name:      "wait-for-ready",
+		Type:      wf.StepWait,
+		Output:    completion,
+		RawResult: raw,
+		Status:    "success",
+	}
+	if readinessErr != nil {
+		result.Status = "failed"
+		result.Error = readinessErr.Error()
+	}
+	state.SetStepResult(result.Name, result)
+
+	return readinessErr
+}
+
+func mergeCompletionOutput(state *wf.RunState, completion map[string]any) {
+	result := state.Steps["display-result"]
+	if result == nil {
+		return
+	}
+	if result.Output == nil {
+		result.Output = make(map[string]any)
+	}
+	for key, value := range completion {
+		result.Output[key] = value
+	}
+}
+
+func consoleRuntimeStatus(detail *console.DeploymentDetail) (json.RawMessage, error) {
+	if detail == nil {
+		return nil, errors.New("Console deployment status is empty")
+	}
+	services := make(map[string]json.RawMessage)
+	for _, lease := range detail.Leases {
+		if lease.Status == nil || len(lease.Status.Services) == 0 {
+			continue
+		}
+		var current map[string]json.RawMessage
+		if err := json.Unmarshal(lease.Status.Services, &current); err != nil {
+			return nil, fmt.Errorf("decode Console lease services: %w", err)
+		}
+		for name, status := range current {
+			services[name] = status
+		}
+	}
+
+	return json.Marshal(map[string]any{"services": services})
+}
+
+func waitForDeploymentReadiness(
+	ctx context.Context,
+	timeout time.Duration,
+	fetch readinessFetcher,
+) (map[string][]string, json.RawMessage, error) {
+	deadlineCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var (
+		lastRaw json.RawMessage
+		lastErr error
+	)
+	for {
+		raw, err := fetch(deadlineCtx)
+		if err == nil {
+			lastRaw = raw
+			ready, uris, decodeErr := deploymentReady(raw)
+			if decodeErr == nil && ready {
+				return uris, raw, nil
+			}
+			lastErr = decodeErr
+		} else {
+			lastErr = err
+		}
+
+		timer := time.NewTimer(2 * time.Second)
+		select {
+		case <-deadlineCtx.Done():
+			timer.Stop()
+			if lastErr != nil {
+				return nil, lastRaw, fmt.Errorf("deployment did not become ready within %s: %w", timeout, lastErr)
+			}
+			return nil, lastRaw, fmt.Errorf("deployment did not become ready within %s", timeout)
+		case <-timer.C:
+		}
+	}
+}
+
+func deploymentReady(raw json.RawMessage) (bool, map[string][]string, error) {
+	var status deploymentRuntimeStatus
+	if err := json.Unmarshal(raw, &status); err != nil {
+		return false, nil, fmt.Errorf("decode deployment service status: %w", err)
+	}
+	if len(status.Services) == 0 {
+		return false, nil, nil
+	}
+
+	uris := make(map[string][]string)
+	for name, service := range status.Services {
+		if service.Total <= 0 || service.Available < service.Total {
+			return false, nil, nil
+		}
+		if len(service.URIs) > 0 {
+			uris[name] = append([]string(nil), service.URIs...)
+		}
+
+	}
+
+	return true, uris, nil
 }
 
 func newBidWaitProgressReporter(report func(string)) steps.WaitProgressReporter {
@@ -464,6 +757,18 @@ func resolveContext(mgrFn func() *aktctx.Manager, ctxNameFn func() string) *aktc
 	return rc
 }
 
+func workflowRail(mgrFn func() *aktctx.Manager, ctxNameFn func() string) transport.Kind {
+	rc := resolveContext(mgrFn, ctxNameFn)
+	if rc == nil {
+		return ""
+	}
+	if rc.AuthMethod == aktctx.AuthMethodConsoleAPI {
+		return transport.KindConsole
+	}
+
+	return transport.KindChain
+}
+
 // filterProviderSteps returns a copy of def without provider-type steps,
 // noting each skipped step on w. Used for console-api auth, where manifest
 // submission is handled by the Console API (SPEC §7.4).
@@ -494,11 +799,14 @@ func filterProviderSteps(def *wf.WorkflowDef, w io.Writer) (*wf.WorkflowDef, err
 }
 
 // printPlan renders the workflow execution plan (name, params, steps).
-func printPlan(out io.Writer, rtDef *wf.WorkflowDef, params map[string]any) error {
+func printPlan(out io.Writer, rtDef *wf.WorkflowDef, params map[string]any, rail transport.Kind) error {
 	var rendered strings.Builder
 
 	fmt.Fprintf(&rendered, "Workflow: %s (v%d)\n", rtDef.Name, rtDef.Version)
 	fmt.Fprintf(&rendered, "  %s\n\n", rtDef.Description)
+	if rail != "" {
+		fmt.Fprintf(&rendered, "Rail: %s\n\n", rail)
+	}
 
 	fmt.Fprintln(&rendered, "Parameters:")
 	for k, v := range params {
@@ -509,10 +817,14 @@ func printPlan(out io.Writer, rtDef *wf.WorkflowDef, params map[string]any) erro
 	fmt.Fprintf(&rendered, "Steps (%d):\n", len(rtDef.Steps))
 	for i, step := range rtDef.Steps {
 		fmt.Fprintf(&rendered, "  %d. [%s] %s", i+1, step.Type, step.Name)
-		if step.Msg != "" {
+		if rail == transport.KindConsole && step.Msg != "" {
+			fmt.Fprintf(&rendered, " -> %s", consolePlanAction(step.Msg))
+		} else if rail == transport.KindConsole && step.Type == wf.StepProvider {
+			fmt.Fprint(&rendered, " -> handled by Console during lease creation")
+		} else if step.Msg != "" {
 			fmt.Fprintf(&rendered, " -> %s", step.Msg)
 		}
-		if step.Action != "" {
+		if step.Action != "" && !(rail == transport.KindConsole && step.Type == wf.StepProvider) {
 			fmt.Fprintf(&rendered, " -> %s", step.Action)
 		}
 		if step.OnError != "" {
@@ -525,6 +837,21 @@ func printPlan(out io.Writer, rtDef *wf.WorkflowDef, params map[string]any) erro
 	}
 
 	return writeWorkflowReport(out, rendered.String(), "plan")
+}
+
+func consolePlanAction(msg string) string {
+	switch msg {
+	case "deployment.MsgCreateDeployment":
+		return "Console API create deployment"
+	case "deployment.MsgUpdateDeployment":
+		return "Console API update deployment"
+	case "deployment.MsgCloseDeployment":
+		return "Console API close deployment"
+	case "market.MsgCreateLease":
+		return "Console API create lease"
+	default:
+		return "unsupported Console action " + msg
+	}
 }
 
 // printResults renders per-step outcomes and the overall workflow status in
@@ -552,6 +879,7 @@ func printResults(out io.Writer, state *wf.RunState, runErr error, recovery *wor
 
 	if runErr == nil {
 		fmt.Fprintf(&rendered, "\nWorkflow %q completed successfully.\n", state.Workflow)
+		renderDeployNext(&rendered, state)
 	} else if recovery != nil {
 		fmt.Fprintln(&rendered, "\nPartial deployment state:")
 		fmt.Fprintf(&rendered, "  DSEQ: %d\n", recovery.DSeq)
@@ -566,6 +894,63 @@ func printResults(out io.Writer, state *wf.RunState, runErr error, recovery *wor
 	}
 
 	return writeWorkflowReport(out, rendered.String(), "pretty")
+}
+
+func renderDeployNext(rendered *strings.Builder, state *wf.RunState) {
+	if state == nil || state.Workflow != "deploy" {
+		return
+	}
+	result := state.Steps["display-result"]
+	if result == nil || result.Output == nil {
+		return
+	}
+	dseq := strings.TrimSpace(fmt.Sprint(result.Output["dseq"]))
+	if dseq == "" || dseq == "<nil>" {
+		return
+	}
+
+	fmt.Fprintln(rendered, "\nDeployment:")
+	fmt.Fprintf(rendered, "  DSEQ: %s\n", dseq)
+	if provider := strings.TrimSpace(fmt.Sprint(result.Output["provider"])); provider != "" && provider != "<nil>" {
+		fmt.Fprintf(rendered, "  Provider: %s\n", provider)
+	}
+	if ready, ok := result.Output["ready"].(bool); ok {
+		if ready {
+			fmt.Fprintln(rendered, "  Ready: yes")
+		} else if result.Output["readiness"] == "not-waited" {
+			fmt.Fprintln(rendered, "  Ready: not checked")
+		}
+	}
+	if uris, ok := result.Output["uris"].(map[string][]string); ok {
+		services := make([]string, 0, len(uris))
+		for service := range uris {
+			services = append(services, service)
+		}
+		sort.Strings(services)
+		for _, service := range services {
+			for _, uri := range uris[service] {
+				fmt.Fprintf(rendered, "  URI (%s): %s\n", service, uri)
+			}
+		}
+	}
+	if link := strings.TrimSpace(fmt.Sprint(result.Output["console_url"])); link != "" && link != "<nil>" {
+		fmt.Fprintf(rendered, "  Console: %s\n", link)
+	}
+
+	fmt.Fprintln(rendered, "\nNext:")
+	if _, consoleRail := result.Output["auto_top_up"]; consoleRail {
+		fmt.Fprintf(rendered, "  Status:  akt console status %s\n", dseq)
+		fmt.Fprintf(rendered, "  Logs:    akt console logs %s\n", dseq)
+		fmt.Fprintln(rendered, "  Auto top-up: enabled daily")
+		fmt.Fprintf(rendered, "  Disable: akt console deployment settings %s false\n", dseq)
+	} else {
+		provider := strings.TrimSpace(fmt.Sprint(result.Output["provider"]))
+		if provider != "" && provider != "<nil>" {
+			fmt.Fprintf(rendered, "  Status:  akt provider lease-status %s --provider %s\n", dseq, provider)
+			fmt.Fprintf(rendered, "  Logs:    akt provider lease-logs %s --provider %s\n", dseq, provider)
+		}
+	}
+	fmt.Fprintf(rendered, "  Close:   akt close %s\n", dseq)
 }
 
 type workflowRecovery struct {
@@ -600,7 +985,8 @@ func deployRecoveryAdvice(state *wf.RunState, runErr error) *workflowRecovery {
 		Provider: provider,
 		Cleanup:  fmt.Sprintf("akt close %d", dseq),
 	}
-	if provider != "" {
+	manifest := state.Steps["send-manifest"]
+	if provider != "" && manifest != nil && manifest.Status == "failed" {
 		if sdlPath, ok := state.Params["sdl-file"].(string); ok && strings.TrimSpace(sdlPath) != "" {
 			recovery.Recovery = fmt.Sprintf(
 				"akt provider send-manifest %s --dseq %d --provider %s",
@@ -674,16 +1060,17 @@ type jsonlTx struct {
 
 // jsonlLine is one JSONL step line (SPEC §2.3.8).
 type jsonlLine struct {
-	Workflow string    `json:"workflow"`
-	ID       string    `json:"id"`
-	Step     string    `json:"step"`
-	Result   string    `json:"result"`
-	Errors   []string  `json:"errors"`
-	Txs      []jsonlTx `json:"txs"`
-	DSeq     uint64    `json:"dseq,omitempty"`
-	Provider string    `json:"provider,omitempty"`
-	Recovery string    `json:"recovery,omitempty"`
-	Cleanup  string    `json:"cleanup,omitempty"`
+	Workflow string         `json:"workflow"`
+	ID       string         `json:"id"`
+	Step     string         `json:"step"`
+	Result   string         `json:"result"`
+	Errors   []string       `json:"errors"`
+	Txs      []jsonlTx      `json:"txs"`
+	Outputs  map[string]any `json:"outputs,omitempty"`
+	DSeq     uint64         `json:"dseq,omitempty"`
+	Provider string         `json:"provider,omitempty"`
+	Recovery string         `json:"recovery,omitempty"`
+	Cleanup  string         `json:"cleanup,omitempty"`
 }
 
 // emitJSONL writes one JSONL line per completed step (SPEC §2.3.8).
@@ -702,6 +1089,7 @@ func emitJSONL(out io.Writer, state *wf.RunState, recovery *workflowRecovery) er
 			Step:     sr.Name,
 			Errors:   []string{},
 			Txs:      []jsonlTx{},
+			Outputs:  sr.Output,
 		}
 
 		switch sr.Status {
@@ -765,7 +1153,7 @@ func (w completeWriter) Write(data []byte) (int, error) {
 // emitDryRunJSONL renders the validated plan without executing or discovering
 // clients. Every line shares one run ID so consumers can treat it like an
 // execution stream, while "planned" distinguishes it from completed work.
-func emitDryRunJSONL(out io.Writer, def *wf.WorkflowDef) error {
+func emitDryRunJSONL(out io.Writer, def *wf.WorkflowDef, params map[string]any) error {
 	enc := json.NewEncoder(completeWriter{writer: out})
 	runID := wf.GenerateWorkflowID()
 
@@ -777,6 +1165,11 @@ func emitDryRunJSONL(out io.Writer, def *wf.WorkflowDef) error {
 			Result:   "planned",
 			Errors:   []string{},
 			Txs:      []jsonlTx{},
+		}
+		if step.Name == "create-deployment" {
+			if deposit, ok := params[flagdefs.FlagDeposit]; ok {
+				line.Outputs = map[string]any{flagdefs.FlagDeposit: deposit}
+			}
 		}
 		if err := enc.Encode(line); err != nil {
 			return fmt.Errorf("render workflow dry-run JSONL: %w", err)

--- a/internal/cli/workflow/commands_test.go
+++ b/internal/cli/workflow/commands_test.go
@@ -494,6 +494,13 @@ func TestConsoleDryRunResolvesAndValidatesDeposit(t *testing.T) {
 			t.Errorf("deposit %q error = %v, want Console minimum guidance", deposit, err)
 		}
 	}
+
+	for _, deposit := range []string{"0.005", "1e0"} {
+		_, err := executeCommand(t, newCommand(), sdl, "--deposit", deposit, "--dry-run")
+		if err == nil {
+			t.Errorf("deposit %q unexpectedly passed Console dry-run validation", deposit)
+		}
+	}
 }
 
 // TestExecuteKeyringContextWithoutChainClient verifies the clear
@@ -706,7 +713,7 @@ func TestWorkflowCommandFailsWhenFinalReportWriteFails(t *testing.T) {
 			responseStatus: http.StatusInternalServerError,
 			wantReport:     "write workflow JSONL report",
 			wantRunFailure: true,
-			wantRequests:   3,
+			wantRequests:   4,
 		},
 	}
 
@@ -719,6 +726,10 @@ func TestWorkflowCommandFailsWhenFinalReportWriteFails(t *testing.T) {
 			requests := 0
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				requests++
+				if r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/123" {
+					_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"123"},"state":"active"}}}`))
+					return
+				}
 				if r.Method != http.MethodDelete || r.URL.Path != "/v1/deployments/123" {
 					t.Errorf("unexpected Console request: %s %s", r.Method, r.URL.Path)
 					w.WriteHeader(http.StatusNotFound)
@@ -776,7 +787,7 @@ func TestWorkflowCommandFailsWhenFinalReportWriteFails(t *testing.T) {
 			case -1:
 				wantRequests = 0
 			case 0:
-				wantRequests = 1
+				wantRequests = 2
 			}
 			if requests != wantRequests {
 				t.Fatalf("Console close requests = %d, want %d engine attempts before rendering", requests, wantRequests)
@@ -861,6 +872,10 @@ func TestWorkflowCommandReturnsRunFailureAfterWritingFinalReport(t *testing.T) {
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/123" {
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"123"},"state":"active"}}}`))
+			return
+		}
 		if r.Method != http.MethodDelete || r.URL.Path != "/v1/deployments/123" {
 			t.Errorf("unexpected Console request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -891,8 +906,8 @@ func TestWorkflowCommandReturnsRunFailureAfterWritingFinalReport(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), `workflow "close" failed`) {
 		t.Fatalf("execute error = %v, want workflow failure", err)
 	}
-	if requests != 3 {
-		t.Fatalf("Console close requests = %d, want 3 engine attempts", requests)
+	if requests != 4 {
+		t.Fatalf("Console close requests = %d, want one preflight and three DELETE attempts", requests)
 	}
 	for _, want := range []string{"Results:", "close-deployment", "failed", "HTTP 500"} {
 		if !strings.Contains(out, want) {

--- a/internal/cli/workflow/commands_test.go
+++ b/internal/cli/workflow/commands_test.go
@@ -226,7 +226,7 @@ func TestCommandFromDefDeploy(t *testing.T) {
 	if cmd.Flags().Lookup("sdl-file") != nil {
 		t.Fatal("deploy command has --sdl-file flag; file param must be positional only")
 	}
-	for _, flag := range []string{"deposit", "bid-timeout", "bid-select", "yes", "dry-run"} {
+	for _, flag := range []string{"deposit", "bid-timeout", "ready-timeout", "no-wait-active", "bid-select", "yes", "dry-run"} {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Fatalf("deploy command missing --%s flag", flag)
 		}
@@ -465,6 +465,37 @@ func TestExecuteDryRunJSONLEmitsPlannedSteps(t *testing.T) {
 	}
 }
 
+func TestConsoleDryRunResolvesAndValidatesDeposit(t *testing.T) {
+	home := t.TempDir()
+	m := newTestManager(t, home, "console", aktctx.AuthMethodConsoleAPI)
+	sdl := writeValidWorkflowSDL(t)
+	newCommand := func() *cobra.Command {
+		return findCommand(CommandsWithManager(
+			func() string { return home },
+			func() string { return "console" },
+			func() *aktctx.Manager { return m },
+		), "deploy")
+	}
+
+	out, err := executeCommand(t, newCommand(), sdl, "--deposit", "$5", "--dry-run")
+	if err != nil {
+		t.Fatalf("Console dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "deposit:") || !strings.Contains(out, "5") || strings.Contains(out, "$5") {
+		t.Fatalf("dry-run did not show resolved Console deposit:\n%s", out)
+	}
+	if !strings.Contains(out, "Rail: console") || !strings.Contains(out, "Console API create deployment") || strings.Contains(out, "deployment.MsgCreateDeployment") {
+		t.Fatalf("dry-run did not translate steps for the Console rail:\n%s", out)
+	}
+
+	for _, deposit := range []string{"auto", "0.49usd"} {
+		_, err := executeCommand(t, newCommand(), sdl, "--deposit", deposit, "--dry-run")
+		if err == nil || !strings.Contains(err.Error(), "$0.50") {
+			t.Errorf("deposit %q error = %v, want Console minimum guidance", deposit, err)
+		}
+	}
+}
+
 // TestExecuteKeyringContextWithoutChainClient verifies the clear
 // wallet/chain-client error when a keyring context has no chain client in
 // the command context (the "neither credential" case).
@@ -505,6 +536,8 @@ func TestExecuteConsoleDeployEndToEnd(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/4242":
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"owner":"o","dseq":"4242"},"state":"active"},"leases":[{"id":{"owner":"o","dseq":"4242","gseq":1,"oseq":1,"provider":"akash1cheap"},"state":"active","status":{"services":{"web":{"available":1,"total":1,"uris":["web.example.test"]}}}}]}}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/deployments":
 			_, _ = w.Write([]byte(`{"data":{"deployments":[],"pagination":{"hasMore":false}}}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/deployments":
@@ -572,6 +605,7 @@ func TestExecuteConsoleDeployEndToEnd(t *testing.T) {
 	for _, want := range []string{
 		"create-deployment", "tx: CREATEHASH",
 		"wait-for-bids", "select-bid", "create-lease",
+		"wait-for-ready", "URI (web): web.example.test", "Next:",
 		"skipping step \"send-manifest\" (manifest submission handled by Console)",
 		"completed successfully",
 	} {
@@ -1046,6 +1080,10 @@ func TestExecuteConsoleUpdateUsesConsoleManifestHandling(t *testing.T) {
 	requests := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/4242" {
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"owner":"o","dseq":"4242"},"state":"active"},"leases":[]}}`))
+			return
+		}
 		if r.Method != http.MethodPut || r.URL.Path != "/v1/deployments/4242" {
 			t.Errorf("unexpected console request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -1076,8 +1114,8 @@ func TestExecuteConsoleUpdateUsesConsoleManifestHandling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("update execute: %v\noutput:\n%s", err, out)
 	}
-	if requests != 1 {
-		t.Errorf("Console requests = %d, want one update request", requests)
+	if requests != 2 {
+		t.Errorf("Console requests = %d, want one preflight and one update", requests)
 	}
 	for _, want := range []string{
 		"skipping step \"send-manifest\" (manifest submission handled by Console)",

--- a/internal/cli/workflow/coverage_edges_test.go
+++ b/internal/cli/workflow/coverage_edges_test.go
@@ -1,0 +1,332 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	aclient "pkg.akt.dev/go/node/client"
+	cv1beta3 "pkg.akt.dev/go/node/client/v1beta3"
+	dv1beta "pkg.akt.dev/go/node/deployment/v1beta4"
+
+	chaincli "pkg.akt.dev/akt/internal/cli/chain"
+	"pkg.akt.dev/akt/internal/console"
+	aktctx "pkg.akt.dev/akt/internal/context"
+	flagdefs "pkg.akt.dev/akt/internal/flags"
+	wf "pkg.akt.dev/akt/internal/workflow"
+)
+
+type coverageLightClient struct {
+	aclient.LightClient
+	query cv1beta3.QueryClient
+}
+
+func (c coverageLightClient) Query() cv1beta3.QueryClient { return c.query }
+
+type coverageQueryClient struct {
+	cv1beta3.QueryClient
+	deployment dv1beta.QueryClient
+}
+
+func (c coverageQueryClient) Deployment() dv1beta.QueryClient { return c.deployment }
+
+type coverageDeploymentQuery struct {
+	dv1beta.QueryClient
+	response *dv1beta.QueryParamsResponse
+	err      error
+}
+
+func (q coverageDeploymentQuery) Params(
+	context.Context,
+	*dv1beta.QueryParamsRequest,
+	...grpc.CallOption,
+) (*dv1beta.QueryParamsResponse, error) {
+	return q.response, q.err
+}
+
+type coverageReadinessProvider struct {
+	raw json.RawMessage
+	err error
+}
+
+func (coverageReadinessProvider) SendManifest(context.Context, string, uint64, []byte) error {
+	return nil
+}
+
+func (coverageReadinessProvider) SendManifestToActiveLeases(context.Context, uint64, []byte) ([]string, error) {
+	return nil, nil
+}
+
+func (p coverageReadinessProvider) LeaseStatus(context.Context, string, uint64) (json.RawMessage, error) {
+	return p.raw, p.err
+}
+
+func TestChainDryRunDepositDiscoveryDecision(t *testing.T) {
+	if !chainDryRunNeedsDepositQuery("auto") || !chainDryRunNeedsDepositQuery("") {
+		t.Fatal("auto deposits must request chain discovery")
+	}
+	if chainDryRunNeedsDepositQuery("5uact") || chainDryRunNeedsDepositQuery("not-a-deposit") {
+		t.Fatal("explicit or invalid deposits must defer to RunE without discovery")
+	}
+}
+
+func TestChainDryRunPreRunOnlyDiscoversAutoDeposit(t *testing.T) {
+	home := t.TempDir()
+	manager := newTestManager(t, home, "chain", aktctx.AuthMethodKeyring)
+	newCommand := func() *cobra.Command {
+		cmd := findCommand(CommandsWithManager(
+			func() string { return home },
+			func() string { return "chain" },
+			func() *aktctx.Manager { return manager },
+		), "deploy")
+		query := coverageQueryClient{deployment: coverageDeploymentQuery{response: &dv1beta.QueryParamsResponse{
+			Params: dv1beta.Params{MinDeposits: sdk.NewCoins(sdk.NewInt64Coin("uact", 5_000_000))},
+		}}}
+		light := coverageLightClient{query: query}
+		base := context.Background()
+		clientContext := sdkclient.Context{}.WithCmdContext(base)
+		ctx := context.WithValue(base, chaincli.ClientContextKey, &clientContext)
+		ctx = context.WithValue(ctx, chaincli.ContextTypeQueryClient, light)
+		cmd.SetContext(ctx)
+
+		return cmd
+	}
+	sdl := writeValidWorkflowSDL(t)
+
+	if out, err := executeCommand(t, newCommand(), sdl, "--deposit", "5uact", "--dry-run"); err != nil {
+		t.Fatalf("explicit deposit dry run: %v\n%s", err, out)
+	}
+	if out, err := executeCommand(t, newCommand(), sdl, "--deposit", "auto", "--dry-run"); err != nil {
+		t.Fatalf("auto deposit dry run: %v\n%s", err, out)
+	}
+}
+
+func TestResolveDryRunParamsAcrossRails(t *testing.T) {
+	t.Run("Console validation", func(t *testing.T) {
+		manager := newTestManager(t, t.TempDir(), "console", aktctx.AuthMethodConsoleAPI)
+		managerFn := func() *aktctx.Manager { return manager }
+		cmd := &cobra.Command{}
+
+		for _, raw := range []string{"bad", "auto", "$0.10"} {
+			_, err := resolveDryRunParams(cmd, map[string]any{flagdefs.FlagDeposit: raw}, managerFn, func() string { return "console" })
+			if err == nil {
+				t.Fatalf("Console deposit %q did not fail", raw)
+			}
+		}
+		resolved, err := resolveDryRunParams(cmd, map[string]any{flagdefs.FlagDeposit: "$0.50"}, managerFn, func() string { return "console" })
+		if err != nil || resolved[flagdefs.FlagDeposit] != "0.5" {
+			t.Fatalf("resolved Console deposit = %#v, %v", resolved, err)
+		}
+	})
+
+	t.Run("chain explicit and auto", func(t *testing.T) {
+		manager := newTestManager(t, t.TempDir(), "chain", aktctx.AuthMethodKeyring)
+		managerFn := func() *aktctx.Manager { return manager }
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		explicit, err := resolveDryRunParams(cmd, map[string]any{flagdefs.FlagDeposit: "5uact"}, managerFn, func() string { return "chain" })
+		if err != nil || explicit[flagdefs.FlagDeposit] != "5uact" {
+			t.Fatalf("explicit chain deposit = %#v, %v", explicit, err)
+		}
+
+		if _, err := resolveDryRunParams(cmd, map[string]any{flagdefs.FlagDeposit: "auto"}, managerFn, func() string { return "chain" }); err == nil {
+			t.Fatal("chain auto deposit without a query client did not fail")
+		}
+
+		query := coverageQueryClient{deployment: coverageDeploymentQuery{response: &dv1beta.QueryParamsResponse{
+			Params: dv1beta.Params{MinDeposits: sdk.NewCoins(sdk.NewInt64Coin("uact", 5_000_000))},
+		}}}
+		light := coverageLightClient{query: query}
+		cmd.SetContext(context.WithValue(context.Background(), chaincli.ContextTypeQueryClient, light))
+		resolved, err := resolveDryRunParams(cmd, map[string]any{flagdefs.FlagDeposit: "auto"}, managerFn, func() string { return "chain" })
+		if err != nil || resolved[flagdefs.FlagDeposit] != "5000000uact" {
+			t.Fatalf("resolved chain deposit = %#v, %v", resolved, err)
+		}
+	})
+}
+
+func coverageDeployState(params map[string]any) *wf.RunState {
+	state := wf.NewRunState("run-coverage", "deploy", "akash1owner", params)
+	state.SetStepResult("create-deployment", &wf.StepResult{
+		Name: "create-deployment", Status: "success", Output: map[string]any{"dseq": "42"},
+	})
+	state.SetStepResult("create-lease", &wf.StepResult{
+		Name: "create-lease", Status: "success", Output: map[string]any{"provider": "akash1provider"},
+	})
+	state.SetStepResult("display-result", &wf.StepResult{Name: "display-result", Status: "success"})
+	return state
+}
+
+func TestEnrichDeployCompletionBoundaryBranches(t *testing.T) {
+	if err := enrichDeployCompletion(context.Background(), nil, &aktctx.Context{}, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	state := coverageDeployState(map[string]any{})
+	if err := enrichDeployCompletion(context.Background(), state, &aktctx.Context{}, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	missing := wf.NewRunState("run", "deploy", "", map[string]any{"ready-timeout": "1s"})
+	if err := enrichDeployCompletion(context.Background(), missing, &aktctx.Context{}, nil, nil); err == nil {
+		t.Fatal("missing create result did not fail")
+	}
+	badDSeq := coverageDeployState(map[string]any{"ready-timeout": "1s"})
+	badDSeq.Steps["create-deployment"].Output["dseq"] = "bad"
+	if err := enrichDeployCompletion(context.Background(), badDSeq, &aktctx.Context{}, nil, nil); err == nil {
+		t.Fatal("invalid create dseq did not fail")
+	}
+
+	for _, timeout := range []any{5, "bad", "0s"} {
+		state = coverageDeployState(map[string]any{"ready-timeout": timeout})
+		if err := enrichDeployCompletion(context.Background(), state, &aktctx.Context{}, nil, nil); err == nil {
+			t.Fatalf("invalid timeout %#v did not fail", timeout)
+		}
+	}
+
+	state = coverageDeployState(map[string]any{"ready-timeout": "1s"})
+	if err := enrichDeployCompletion(context.Background(), state, &aktctx.Context{AuthMethod: aktctx.AuthMethodConsoleAPI}, nil, nil); err == nil {
+		t.Fatal("missing Console readiness client did not fail")
+	}
+	state = coverageDeployState(map[string]any{"ready-timeout": "1s"})
+	if err := enrichDeployCompletion(context.Background(), state, &aktctx.Context{}, nil, nil); err == nil {
+		t.Fatal("missing provider readiness client did not fail")
+	}
+
+	state = coverageDeployState(map[string]any{"ready-timeout": "20ms"})
+	provider := coverageReadinessProvider{raw: json.RawMessage(`{"services":{"web":{"available":1,"total":1,"uris":["https://web.example"]}}}`)}
+	if err := enrichDeployCompletion(context.Background(), state, &aktctx.Context{}, nil, provider); err != nil {
+		t.Fatal(err)
+	}
+	ready, _ := state.Steps["display-result"].Output["ready"].(bool)
+	if state.Steps["wait-for-ready"].Status != "success" || !ready {
+		t.Fatalf("successful readiness = %#v", state.Steps)
+	}
+
+	state = coverageDeployState(map[string]any{"ready-timeout": "500ms"})
+	provider = coverageReadinessProvider{err: errors.New("provider unavailable")}
+	err := enrichDeployCompletion(context.Background(), state, &aktctx.Context{}, nil, provider)
+	if err == nil || state.Steps["wait-for-ready"].Status != "failed" {
+		t.Fatalf("failed readiness = %v, %#v", err, state.Steps["wait-for-ready"])
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	state = coverageDeployState(map[string]any{"ready-timeout": "500ms"})
+	err = enrichDeployCompletion(
+		context.Background(),
+		state,
+		&aktctx.Context{AuthMethod: aktctx.AuthMethodConsoleAPI},
+		console.New(server.URL, "key"),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "503") {
+		t.Fatalf("Console readiness error = %v", err)
+	}
+}
+
+func TestEnrichSuccessfulDeployPreservesEngineFailures(t *testing.T) {
+	sentinel := errors.New("engine failed")
+	if err := enrichSuccessfulDeploy(context.Background(), nil, nil, nil, nil, sentinel); !errors.Is(err, sentinel) {
+		t.Fatalf("engine failure = %v", err)
+	}
+	if err := enrichSuccessfulDeploy(context.Background(), nil, nil, nil, nil, nil); err != nil {
+		t.Fatalf("successful non-deploy run = %v", err)
+	}
+}
+
+func TestConsoleRuntimeStatusBoundaries(t *testing.T) {
+	if _, err := consoleRuntimeStatus(nil); err == nil {
+		t.Fatal("nil deployment status did not fail")
+	}
+	bad := &console.DeploymentDetail{Leases: []console.Lease{{Status: &console.LeaseStatus{Services: json.RawMessage(`{`)}}}}
+	if _, err := consoleRuntimeStatus(bad); err == nil {
+		t.Fatal("malformed service status did not fail")
+	}
+	detail := &console.DeploymentDetail{Leases: []console.Lease{
+		{},
+		{Status: &console.LeaseStatus{}},
+		{Status: &console.LeaseStatus{Services: json.RawMessage(`{"web":{"available":1,"total":1}}`)}},
+	}}
+	raw, err := consoleRuntimeStatus(detail)
+	if err != nil || !strings.Contains(string(raw), "web") {
+		t.Fatalf("Console runtime status = %s, %v", raw, err)
+	}
+}
+
+func TestReadinessDecodeAndFetchFailures(t *testing.T) {
+	for _, raw := range []json.RawMessage{
+		json.RawMessage(`{`),
+		json.RawMessage(`{"services":{}}`),
+		json.RawMessage(`{"services":{"web":{"available":1,"total":0}}}`),
+	} {
+		ready, _, err := deploymentReady(raw)
+		if string(raw) == "{" {
+			if err == nil {
+				t.Fatal("invalid readiness JSON did not fail")
+			}
+		} else if err != nil || ready {
+			t.Fatalf("non-ready status %s = %t, %v", raw, ready, err)
+		}
+	}
+
+	_, _, err := waitForDeploymentReadiness(context.Background(), time.Millisecond, func(context.Context) (json.RawMessage, error) {
+		return nil, errors.New("fetch failed")
+	})
+	if err == nil || !strings.Contains(err.Error(), "fetch failed") {
+		t.Fatalf("fetch timeout = %v", err)
+	}
+
+	requests := 0
+	uris, _, err := waitForDeploymentReadiness(context.Background(), 3*time.Second, func(context.Context) (json.RawMessage, error) {
+		requests++
+		if requests == 1 {
+			return json.RawMessage(`{"services":{"web":{"available":0,"total":1}}}`), nil
+		}
+		return json.RawMessage(`{"services":{"web":{"available":1,"total":1,"uris":["https://web.example"]}}}`), nil
+	})
+	if err != nil || requests != 2 || len(uris["web"]) != 1 {
+		t.Fatalf("readiness retry = requests %d, uris %#v, err %v", requests, uris, err)
+	}
+}
+
+func TestRenderDeployNextBoundaryAndChainActions(t *testing.T) {
+	var rendered strings.Builder
+	renderDeployNext(&rendered, nil)
+	renderDeployNext(&rendered, wf.NewRunState("run", "update", "", nil))
+	state := wf.NewRunState("run", "deploy", "", nil)
+	renderDeployNext(&rendered, state)
+	state.SetStepResult("display-result", &wf.StepResult{Name: "display-result", Output: map[string]any{}})
+	renderDeployNext(&rendered, state)
+
+	state.Steps["display-result"].Output = map[string]any{
+		"dseq": "42", "provider": "akash1provider", "ready": true,
+		"uris": map[string][]string{"web": {"https://web.example"}},
+	}
+	rendered.Reset()
+	renderDeployNext(&rendered, state)
+	for _, want := range []string{"Ready: yes", "URI (web)", "akt provider lease-status 42 --provider akash1provider", "akt close 42"} {
+		if !strings.Contains(rendered.String(), want) {
+			t.Errorf("chain next actions missing %q:\n%s", want, rendered.String())
+		}
+	}
+	if got := consolePlanAction("unknown.Msg"); got != "unsupported Console action unknown.Msg" {
+		t.Fatalf("unknown Console plan action = %q", got)
+	}
+}
+
+func TestMergeCompletionOutputWithoutDisplayResult(t *testing.T) {
+	state := wf.NewRunState("run", "deploy", "", nil)
+	mergeCompletionOutput(state, map[string]any{"ready": true})
+}

--- a/internal/cli/workflow/helpers_test.go
+++ b/internal/cli/workflow/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	flagdefs "pkg.akt.dev/akt/internal/flags"
 
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"pkg.akt.dev/akt/internal/console"
 	aktctx "pkg.akt.dev/akt/internal/context"
 	wf "pkg.akt.dev/akt/internal/workflow"
 	"pkg.akt.dev/akt/internal/workflow/steps"
@@ -110,6 +112,7 @@ func TestEmitJSONLShape(t *testing.T) {
 		Status: "success",
 		TxHash: "ABC123",
 		Height: 42,
+		Output: map[string]any{"dseq": "12345", "provider": "akash1provider"},
 	})
 	state.SetStepResult("skipme", &wf.StepResult{Name: "skipme", Status: "skipped"})
 	state.SetStepResult("boom", &wf.StepResult{Name: "boom", Status: "failed", Error: "out of gas"})
@@ -130,6 +133,7 @@ func TestEmitJSONLShape(t *testing.T) {
 		Step     string `json:"step"`
 		Result   string `json:"result"`
 		Errors   []string
+		Outputs  map[string]any `json:"outputs"`
 		Txs      []struct {
 			Hash   string `json:"hash"`
 			Height int64  `json:"height"`
@@ -160,6 +164,9 @@ func TestEmitJSONLShape(t *testing.T) {
 
 	if got[0].Result != "completed" || len(got[0].Txs) != 1 || got[0].Txs[0].Hash != "ABC123" || got[0].Txs[0].Height != 42 {
 		t.Errorf("success line = %+v, want completed with the tx", got[0])
+	}
+	if got[0].Outputs["dseq"] != "12345" || got[0].Outputs["provider"] != "akash1provider" {
+		t.Errorf("success outputs = %#v, want workflow step values", got[0].Outputs)
 	}
 	if got[1].Result != "skipped" {
 		t.Errorf("skipped line = %+v", got[1])
@@ -315,6 +322,26 @@ func TestDeployRecoveryAdviceJSONLFields(t *testing.T) {
 	}
 }
 
+func TestReadinessFailureDoesNotSuggestResendingManifest(t *testing.T) {
+	state := wf.NewRunState("run-1", "deploy", "akash1owner", map[string]any{"sdl-file": "deploy.yaml"})
+	state.SetStepResult("create-deployment", &wf.StepResult{
+		Name: "create-deployment", Status: "success", Output: map[string]any{"dseq": "77"},
+	})
+	state.SetStepResult("create-lease", &wf.StepResult{
+		Name: "create-lease", Status: "success", Output: map[string]any{"provider": "akash1provider"},
+	})
+	state.SetStepResult("send-manifest", &wf.StepResult{Name: "send-manifest", Status: "success"})
+	state.SetStepResult("wait-for-ready", &wf.StepResult{Name: "wait-for-ready", Status: "failed"})
+
+	advice := deployRecoveryAdvice(state, errors.New("readiness timeout"))
+	if advice == nil || advice.Cleanup != "akt close 77" {
+		t.Fatalf("readiness recovery = %+v", advice)
+	}
+	if advice.Recovery != "" {
+		t.Fatalf("readiness recovery incorrectly resends a successful manifest: %s", advice.Recovery)
+	}
+}
+
 func TestDeployRecoveryAdviceRequiresCompletedCreate(t *testing.T) {
 	state := wf.NewRunState("run-1", "deploy", "akash1owner", map[string]any{"sdl-file": "deploy.yaml"})
 	state.SetStepResult("create-deployment", &wf.StepResult{Name: "create-deployment", Status: "failed"})
@@ -337,6 +364,76 @@ func TestDeployRecoveryAdviceRequiresCompletedCreate(t *testing.T) {
 func TestShellQuoteKeepsRecoveryCommandsCopyPasteable(t *testing.T) {
 	if got, want := shellQuote("/tmp/operator's deployment.yaml"), `'/tmp/operator'"'"'s deployment.yaml'`; got != want {
 		t.Errorf("shellQuote = %q, want %q", got, want)
+	}
+}
+
+func TestDeploymentReadyRequiresEveryServiceAndPreservesURIs(t *testing.T) {
+	raw := json.RawMessage(`{"services":{"web":{"available":2,"total":2,"uris":["one.example","two.example"]},"worker":{"available":1,"total":1,"uris":[]}}}`)
+	ready, uris, err := deploymentReady(raw)
+	if err != nil || !ready {
+		t.Fatalf("ready status = %t, error %v", ready, err)
+	}
+	if got := strings.Join(uris["web"], ","); got != "one.example,two.example" {
+		t.Fatalf("web URIs = %q", got)
+	}
+
+	ready, _, err = deploymentReady(json.RawMessage(`{"services":{"web":{"available":0,"total":1}}}`))
+	if err != nil || ready {
+		t.Fatalf("unavailable service status = %t, error %v", ready, err)
+	}
+}
+
+func TestWaitForDeploymentReadinessReturnsBoundedTimeout(t *testing.T) {
+	_, _, err := waitForDeploymentReadiness(
+		context.Background(),
+		5*time.Millisecond,
+		func(context.Context) (json.RawMessage, error) {
+			return json.RawMessage(`{"services":{}}`), nil
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "within 5ms") {
+		t.Fatalf("readiness timeout = %v", err)
+	}
+}
+
+func TestConsoleDeployCompletionIncludesDeepLinkAndOptOut(t *testing.T) {
+	state := wf.NewRunState("run-1", "deploy", "", map[string]any{
+		"ready-timeout":  "2m",
+		"no-wait-active": true,
+	})
+	state.SetStepResult("create-deployment", &wf.StepResult{
+		Name: "create-deployment", Status: "success", Output: map[string]any{"dseq": "4242"},
+	})
+	state.SetStepResult("select-bid", &wf.StepResult{
+		Name: "select-bid", Status: "success", Output: map[string]any{"provider": "akash1provider", "price": "1uact"},
+	})
+	state.SetStepResult("display-result", &wf.StepResult{Name: "display-result", Status: "success"})
+
+	err := enrichDeployCompletion(
+		context.Background(),
+		state,
+		&aktctx.Context{AuthMethod: aktctx.AuthMethodConsoleAPI},
+		console.New("", "key"),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("enrich Console completion: %v", err)
+	}
+	output := state.Steps["display-result"].Output
+	if output["console_url"] != "https://console.akash.network/deployments/4242" || output["auto_top_up"] != "daily" {
+		t.Fatalf("Console completion output = %#v", output)
+	}
+
+	var rendered strings.Builder
+	renderDeployNext(&rendered, state)
+	for _, want := range []string{
+		"https://console.akash.network/deployments/4242",
+		"akt console deployment settings 4242 false",
+		"akt console status 4242",
+	} {
+		if !strings.Contains(rendered.String(), want) {
+			t.Errorf("completion output missing %q:\n%s", want, rendered.String())
+		}
 	}
 }
 

--- a/internal/console/actionlog_test.go
+++ b/internal/console/actionlog_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -205,7 +206,7 @@ func TestRedactResponseSecretWithoutCredentialPreservesDiagnostic(t *testing.T) 
 	}
 }
 
-func TestCloseAlreadyClosedRecordedAsSuccess(t *testing.T) {
+func TestCloseAlreadyClosedRecordedAsFailed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -226,33 +227,47 @@ func TestCloseAlreadyClosedRecordedAsSuccess(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}
-	// Desired end state was reached, so the idempotent close logs as success.
-	if entries[0].Action != "close-deployment" || entries[0].Status != "success" || entries[0].DSeq != 555 {
+	if entries[0].Action != "close-deployment" || entries[0].Status != "failed" || entries[0].DSeq != 555 {
 		t.Errorf("already-closed entry wrong: %+v", entries[0])
+	}
+	if !strings.Contains(entries[0].Error, "already closed") {
+		t.Errorf("already-closed entry error = %q", entries[0].Error)
 	}
 }
 
-func TestRepeatedSuccessfulCloseRecordsEveryAttempt(t *testing.T) {
+func TestRepeatedCloseRecordsTruthfulOutcomes(t *testing.T) {
 	var deletes atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/v1/deployments/555" {
+		if r.URL.Path != "/v1/deployments/555" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
-		deletes.Add(1)
-		_, _ = w.Write([]byte(`{"data":{"success":true}}`))
+		switch r.Method {
+		case http.MethodGet:
+			state := "active"
+			if deletes.Load() > 0 {
+				state = "closed"
+			}
+			_, _ = fmt.Fprintf(w, `{"data":{"deployment":{"id":{"dseq":"555"},"state":%q}}}`, state)
+		case http.MethodDelete:
+			deletes.Add(1)
+			_, _ = w.Write([]byte(`{"data":{"success":true}}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
 	}))
 	defer srv.Close()
 
 	l := openTestLog(t)
 	c := New(srv.URL, "test-key").WithActionLog(l)
-	for attempt := 1; attempt <= 2; attempt++ {
-		if err := c.CloseDeployment(context.Background(), "555"); err != nil {
-			t.Fatalf("CloseDeployment() attempt %d: %v", attempt, err)
-		}
+	if err := c.CloseDeployment(context.Background(), "555"); err != nil {
+		t.Fatalf("first CloseDeployment(): %v", err)
+	}
+	if err := c.CloseDeployment(context.Background(), "555"); !errors.Is(err, ErrAlreadyClosed) {
+		t.Fatalf("second CloseDeployment() = %v, want ErrAlreadyClosed", err)
 	}
 
-	if got := deletes.Load(); got != 2 {
-		t.Fatalf("DELETE requests = %d, want 2", got)
+	if got := deletes.Load(); got != 1 {
+		t.Fatalf("DELETE requests = %d, want 1", got)
 	}
 	entries, err := l.Read(actionlog.Filter{Type: actionlog.TypeConsole})
 	if err != nil {
@@ -261,17 +276,22 @@ func TestRepeatedSuccessfulCloseRecordsEveryAttempt(t *testing.T) {
 	if len(entries) != 2 {
 		t.Fatalf("close action entries = %d, want 2: %+v", len(entries), entries)
 	}
-	for i, entry := range entries {
-		if entry.Action != "close-deployment" || entry.Status != "success" || entry.DSeq != 555 || entry.Error != "" {
-			t.Errorf("close action entry %d = %+v", i, entry)
-		}
+	if entries[0].Action != "close-deployment" || entries[0].Status != "failed" || entries[0].DSeq != 555 || !strings.Contains(entries[0].Error, "already closed") {
+		t.Errorf("second close action entry = %+v", entries[0])
+	}
+	if entries[1].Action != "close-deployment" || entries[1].Status != "success" || entries[1].DSeq != 555 || entries[1].Error != "" {
+		t.Errorf("first close action entry = %+v", entries[1])
 	}
 }
 
 func TestCloseValidation400RecordedAsFailed(t *testing.T) {
 	// A 400 without already-closed semantics is a genuine failure: it must
 	// not be logged as a successful close.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"777"},"state":"active"}}}`))
+			return
+		}
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":"deployment cannot be closed while active leases exist"}`))
 	}))
@@ -314,6 +334,8 @@ func TestNewMutationsRecordedInActionLog(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":{"dseq":"42","autoTopUpEnabled":true}}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/api-keys":
 			_, _ = w.Write([]byte(`{"data":{"id":"k1","name":"n","apiKey":"secret"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/api-keys":
+			_, _ = w.Write([]byte(`{"data":[{"id":"11111111-1111-4111-8111-111111111111","name":"n"}]}`))
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/api-keys/11111111-1111-4111-8111-111111111111":
 			w.WriteHeader(http.StatusNoContent)
 		default:

--- a/internal/console/actionlog_test.go
+++ b/internal/console/actionlog_test.go
@@ -306,13 +306,15 @@ func TestCloseValidation400RecordedAsFailed(t *testing.T) {
 func TestNewMutationsRecordedInActionLog(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/deployments/42":
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"42"},"state":"active"}}}`))
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/wallet-settings":
 			_, _ = w.Write([]byte(`{"data":{"autoReloadEnabled":true}}`))
 		case r.Method == http.MethodPatch && r.URL.Path == "/v2/deployment-settings/42":
 			_, _ = w.Write([]byte(`{"data":{"dseq":"42","autoTopUpEnabled":true}}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/api-keys":
 			_, _ = w.Write([]byte(`{"data":{"id":"k1","name":"n","apiKey":"secret"}}`))
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/api-keys/k1":
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/api-keys/11111111-1111-4111-8111-111111111111":
 			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -334,7 +336,7 @@ func TestNewMutationsRecordedInActionLog(t *testing.T) {
 	if _, err := c.CreateAPIKey(ctx, "n", ""); err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}
-	if err := c.DeleteAPIKey(ctx, "k1"); err != nil {
+	if err := c.DeleteAPIKey(ctx, "11111111-1111-4111-8111-111111111111"); err != nil {
 		t.Fatalf("DeleteAPIKey: %v", err)
 	}
 
@@ -380,7 +382,7 @@ func TestConsoleValidationFailuresOccurBeforeNetworkAndAreLogged(t *testing.T) {
 	if _, err := client.UpdateDeployment(context.Background(), "42", "not-valid-sdl: ["); err == nil || !strings.Contains(err.Error(), "prepare deployment SDL") {
 		t.Fatalf("invalid deployment SDL error = %v", err)
 	}
-	if err := client.Deposit(context.Background(), "42", 0); err == nil || !strings.Contains(err.Error(), "prepare deployment deposit") {
+	if err := client.Deposit(context.Background(), "42", 0); err == nil || !strings.Contains(err.Error(), "at least $0.50") {
 		t.Fatalf("invalid deployment deposit error = %v", err)
 	}
 	if requests.Load() != 0 {

--- a/internal/console/apikeys.go
+++ b/internal/console/apikeys.go
@@ -7,7 +7,12 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/google/uuid"
 )
+
+// MaxJWTTTLSeconds bounds Console-issued provider credentials.
+const MaxJWTTTLSeconds = 3600
 
 // ListAPIKeys lists the account's API keys. Secrets are never included.
 //
@@ -63,6 +68,12 @@ func (c *Client) CreateAPIKey(ctx context.Context, name, expiresAt string) (*Cre
 //
 // Wire: DELETE /v1/api-keys/{id} → 204.
 func (c *Client) DeleteAPIKey(ctx context.Context, id string) error {
+	if _, parseErr := uuid.Parse(id); parseErr != nil {
+		err := fmt.Errorf("console: API key ID must be a valid UUID: %w", parseErr)
+		c.record("delete-api-key", "", err)
+		return err
+	}
+
 	err := c.doJSON(ctx, http.MethodDelete, "/v1/api-keys/"+url.PathEscape(id), nil, nil)
 	if errors.Is(err, ErrNotFound) {
 		err = nil
@@ -80,6 +91,10 @@ func (c *Client) DeleteAPIKey(ctx context.Context, id string) error {
 // {"data":{"ttl":..., "leases":{"access":"scoped","scope":[...]}}},
 // response {"data":{"token":...}}.
 func (c *Client) CreateJWTToken(ctx context.Context, ttl int, scope []string) (string, error) {
+	if ttl < 1 || ttl > MaxJWTTTLSeconds {
+		return "", fmt.Errorf("console: JWT TTL must be between 1 and %d seconds, got %d", MaxJWTTTLSeconds, ttl)
+	}
+
 	body := envelope(map[string]any{
 		"ttl": ttl,
 		"leases": map[string]any{

--- a/internal/console/apikeys.go
+++ b/internal/console/apikeys.go
@@ -63,22 +63,42 @@ func (c *Client) CreateAPIKey(ctx context.Context, name, expiresAt string) (*Cre
 	return nil, unknown
 }
 
-// DeleteAPIKey deletes an API key by ID. A missing key (404) is treated as a
-// no-op and returns nil.
+// DeleteAPIKey deletes an API key by ID. Console's DELETE endpoint is
+// idempotent, so the client first proves the key is present in the account's
+// key list. A missing key is returned as ErrNotFound without sending DELETE,
+// ensuring callers never report a deletion the API did not perform.
 //
 // Wire: DELETE /v1/api-keys/{id} → 204.
 func (c *Client) DeleteAPIKey(ctx context.Context, id string) error {
-	if _, parseErr := uuid.Parse(id); parseErr != nil {
+	parsedID, parseErr := uuid.Parse(id)
+	if parseErr != nil {
 		err := fmt.Errorf("console: API key ID must be a valid UUID: %w", parseErr)
 		c.record("delete-api-key", "", err)
 		return err
 	}
 
-	err := c.doJSON(ctx, http.MethodDelete, "/v1/api-keys/"+url.PathEscape(id), nil, nil)
-	if errors.Is(err, ErrNotFound) {
-		err = nil
+	keys, err := c.ListAPIKeys(ctx)
+	if err != nil {
+		err = fmt.Errorf("console: preflight API key deletion: %w", err)
+		c.record("delete-api-key", "", err)
+		return err
 	}
 
+	found := false
+	for _, key := range keys {
+		keyID, keyErr := uuid.Parse(key.ID)
+		if keyErr == nil && keyID == parsedID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		err = fmt.Errorf("%w: API key %s", ErrNotFound, parsedID.String())
+		c.record("delete-api-key", "", err)
+		return err
+	}
+
+	err = c.doJSON(ctx, http.MethodDelete, "/v1/api-keys/"+url.PathEscape(parsedID.String()), nil, nil)
 	c.record("delete-api-key", "", err)
 
 	return err

--- a/internal/console/apikeys_test.go
+++ b/internal/console/apikeys_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -95,26 +96,74 @@ func TestCreateAPIKeyRejectsIncompleteOneTimeSecret(t *testing.T) {
 
 func TestDeleteAPIKey(t *testing.T) {
 	id := "11111111-1111-4111-8111-111111111111"
+	var lists atomic.Int32
+	var deletes atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/v1/api-keys/"+id, r.URL.Path)
-
-		w.WriteHeader(http.StatusNoContent)
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/api-keys":
+			lists.Add(1)
+			_, _ = w.Write([]byte(`{"data":[{"id":"` + id + `","name":"ci"}]}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/api-keys/"+id:
+			deletes.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer srv.Close()
 
 	c := console.New(srv.URL, "test-key")
 	require.NoError(t, c.DeleteAPIKey(context.Background(), id))
+	assert.Equal(t, int32(1), lists.Load())
+	assert.Equal(t, int32(1), deletes.Load())
 }
 
-func TestDeleteAPIKeyNotFoundIsNoop(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
+func TestDeleteAPIKeyNotFoundIsError(t *testing.T) {
+	var deletes atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case http.MethodDelete:
+			deletes.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
 	}))
 	defer srv.Close()
 
 	c := console.New(srv.URL, "test-key")
-	assert.NoError(t, c.DeleteAPIKey(context.Background(), "22222222-2222-4222-8222-222222222222"), "404 on delete is a no-op")
+	err := c.DeleteAPIKey(context.Background(), "22222222-2222-4222-8222-222222222222")
+	assert.ErrorIs(t, err, console.ErrNotFound)
+	assert.Zero(t, deletes.Load(), "an absent key must not reach the idempotent DELETE endpoint")
+}
+
+func TestDeleteAPIKeyPreservesDeleteNotFound(t *testing.T) {
+	id := "22222222-2222-4222-8222-222222222222"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"data":[{"id":"` + id + `","name":"ci"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	err := console.New(srv.URL, "test-key").DeleteAPIKey(context.Background(), id)
+	assert.ErrorIs(t, err, console.ErrNotFound)
+}
+
+func TestDeleteAPIKeyPreflightFailureIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	err := console.New(srv.URL, "test-key").DeleteAPIKey(
+		context.Background(), "22222222-2222-4222-8222-222222222222")
+	require.ErrorContains(t, err, "preflight API key deletion")
 }
 
 func TestCreateJWTToken(t *testing.T) {

--- a/internal/console/apikeys_test.go
+++ b/internal/console/apikeys_test.go
@@ -94,16 +94,17 @@ func TestCreateAPIKeyRejectsIncompleteOneTimeSecret(t *testing.T) {
 }
 
 func TestDeleteAPIKey(t *testing.T) {
+	id := "11111111-1111-4111-8111-111111111111"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/v1/api-keys/key-1", r.URL.Path)
+		assert.Equal(t, "/v1/api-keys/"+id, r.URL.Path)
 
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
 
 	c := console.New(srv.URL, "test-key")
-	require.NoError(t, c.DeleteAPIKey(context.Background(), "key-1"))
+	require.NoError(t, c.DeleteAPIKey(context.Background(), id))
 }
 
 func TestDeleteAPIKeyNotFoundIsNoop(t *testing.T) {
@@ -113,7 +114,7 @@ func TestDeleteAPIKeyNotFoundIsNoop(t *testing.T) {
 	defer srv.Close()
 
 	c := console.New(srv.URL, "test-key")
-	assert.NoError(t, c.DeleteAPIKey(context.Background(), "missing"), "404 on delete is a no-op")
+	assert.NoError(t, c.DeleteAPIKey(context.Background(), "22222222-2222-4222-8222-222222222222"), "404 on delete is a no-op")
 }
 
 func TestCreateJWTToken(t *testing.T) {

--- a/internal/console/client.go
+++ b/internal/console/client.go
@@ -57,11 +57,9 @@ var (
 	ErrNotFound = errors.New("console: resource not found")
 
 	// ErrAlreadyClosed is returned by CloseDeployment when the deployment is
-	// already closed (the API answers 404, or 400 with an already-closed
-	// message). Callers that want idempotent close semantics should treat it
-	// as success:
-	//
-	//	if err := c.CloseDeployment(ctx, dseq); err != nil && !errors.Is(err, console.ErrAlreadyClosed) { ... }
+	// already closed or absent (the preflight answers 404 or reports a closed
+	// state, or the DELETE reports unambiguous already-closed semantics).
+	// Callers must preserve this as a failed mutation.
 	ErrAlreadyClosed = errors.New("console: deployment already closed")
 )
 

--- a/internal/console/client.go
+++ b/internal/console/client.go
@@ -28,6 +28,9 @@ import (
 // DefaultBaseURL is the production Console API endpoint.
 const DefaultBaseURL = "https://console-api.akash.network"
 
+// DefaultUIBaseURL is the production Console browser origin.
+const DefaultUIBaseURL = "https://console.akash.network"
+
 // MinDepositUSD is the minimum deployment deposit the Console API accepts.
 // It lives here — the leaf package every Console caller already imports —
 // so the CLI, the workflow transport, and the client itself cannot drift
@@ -100,6 +103,17 @@ func New(baseURL, apiKey string) *Client {
 			},
 		},
 	}
+}
+
+// DeploymentURL returns a production Console deep link for dseq. Custom API
+// origins intentionally return an empty string: they may have no matching UI,
+// and linking them to production would point at a different account.
+func (c *Client) DeploymentURL(dseq string) string {
+	if validateDSeq(dseq) != nil || strings.TrimRight(c.baseURL, "/") != DefaultBaseURL {
+		return ""
+	}
+
+	return DefaultUIBaseURL + "/deployments/" + dseq
 }
 
 // WithActionLog attaches a per-context action logger; state-changing Console

--- a/internal/console/client_edges_test.go
+++ b/internal/console/client_edges_test.go
@@ -40,6 +40,18 @@ func TestNewDefaultsToProductionBaseURL(t *testing.T) {
 	}
 }
 
+func TestDeploymentURLOnlyLinksProductionConsole(t *testing.T) {
+	if got := console.New("", "key").DeploymentURL("4242"); got != "https://console.akash.network/deployments/4242" {
+		t.Fatalf("production deployment URL = %q", got)
+	}
+	if got := console.New("https://console-api.example.test", "key").DeploymentURL("4242"); got != "" {
+		t.Fatalf("custom API deployment URL = %q, want empty", got)
+	}
+	if got := console.New("", "key").DeploymentURL("0"); got != "" {
+		t.Fatalf("invalid deployment URL = %q, want empty", got)
+	}
+}
+
 type consoleRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn consoleRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {

--- a/internal/console/client_test.go
+++ b/internal/console/client_test.go
@@ -220,21 +220,27 @@ func TestPostNotRetriedOn429(t *testing.T) {
 
 func TestDeleteRetriedOn5xx(t *testing.T) {
 	// DELETE is idempotent by HTTP semantics: replaying it on 5xx is safe.
-	var calls atomic.Int32
+	var deletes atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodDelete, r.Method)
-		if calls.Add(1) < 3 {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"1"},"state":"active"}}}`))
+		case http.MethodDelete:
+			if deletes.Add(1) < 3 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"success":true}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
-		_, _ = w.Write([]byte(`{"data":{"success":true}}`))
 	}))
 	defer srv.Close()
 
 	c := console.New(srv.URL, "key")
 	require.NoError(t, c.CloseDeployment(context.Background(), "1"))
-	assert.Equal(t, int32(3), calls.Load(), "DELETE + 5xx must retry")
+	assert.Equal(t, int32(3), deletes.Load(), "DELETE + 5xx must retry")
 }
 
 func TestDataEnvelopeUnwrapping(t *testing.T) {
@@ -324,15 +330,20 @@ func TestEmptyBodyIsAnErrorWhenResultExpected(t *testing.T) {
 	}
 }
 
-func TestEmptyBodyIsFineWhenNoResultExpected(t *testing.T) {
+func TestEmptyDeleteBodyIsFineWhenNoResultExpected(t *testing.T) {
 	// Endpoints that return no payload (e.g. DELETE) pass a nil result and
 	// must keep succeeding on an empty body.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	const id = "11111111-1111-4111-8111-111111111111"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"data":[{"id":"` + id + `","name":"ci"}]}`))
+			return
+		}
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
 
-	if err := console.New(srv.URL, "k").DeleteAPIKey(context.Background(), "11111111-1111-4111-8111-111111111111"); err != nil {
+	if err := console.New(srv.URL, "k").DeleteAPIKey(context.Background(), id); err != nil {
 		t.Fatalf("empty body with no expected result must succeed: %v", err)
 	}
 }

--- a/internal/console/client_test.go
+++ b/internal/console/client_test.go
@@ -332,7 +332,7 @@ func TestEmptyBodyIsFineWhenNoResultExpected(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if err := console.New(srv.URL, "k").DeleteAPIKey(context.Background(), "k1"); err != nil {
+	if err := console.New(srv.URL, "k").DeleteAPIKey(context.Background(), "11111111-1111-4111-8111-111111111111"); err != nil {
 		t.Fatalf("empty body with no expected result must succeed: %v", err)
 	}
 }

--- a/internal/console/deployments.go
+++ b/internal/console/deployments.go
@@ -23,6 +23,11 @@ import (
 //
 // Wire: POST /v1/deployments, body {"data":{"sdl":..., "deposit":...}}.
 func (c *Client) CreateDeployment(ctx context.Context, sdl string, depositUSD float64) (*CreateDeploymentResult, error) {
+	if err := validateDepositUSD(depositUSD); err != nil {
+		c.record("create-deployment", "", err)
+		return nil, err
+	}
+
 	versionHash, manifest, err := deploymentArtifacts(sdl)
 	if err != nil {
 		wrapped := fmt.Errorf("prepare deployment SDL: %w", err)
@@ -220,25 +225,18 @@ func deploymentPaginationLimitError() error {
 	)
 }
 
-// ListDeployments lists deployments with pagination. Out-of-range values are
-// omitted from the query instead of being sent — the API requires skip >= 0
-// and limit >= 1, so a negative skip falls back to 0 and a non-positive limit
-// falls back to the server default page size.
+// ListDeployments lists deployments with validated pagination.
 //
 // Wire: GET /v1/deployments?skip=&limit=, data-enveloped response.
 func (c *Client) ListDeployments(ctx context.Context, skip, limit int) (*DeploymentList, error) {
-	var params []string
-	if skip >= 0 {
-		params = append(params, "skip="+strconv.Itoa(skip))
+	if skip < 0 {
+		return nil, fmt.Errorf("console: deployment pagination skip must be non-negative, got %d", skip)
 	}
-	if limit >= 1 {
-		params = append(params, "limit="+strconv.Itoa(limit))
+	if limit < 1 {
+		return nil, fmt.Errorf("console: deployment pagination limit must be greater than zero, got %d", limit)
 	}
 
-	path := "/v1/deployments"
-	if len(params) > 0 {
-		path += "?" + strings.Join(params, "&")
-	}
+	path := "/v1/deployments?skip=" + strconv.Itoa(skip) + "&limit=" + strconv.Itoa(limit)
 
 	var out DeploymentList
 	if err := c.doData(ctx, http.MethodGet, path, nil, &out); err != nil {
@@ -248,6 +246,52 @@ func (c *Client) ListDeployments(ctx context.Context, skip, limit int) (*Deploym
 	regroupLeases(out.Deployments)
 
 	return &out, nil
+}
+
+// ListDeploymentsByState traverses the bounded deployment collection, applies
+// the state filter, and only then applies the requested page window.
+func (c *Client) ListDeploymentsByState(ctx context.Context, state string, skip, limit int) (*DeploymentList, error) {
+	if skip < 0 {
+		return nil, fmt.Errorf("console: deployment pagination skip must be non-negative, got %d", skip)
+	}
+	if limit < 1 {
+		return nil, fmt.Errorf("console: deployment pagination limit must be greater than zero, got %d", limit)
+	}
+	state = strings.ToLower(strings.TrimSpace(state))
+	if state != "active" && state != "closed" {
+		return nil, fmt.Errorf("console: deployment state must be active or closed, got %q", state)
+	}
+
+	all, err := c.listAllDeployments(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]DeploymentListItem, 0, len(all))
+	for _, item := range all {
+		if strings.EqualFold(item.Deployment.State, state) {
+			filtered = append(filtered, item)
+		}
+	}
+
+	total := len(filtered)
+	start := skip
+	if start > total {
+		start = total
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+
+	return &DeploymentList{
+		Deployments: filtered[start:end],
+		Pagination: Pagination{
+			Total:   total,
+			Skip:    skip,
+			Limit:   limit,
+			HasMore: end < total,
+		},
+	}, nil
 }
 
 // regroupLeases re-files each lease under the deployment its own ID names.
@@ -296,6 +340,10 @@ func regroupLeases(items []DeploymentListItem) {
 //
 // Wire: GET /v1/deployments/{dseq}, data-enveloped response.
 func (c *Client) GetDeployment(ctx context.Context, dseq string) (*DeploymentDetail, error) {
+	if err := validateDSeq(dseq); err != nil {
+		return nil, err
+	}
+
 	var out DeploymentDetail
 	if err := c.doData(ctx, http.MethodGet, "/v1/deployments/"+url.PathEscape(dseq), nil, &out); err != nil {
 		return nil, err
@@ -309,9 +357,19 @@ func (c *Client) GetDeployment(ctx context.Context, dseq string) (*DeploymentDet
 // Wire: PUT /v1/deployments/{dseq}, body {"data":{"sdl":...}}, data-enveloped
 // response.
 func (c *Client) UpdateDeployment(ctx context.Context, dseq, sdl string) (*DeploymentDetail, error) {
+	if err := validateDSeq(dseq); err != nil {
+		c.record("update-deployment", dseq, err)
+		return nil, err
+	}
+
 	expectedHash, _, err := deploymentArtifacts(sdl)
 	if err != nil {
 		wrapped := fmt.Errorf("prepare deployment SDL: %w", err)
+		c.record("update-deployment", dseq, wrapped)
+		return nil, wrapped
+	}
+	if _, err := c.requireMutableDeployment(ctx, dseq); err != nil {
+		wrapped := fmt.Errorf("preflight deployment update: %w", err)
 		c.record("update-deployment", dseq, wrapped)
 		return nil, wrapped
 	}
@@ -385,6 +443,11 @@ func isTransientManifestVersionError(err error) bool {
 //
 // Wire: DELETE /v1/deployments/{dseq}.
 func (c *Client) CloseDeployment(ctx context.Context, dseq string) error {
+	if err := validateDSeq(dseq); err != nil {
+		c.record("close-deployment", dseq, err)
+		return err
+	}
+
 	var out struct {
 		Success *bool `json:"success"`
 	}
@@ -437,6 +500,15 @@ func isAlreadyClosed(err error) bool {
 //
 // Wire: POST /v1/deposit-deployment, body {"data":{"dseq":..., "deposit":...}}.
 func (c *Client) Deposit(ctx context.Context, dseq string, amountUSD float64) error {
+	if err := validateDSeq(dseq); err != nil {
+		c.record("deposit", dseq, err)
+		return err
+	}
+	if err := validateDepositUSD(amountUSD); err != nil {
+		c.record("deposit", dseq, err)
+		return err
+	}
+
 	expectedMicros, err := consoleDepositMicros(amountUSD)
 	if err != nil {
 		wrapped := fmt.Errorf("prepare deployment deposit: %w", err)
@@ -449,6 +521,10 @@ func (c *Client) Deposit(ctx context.Context, dseq string, amountUSD float64) er
 		wrapped := fmt.Errorf("snapshot deployment escrow before deposit: %w", err)
 		c.record("deposit", dseq, wrapped)
 		return wrapped
+	}
+	if err := requireMutableState(before, dseq); err != nil {
+		c.record("deposit", dseq, err)
+		return err
 	}
 	if before.Deployment.ID.DSeq.String() != dseq {
 		wrapped := fmt.Errorf("console: deployment pre-state returned dseq %q, want %q", before.Deployment.ID.DSeq.String(), dseq)
@@ -512,6 +588,17 @@ func consoleDepositMicros(amountUSD float64) (*big.Int, error) {
 	}
 
 	return new(big.Int).Set(amount.Num()), nil
+}
+
+func validateDepositUSD(amountUSD float64) error {
+	if amountUSD < MinDepositUSD {
+		return fmt.Errorf("console: deployment deposit must be at least $%.2f, got %v", MinDepositUSD, amountUSD)
+	}
+	if _, err := consoleDepositMicros(amountUSD); err != nil {
+		return fmt.Errorf("console: invalid deployment deposit: %w", err)
+	}
+
+	return nil
 }
 
 func deploymentEscrowTotals(detail *DeploymentDetail) (map[string]*big.Rat, error) {
@@ -678,6 +765,10 @@ func depositTotalDeltaMatches(before, after map[string]*big.Rat, expected *big.I
 //
 // Wire: GET /v1/bids?dseq=, response {"data":[{"bid":{...}}]}.
 func (c *Client) FetchBids(ctx context.Context, dseq string) ([]Bid, error) {
+	if err := validateDSeq(dseq); err != nil {
+		return nil, err
+	}
+
 	path := "/v1/bids?dseq=" + url.QueryEscape(dseq)
 
 	var wrapped []struct {
@@ -702,6 +793,12 @@ func (c *Client) FetchBids(ctx context.Context, dseq string) ([]Bid, error) {
 // data-enveloped: {"manifest":..., "leases":[{dseq,gseq,oseq,provider}]}.
 // The response is data-enveloped.
 func (c *Client) CreateLease(ctx context.Context, manifest string, leases []LeaseRequest) (*DeploymentDetail, error) {
+	for _, lease := range leases {
+		if err := validateDSeq(lease.DSeq); err != nil {
+			return nil, err
+		}
+	}
+
 	body := map[string]any{
 		"manifest": manifest,
 		"leases":   leases,
@@ -794,6 +891,10 @@ func requestedLeasesActive(actual []Lease, requested []LeaseRequest) bool {
 //
 // Wire: GET /v2/deployment-settings/{dseq}, data-enveloped response.
 func (c *Client) GetDeploymentSettings(ctx context.Context, dseq string) (*DeploymentSettings, error) {
+	if err := validateDSeq(dseq); err != nil {
+		return nil, err
+	}
+
 	var out DeploymentSettings
 	if err := c.doData(ctx, http.MethodGet, "/v2/deployment-settings/"+url.PathEscape(dseq), nil, &out); err != nil {
 		return nil, err
@@ -810,6 +911,16 @@ func (c *Client) GetDeploymentSettings(ctx context.Context, dseq string) (*Deplo
 // {"data":{"autoTopUpEnabled":...}}; on 404, POST /v2/deployment-settings,
 // body {"data":{"dseq":..., "autoTopUpEnabled":...}}.
 func (c *Client) SetDeploymentAutoTopUp(ctx context.Context, dseq string, enabled bool) (*DeploymentSettings, error) {
+	if err := validateDSeq(dseq); err != nil {
+		c.record("update-deployment-settings", dseq, err)
+		return nil, err
+	}
+	if _, err := c.requireMutableDeployment(ctx, dseq); err != nil {
+		wrapped := fmt.Errorf("preflight deployment settings: %w", err)
+		c.record("update-deployment-settings", dseq, wrapped)
+		return nil, wrapped
+	}
+
 	var out struct {
 		DSeq                 *FlexString `json:"dseq"`
 		AutoTopUpEnabled     *bool       `json:"autoTopUpEnabled"`
@@ -838,4 +949,28 @@ func (c *Client) SetDeploymentAutoTopUp(ctx context.Context, dseq string, enable
 		EstimatedTopUpAmount: out.EstimatedTopUpAmount,
 		TopUpFrequencyMs:     out.TopUpFrequencyMs,
 	}, nil
+}
+
+func (c *Client) requireMutableDeployment(ctx context.Context, dseq string) (*DeploymentDetail, error) {
+	detail, err := c.GetDeployment(ctx, dseq)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireMutableState(detail, dseq); err != nil {
+		return nil, err
+	}
+
+	return detail, nil
+}
+
+func requireMutableState(detail *DeploymentDetail, dseq string) error {
+	state := "unknown"
+	if detail != nil && strings.TrimSpace(detail.Deployment.State) != "" {
+		state = strings.ToLower(strings.TrimSpace(detail.Deployment.State))
+	}
+	if state == "closed" {
+		return fmt.Errorf("console: deployment %s is closed and cannot be modified", dseq)
+	}
+
+	return nil
 }

--- a/internal/console/deployments.go
+++ b/internal/console/deployments.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -436,10 +437,10 @@ func isTransientManifestVersionError(err error) bool {
 		strings.Contains(strings.ToLower(httpErr.Body), "manifest version validation failed")
 }
 
-// CloseDeployment closes a deployment. If the deployment is already closed
-// (the API answers 404, or 400 with an already-closed message) it returns
-// ErrAlreadyClosed, which callers may treat as success for idempotent
-// behavior. Any other 400 is a genuine failure and is returned as-is.
+// CloseDeployment closes an active deployment. It first reads the deployment
+// so an absent or already-closed target is reported as ErrAlreadyClosed and no
+// DELETE is sent. The command therefore never reports a mutation it did not
+// perform.
 //
 // Wire: DELETE /v1/deployments/{dseq}.
 func (c *Client) CloseDeployment(ctx context.Context, dseq string) error {
@@ -447,11 +448,26 @@ func (c *Client) CloseDeployment(ctx context.Context, dseq string) error {
 		c.record("close-deployment", dseq, err)
 		return err
 	}
+	detail, err := c.GetDeployment(ctx, dseq)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			err = fmt.Errorf("%w (dseq %s)", ErrAlreadyClosed, dseq)
+		} else {
+			err = fmt.Errorf("preflight close deployment: %w", err)
+		}
+		c.record("close-deployment", dseq, err)
+		return err
+	}
+	if strings.EqualFold(strings.TrimSpace(detail.Deployment.State), "closed") {
+		err = fmt.Errorf("%w (dseq %s)", ErrAlreadyClosed, dseq)
+		c.record("close-deployment", dseq, err)
+		return err
+	}
 
 	var out struct {
 		Success *bool `json:"success"`
 	}
-	err := c.doData(ctx, http.MethodDelete, "/v1/deployments/"+url.PathEscape(dseq), nil, &out)
+	err = c.doData(ctx, http.MethodDelete, "/v1/deployments/"+url.PathEscape(dseq), nil, &out)
 	if err == nil && (out.Success == nil || !*out.Success) {
 		err = errors.New("console: close deployment response did not acknowledge success: true")
 	}
@@ -462,9 +478,9 @@ func (c *Client) CloseDeployment(ctx context.Context, dseq string) error {
 		return nil
 
 	case isAlreadyClosed(err):
-		// Desired end state reached; log as success but surface the sentinel.
-		c.record("close-deployment", dseq, nil)
-		return fmt.Errorf("%w (dseq %s)", ErrAlreadyClosed, dseq)
+		err = fmt.Errorf("%w (dseq %s)", ErrAlreadyClosed, dseq)
+		c.record("close-deployment", dseq, err)
+		return err
 
 	default:
 		c.record("close-deployment", dseq, err)
@@ -591,11 +607,19 @@ func consoleDepositMicros(amountUSD float64) (*big.Int, error) {
 }
 
 func validateDepositUSD(amountUSD float64) error {
+	if math.IsNaN(amountUSD) || math.IsInf(amountUSD, 0) {
+		return fmt.Errorf("console: deployment deposit must be a finite USD amount")
+	}
+	if amountUSD < 0 {
+		return fmt.Errorf("console: deployment deposit must not be negative")
+	}
+
+	text := strconv.FormatFloat(amountUSD, 'f', -1, 64)
+	if _, fraction, ok := strings.Cut(text, "."); ok && len(fraction) > 2 {
+		return fmt.Errorf("console: deployment deposit must have at most two fractional digits")
+	}
 	if amountUSD < MinDepositUSD {
 		return fmt.Errorf("console: deployment deposit must be at least $%.2f, got %v", MinDepositUSD, amountUSD)
-	}
-	if _, err := consoleDepositMicros(amountUSD); err != nil {
-		return fmt.Errorf("console: invalid deployment deposit: %w", err)
 	}
 
 	return nil

--- a/internal/console/deployments_test.go
+++ b/internal/console/deployments_test.go
@@ -321,6 +321,35 @@ func TestListDeployments(t *testing.T) {
 	assert.True(t, resp.Pagination.HasMore)
 }
 
+func TestListDeploymentsByStateFiltersBeforeApplyingPageWindow(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("skip") {
+		case "0":
+			_, _ = w.Write([]byte(`{"data":{"deployments":[
+				{"deployment":{"id":{"dseq":"1"},"state":"active"}},
+				{"deployment":{"id":{"dseq":"2"},"state":"closed"}}
+			],"pagination":{"skip":0,"limit":2,"hasMore":true}}}`))
+		case "2":
+			_, _ = w.Write([]byte(`{"data":{"deployments":[
+				{"deployment":{"id":{"dseq":"3"},"state":"active"}},
+				{"deployment":{"id":{"dseq":"4"},"state":"active"}}
+			],"pagination":{"skip":2,"limit":2,"hasMore":false}}}`))
+		default:
+			t.Fatalf("unexpected pagination request %s", r.URL.RawQuery)
+		}
+	}))
+	defer srv.Close()
+
+	result, err := console.New(srv.URL, "test-key").ListDeploymentsByState(
+		context.Background(), "active", 1, 1,
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Deployments, 1)
+	assert.Equal(t, "3", result.Deployments[0].Deployment.ID.DSeq.String())
+	assert.Equal(t, 3, result.Pagination.Total)
+	assert.True(t, result.Pagination.HasMore)
+}
+
 func TestGetDeployment(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -358,6 +387,11 @@ func TestGetDeployment(t *testing.T) {
 func TestUpdateDeployment(t *testing.T) {
 	expectedHash := versionHash(t, validUpdateSDL)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			assert.Equal(t, "/v1/deployments/555", r.URL.Path)
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"555"},"state":"active"}}}`))
+			return
+		}
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Equal(t, "/v1/deployments/555", r.URL.Path)
 
@@ -607,7 +641,7 @@ func TestDepositRejectsInvalidAmountBeforeNetwork(t *testing.T) {
 	defer srv.Close()
 
 	err := console.New(srv.URL, "test-key").Deposit(context.Background(), "321", 0)
-	require.ErrorContains(t, err, "prepare deployment deposit")
+	require.ErrorContains(t, err, "at least $0.50")
 	assert.Equal(t, int32(0), requests.Load(), "invalid amount must not read or mutate remote state")
 }
 
@@ -981,6 +1015,11 @@ func TestGetDeploymentSettingsNotFound(t *testing.T) {
 
 func TestSetDeploymentAutoTopUpPatch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			assert.Equal(t, "/v1/deployments/321", r.URL.Path)
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"321"},"state":"active"}}}`))
+			return
+		}
 		assert.Equal(t, http.MethodPatch, r.Method)
 		assert.Equal(t, "/v2/deployment-settings/321", r.URL.Path)
 
@@ -1002,6 +1041,9 @@ func TestSetDeploymentAutoTopUpFallsBackToPost(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
+		case http.MethodGet:
+			assert.Equal(t, "/v1/deployments/654", r.URL.Path)
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"654"},"state":"active"}}}`))
 		case http.MethodPatch:
 			patchCalled = true
 			assert.Equal(t, "/v2/deployment-settings/654", r.URL.Path)

--- a/internal/console/deployments_test.go
+++ b/internal/console/deployments_test.go
@@ -505,10 +505,15 @@ func TestUpdateDeploymentRetriesTransientManifestValidation(t *testing.T) {
 
 func TestCloseDeployment(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodDelete, r.Method)
 		assert.Equal(t, "/v1/deployments/99999", r.URL.Path)
-
-		_, _ = w.Write([]byte(`{"data":{"success":true}}`))
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"99999"},"state":"active"}}}`))
+		case http.MethodDelete:
+			_, _ = w.Write([]byte(`{"data":{"success":true}}`))
+		default:
+			t.Fatalf("unexpected request method %s", r.Method)
+		}
 	}))
 	defer srv.Close()
 
@@ -522,7 +527,12 @@ func TestCloseDeploymentRejectsMissingOrFalseSuccess(t *testing.T) {
 		`{"data":{"success":false}}`,
 	} {
 		t.Run(body, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"1"},"state":"active"}}}`))
+					return
+				}
+				assert.Equal(t, http.MethodDelete, r.Method)
 				_, _ = w.Write([]byte(body))
 			}))
 			defer srv.Close()
@@ -539,7 +549,7 @@ func TestCloseDeploymentAlreadyClosedSentinel(t *testing.T) {
 		status int
 		body   string
 	}{
-		// 404 = resource gone = desired end state, regardless of body.
+		// 404 during preflight = resource absent, regardless of body.
 		{"404", http.StatusNotFound, `{"error":"no such deployment"}`},
 		// 400 maps to the sentinel only when the body says so.
 		{"400 already closed", http.StatusBadRequest, `{"error":"deployment already closed"}`},
@@ -549,7 +559,11 @@ func TestCloseDeploymentAlreadyClosedSentinel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.status != http.StatusNotFound && r.Method == http.MethodGet {
+					_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"1"},"state":"active"}}}`))
+					return
+				}
 				w.WriteHeader(tt.status)
 				_, _ = w.Write([]byte(tt.body))
 			}))
@@ -559,9 +573,33 @@ func TestCloseDeploymentAlreadyClosedSentinel(t *testing.T) {
 			err := c.CloseDeployment(context.Background(), "1")
 			require.Error(t, err)
 			assert.ErrorIs(t, err, console.ErrAlreadyClosed,
-				"HTTP %d %q must map to ErrAlreadyClosed for idempotent close", tt.status, tt.body)
+				"HTTP %d %q must map to ErrAlreadyClosed", tt.status, tt.body)
 		})
 	}
+}
+
+func TestCloseDeploymentRejectsClosedPreflightBeforeDelete(t *testing.T) {
+	var gets atomic.Int32
+	var deletes atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			gets.Add(1)
+			assert.Equal(t, "/v1/deployments/1", r.URL.Path)
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"1"},"state":"closed"}}}`))
+		case http.MethodDelete:
+			deletes.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	err := console.New(srv.URL, "test-key").CloseDeployment(context.Background(), "1")
+	require.ErrorIs(t, err, console.ErrAlreadyClosed)
+	assert.Equal(t, int32(1), gets.Load())
+	assert.Equal(t, int32(0), deletes.Load(), "closed preflight must prevent a false mutation")
 }
 
 func TestCloseDeploymentBadRequestValidationIsRealError(t *testing.T) {
@@ -640,8 +678,13 @@ func TestDepositRejectsInvalidAmountBeforeNetwork(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := console.New(srv.URL, "test-key").Deposit(context.Background(), "321", 0)
+	client := console.New(srv.URL, "test-key")
+	err := client.Deposit(context.Background(), "321", 0)
 	require.ErrorContains(t, err, "at least $0.50")
+	err = client.Deposit(context.Background(), "321", -1)
+	require.ErrorContains(t, err, "must not be negative")
+	err = client.Deposit(context.Background(), "321", 0.505)
+	require.ErrorContains(t, err, "at most two fractional digits")
 	assert.Equal(t, int32(0), requests.Load(), "invalid amount must not read or mutate remote state")
 }
 

--- a/internal/console/manifests.go
+++ b/internal/console/manifests.go
@@ -17,8 +17,9 @@ import (
 // — "../..", absolute paths, empty strings — must never reach
 // filepath.Join.
 func validateDSeq(dseq string) error {
-	if _, err := strconv.ParseUint(dseq, 10, 64); err != nil {
-		return fmt.Errorf("console: invalid dseq %q: must be a plain numeric sequence", dseq)
+	parsed, err := strconv.ParseUint(dseq, 10, 64)
+	if err != nil || parsed == 0 {
+		return fmt.Errorf("console: invalid dseq %q: must be a positive numeric sequence", dseq)
 	}
 
 	return nil

--- a/internal/console/request_validation_test.go
+++ b/internal/console/request_validation_test.go
@@ -2,6 +2,7 @@ package console_test
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -114,4 +115,92 @@ func TestConsoleDeploymentMutationsRejectClosedState(t *testing.T) {
 			assert.Equal(t, int32(1), requests.Load(), "closed mutation must stop after state preflight")
 		})
 	}
+}
+
+func TestDeploymentStateListAndMutationValidationEdges(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer srv.Close()
+	client := console.New(srv.URL, "test-key")
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{name: "state skip", call: func() error {
+			_, err := client.ListDeploymentsByState(context.Background(), "active", -1, 1)
+			return err
+		}},
+		{name: "state limit", call: func() error {
+			_, err := client.ListDeploymentsByState(context.Background(), "active", 0, 0)
+			return err
+		}},
+		{name: "state value", call: func() error {
+			_, err := client.ListDeploymentsByState(context.Background(), "pending", 0, 1)
+			return err
+		}},
+		{name: "update dseq", call: func() error {
+			_, err := client.UpdateDeployment(context.Background(), "bad", validUpdateSDL)
+			return err
+		}},
+		{name: "close dseq", call: func() error {
+			return client.CloseDeployment(context.Background(), "bad")
+		}},
+		{name: "deposit dseq", call: func() error {
+			return client.Deposit(context.Background(), "bad", 1)
+		}},
+		{name: "deposit nan", call: func() error {
+			return client.Deposit(context.Background(), "1", math.NaN())
+		}},
+		{name: "deposit sub-micro precision", call: func() error {
+			return client.Deposit(context.Background(), "1", 0.5000001)
+		}},
+		{name: "get settings dseq", call: func() error {
+			_, err := client.GetDeploymentSettings(context.Background(), "bad")
+			return err
+		}},
+		{name: "set settings dseq", call: func() error {
+			_, err := client.SetDeploymentAutoTopUp(context.Background(), "bad", true)
+			return err
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Error(t, test.call())
+		})
+	}
+	assert.Zero(t, requests.Load(), "validation failures must not reach Console")
+}
+
+func TestDeploymentStateListBoundsAndRequestFailure(t *testing.T) {
+	t.Run("page bounds", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":{"deployments":[{"deployment":{"id":{"dseq":"1"},"state":"active"}}],"pagination":{"hasMore":false}}}`))
+		}))
+		defer srv.Close()
+		result, err := console.New(srv.URL, "test-key").ListDeploymentsByState(context.Background(), " ACTIVE ", 10, 5)
+		require.NoError(t, err)
+		assert.Empty(t, result.Deployments)
+		assert.Equal(t, 1, result.Pagination.Total)
+	})
+
+	t.Run("collection request", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "offline", http.StatusBadGateway)
+		}))
+		defer srv.Close()
+		_, err := console.New(srv.URL, "test-key").ListDeploymentsByState(context.Background(), "active", 0, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("mutable preflight request", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "offline", http.StatusBadGateway)
+		}))
+		defer srv.Close()
+		_, err := console.New(srv.URL, "test-key").SetDeploymentAutoTopUp(context.Background(), "42", true)
+		require.ErrorContains(t, err, "preflight deployment settings")
+	})
 }

--- a/internal/console/request_validation_test.go
+++ b/internal/console/request_validation_test.go
@@ -54,7 +54,7 @@ func TestConsoleRequestBoundariesRejectInvalidValuesBeforeHTTP(t *testing.T) {
 			return err
 		}, want: "invalid dseq"},
 		{name: "create deposit", call: func() error {
-			_, err := client.CreateDeployment(context.Background(), validUpdateSDL, 0.499999)
+			_, err := client.CreateDeployment(context.Background(), validUpdateSDL, 0.49)
 			return err
 		}, want: "at least $0.50"},
 		{name: "escrow deposit", call: func() error {

--- a/internal/console/request_validation_test.go
+++ b/internal/console/request_validation_test.go
@@ -1,0 +1,117 @@
+package console_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"pkg.akt.dev/akt/internal/console"
+)
+
+func TestConsoleRequestBoundariesRejectInvalidValuesBeforeHTTP(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer srv.Close()
+
+	client := console.New(srv.URL, "test-key")
+	tests := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{name: "negative pagination", call: func() error {
+			_, err := client.ListDeployments(context.Background(), -1, 20)
+			return err
+		}, want: "skip must be non-negative"},
+		{name: "zero page size", call: func() error {
+			_, err := client.ListDeployments(context.Background(), 0, 0)
+			return err
+		}, want: "limit must be greater than zero"},
+		{name: "deployment dseq", call: func() error {
+			_, err := client.GetDeployment(context.Background(), "not-a-number")
+			return err
+		}, want: "invalid dseq"},
+		{name: "bid dseq", call: func() error {
+			_, err := client.FetchBids(context.Background(), "not-a-number")
+			return err
+		}, want: "invalid dseq"},
+		{name: "settings dseq", call: func() error {
+			_, err := client.GetDeploymentSettings(context.Background(), "0")
+			return err
+		}, want: "invalid dseq"},
+		{name: "lease dseq", call: func() error {
+			_, err := client.CreateLease(context.Background(), "[]", []console.LeaseRequest{{
+				DSeq: "bad", GSeq: 1, OSeq: 1, Provider: "akash1provider",
+			}})
+			return err
+		}, want: "invalid dseq"},
+		{name: "create deposit", call: func() error {
+			_, err := client.CreateDeployment(context.Background(), validUpdateSDL, 0.499999)
+			return err
+		}, want: "at least $0.50"},
+		{name: "escrow deposit", call: func() error {
+			return client.Deposit(context.Background(), "123", 0.01)
+		}, want: "at least $0.50"},
+		{name: "api key uuid", call: func() error {
+			return client.DeleteAPIKey(context.Background(), "")
+		}, want: "valid UUID"},
+		{name: "jwt zero ttl", call: func() error {
+			_, err := client.CreateJWTToken(context.Background(), 0, []string{"logs"})
+			return err
+		}, want: "between 1 and 3600"},
+		{name: "jwt excessive ttl", call: func() error {
+			_, err := client.CreateJWTToken(context.Background(), 3601, []string{"logs"})
+			return err
+		}, want: "between 1 and 3600"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.ErrorContains(t, test.call(), test.want)
+		})
+	}
+	assert.Zero(t, requests.Load(), "invalid requests must not reach Console")
+}
+
+func TestConsoleDeploymentMutationsRejectClosedState(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*console.Client) error
+	}{
+		{name: "update", call: func(client *console.Client) error {
+			_, err := client.UpdateDeployment(context.Background(), "42", validUpdateSDL)
+			return err
+		}},
+		{name: "deposit", call: func(client *console.Client) error {
+			return client.Deposit(context.Background(), "42", 0.50)
+		}},
+		{name: "settings", call: func(client *console.Client) error {
+			_, err := client.SetDeploymentAutoTopUp(context.Background(), "42", false)
+			return err
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/v1/deployments/42", r.URL.Path)
+				_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"dseq":"42"},"state":"closed"}}}`))
+			}))
+			defer srv.Close()
+
+			err := test.call(console.New(srv.URL, "test-key"))
+			require.ErrorContains(t, err, "is closed")
+			assert.Equal(t, int32(1), requests.Load(), "closed mutation must stop after state preflight")
+		})
+	}
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -245,6 +245,7 @@ const (
 	FlagTail                        = "tail"
 	FlagTemplate                    = "template"
 	FlagTestnetRootDir              = "testnet-rootdir"
+	FlagTimeout                     = "timeout"
 	FlagTimeoutDuration             = "timeout-duration"
 	FlagTimeoutHeight               = "timeout-height"
 	FlagTip                         = "tip"

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -13,6 +13,7 @@ import (
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	v1beta3 "pkg.akt.dev/go/node/client/v1beta3"
@@ -94,6 +95,10 @@ func TestNewRegistersExactToolsForEachAvailableRail(t *testing.T) {
 		WithAccountRetriever(authtypes.AccountRetriever{}).
 		WithBroadcastMode("sync").
 		WithSignModeStr(flags.SignModeDirect)
+	missingAccountAddress := sdk.AccAddress([]byte("01234567890123456789"))
+	missingAccountContext := keyringChainContext.
+		WithFrom(missingAccountAddress.String()).
+		WithFromAddress(missingAccountAddress)
 
 	tests := []struct {
 		name          string
@@ -146,6 +151,12 @@ func TestNewRegistersExactToolsForEachAvailableRail(t *testing.T) {
 				),
 				consoleWriteToolNames()...,
 			),
+		},
+		{
+			name:          "missing chain account retains query rail",
+			clientContext: missingAccountContext,
+			enableWrites:  true,
+			want:          chainQueryToolNames(),
 		},
 	}
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -136,7 +136,7 @@ func (s *Server) registerChainTools(
 	// the write rail, never the already-healthy public query rail.
 	cl, err := client.NewClient(ctx, cctx)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // signer discovery is optional after query registration
 	}
 	s.registerWriteTools(ctx, cl, providerAuthType)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -113,6 +113,22 @@ func (s *Server) registerChainTools(
 	providerAuthType string,
 	enableWrites bool,
 ) error {
+	return s.registerChainToolsWithLightClient(
+		ctx,
+		cctx,
+		providerAuthType,
+		enableWrites,
+		client.NewLightClient,
+	)
+}
+
+func (s *Server) registerChainToolsWithLightClient(
+	ctx context.Context,
+	cctx sdkclient.Context,
+	providerAuthType string,
+	enableWrites bool,
+	newLightClient func(sdkclient.Context) (client.LightClient, error),
+) error {
 	// Checked before building a client, because the constructors accept an
 	// empty context happily and hand back something that fails on every call.
 	// Registering those tools would advertise a chain rail that cannot work,
@@ -121,7 +137,7 @@ func (s *Server) registerChainTools(
 		return errors.New("no chain RPC endpoint configured for the active context")
 	}
 
-	light, err := client.NewLightClient(cctx)
+	light, err := newLightClient(cctx)
 	if err != nil {
 		return err
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -121,24 +121,24 @@ func (s *Server) registerChainTools(
 		return errors.New("no chain RPC endpoint configured for the active context")
 	}
 
-	if enableWrites {
-		cl, err := client.NewClient(ctx, cctx)
-		if err != nil {
-			return err
-		}
-
-		s.registerQueryTools(cl, providerAuthType)
-		s.registerWriteTools(ctx, cl, providerAuthType)
-
-		return nil
-	}
-
-	cl, err := client.NewLightClient(cctx)
+	light, err := client.NewLightClient(cctx)
 	if err != nil {
 		return err
 	}
+	s.registerQueryTools(light, providerAuthType)
 
-	s.registerQueryTools(cl, providerAuthType)
+	if !enableWrites {
+		return nil
+	}
+
+	// A signing client resolves the account against chain state. A new or
+	// unfunded key can legitimately have no account yet; that must only remove
+	// the write rail, never the already-healthy public query rail.
+	cl, err := client.NewClient(ctx, cctx)
+	if err != nil {
+		return nil
+	}
+	s.registerWriteTools(ctx, cl, providerAuthType)
 
 	return nil
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2,10 +2,12 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	chainclient "pkg.akt.dev/go/node/client/v1beta3"
 
 	aktconsole "pkg.akt.dev/akt/internal/console"
 )
@@ -106,5 +108,21 @@ func TestNewWithConsoleOnlySucceeds(t *testing.T) {
 	}
 	if s == nil {
 		t.Fatal("expected a server")
+	}
+}
+
+func TestRegisterChainToolsReturnsLightClientFailure(t *testing.T) {
+	sentinel := errors.New("light client failed")
+	err := (&Server{}).registerChainToolsWithLightClient(
+		context.Background(),
+		sdkclient.Context{}.WithNodeURI("https://rpc.example.test"),
+		"jwt",
+		false,
+		func(sdkclient.Context) (chainclient.LightClient, error) {
+			return nil, sentinel
+		},
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("light client error = %v", err)
 	}
 }

--- a/internal/provider/boundary.go
+++ b/internal/provider/boundary.go
@@ -67,7 +67,7 @@ func wrapGatewayClient(
 	providerURL string,
 	authorization gatewayAuthorization,
 	redactionSecrets ...string,
-) (rest.Client, error) {
+) (*gatewayClient, error) {
 	host, err := url.Parse(providerURL)
 	if err != nil {
 		return nil, err

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -18,6 +18,22 @@ import (
 	atls "pkg.akt.dev/go/util/tls"
 )
 
+// GatewayClientOption configures akt's provider gateway boundary.
+type GatewayClientOption func(*gatewayClient) error
+
+// WithOneShotTimeout sets the deadline applied to finite provider gateway
+// requests. Established streaming requests retain the caller's lifetime.
+func WithOneShotTimeout(timeout time.Duration) GatewayClientOption {
+	return func(client *gatewayClient) error {
+		if timeout <= 0 {
+			return fmt.Errorf("provider gateway timeout must be greater than zero")
+		}
+		client.oneShotTimeout = timeout
+
+		return nil
+	}
+}
+
 // NewPublicGatewayClient creates a provider gateway REST client without
 // attaching wallet authentication. It is only suitable for public endpoints
 // such as provider status.
@@ -25,12 +41,31 @@ func NewPublicGatewayClient(
 	ctx context.Context,
 	addr sdk.AccAddress,
 	providerURL string,
+	options ...GatewayClientOption,
 ) (rest.Client, error) {
 	client, err := rest.NewClient(ctx, addr, rest.WithProviderURL(providerURL))
 	if err != nil {
 		return nil, err
 	}
-	return wrapGatewayClient(gatewayStreamBoundaryClient{Client: client}, providerURL, nil)
+	gateway, err := wrapGatewayClient(gatewayStreamBoundaryClient{Client: client}, providerURL, nil)
+	return configurePublicGatewayClient(gateway, err, options...)
+}
+
+func configurePublicGatewayClient(
+	gateway *gatewayClient,
+	gatewayErr error,
+	options ...GatewayClientOption,
+) (rest.Client, error) {
+	if gatewayErr != nil {
+		return nil, gatewayErr
+	}
+	for _, option := range options {
+		if err := option(gateway); err != nil {
+			return nil, err
+		}
+	}
+
+	return gateway, nil
 }
 
 // NewTokenGatewayClient creates a provider client authenticated by an existing

--- a/internal/provider/client_boundary_test.go
+++ b/internal/provider/client_boundary_test.go
@@ -414,7 +414,7 @@ func TestGatewayStreamRetainsCallerCancellation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("wrap gateway client: %v", err)
 	}
-	bounded := wrapped.(*gatewayClient)
+	bounded := wrapped
 	bounded.oneShotTimeout = 10 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -843,7 +843,7 @@ func TestGatewayBoundaryStreamCancellationAndDecodeFailures(t *testing.T) {
 		defer server.Close()
 
 		wrapped := gatewayBoundaryClientForWebsocketServer(t, server.URL)
-		client := wrapped.(*gatewayClient)
+		client := wrapped
 		source := client.Client.(gatewayStreamRequestSource)
 		ctx, cancel := context.WithCancel(context.Background())
 		stream, onClose, err := openGatewayStream[rest.ServiceLogMessage](
@@ -1126,7 +1126,7 @@ func newClosedWebsocketConn(t *testing.T) *websocket.Conn {
 	return conn
 }
 
-func gatewayBoundaryClientForWebsocketServer(t *testing.T, rawURL string) rest.Client {
+func gatewayBoundaryClientForWebsocketServer(t *testing.T, rawURL string) *gatewayClient {
 	t.Helper()
 	serverURL, err := url.Parse(rawURL)
 	if err != nil {
@@ -1557,7 +1557,7 @@ func gatewayClientForRequest(t *testing.T, do gatewayRequestClientFunc) *gateway
 	if err != nil {
 		t.Fatalf("wrap request client: %v", err)
 	}
-	return wrapped.(*gatewayClient)
+	return wrapped
 }
 
 func sdkClientContextForBoundary(kr sdkkeyring.Keyring, owner sdk.AccAddress) sdkclient.Context {

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -157,6 +157,28 @@ func TestPublicGatewayClientDoesNotSendWalletAuthentication(t *testing.T) {
 	}
 }
 
+func TestPublicGatewayClientRejectsNonPositiveOneShotTimeout(t *testing.T) {
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		_, err := NewPublicGatewayClient(
+			context.Background(),
+			nil,
+			"https://provider.example.com:8443",
+			WithOneShotTimeout(timeout),
+		)
+		if err == nil || !strings.Contains(err.Error(), "timeout must be greater than zero") {
+			t.Fatalf("timeout %s error = %v", timeout, err)
+		}
+	}
+}
+
+func TestConfigurePublicGatewayClientPreservesWrapFailure(t *testing.T) {
+	wantErr := errors.New("wrap public gateway")
+	client, err := configurePublicGatewayClient(nil, wantErr)
+	if client != nil || !errors.Is(err, wantErr) {
+		t.Fatalf("configure public gateway = %T, %v; want nil and wrap failure", client, err)
+	}
+}
+
 func TestGatewayAuthenticationRejectsInvalidBoundary(t *testing.T) {
 	kr, _, owner := newProviderTestIdentity(t)
 	tests := []struct {

--- a/internal/provider/gateway.go
+++ b/internal/provider/gateway.go
@@ -230,3 +230,18 @@ func GatewayError(action string, err error) error {
 
 	return fmt.Errorf("%s: %w", action, err)
 }
+
+// GatewayErrorForProvider preserves the gateway failure and gives operators
+// an exact read-only chain fallback for the provider's registered attributes.
+func GatewayErrorForProvider(action, provider string, err error) error {
+	wrapped := GatewayError(action, err)
+	if wrapped == nil {
+		return nil
+	}
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return wrapped
+	}
+
+	return fmt.Errorf("%w; inspect on-chain provider attributes with `akt query provider %s`", wrapped, provider)
+}

--- a/internal/provider/gateway_test.go
+++ b/internal/provider/gateway_test.go
@@ -368,3 +368,14 @@ func TestGatewayErrorForProviderIncludesExactChainFallback(t *testing.T) {
 		t.Fatalf("fallback error = %q, want %q", err, want)
 	}
 }
+
+func TestGatewayErrorForProviderHandlesNilAndBlankProvider(t *testing.T) {
+	if err := GatewayErrorForProvider("query status", "akash1provider", nil); err != nil {
+		t.Fatalf("nil gateway error = %v", err)
+	}
+	sentinel := errors.New("offline")
+	err := GatewayErrorForProvider("query status", "   ", sentinel)
+	if !errors.Is(err, sentinel) || strings.Contains(err.Error(), "akt query provider") {
+		t.Fatalf("blank-provider error = %v", err)
+	}
+}

--- a/internal/provider/gateway_test.go
+++ b/internal/provider/gateway_test.go
@@ -355,3 +355,16 @@ func TestGatewayErrorPreservesOrdinaryErrors(t *testing.T) {
 		t.Fatalf("GatewayError = %q, want action context", err)
 	}
 }
+
+func TestGatewayErrorForProviderIncludesExactChainFallback(t *testing.T) {
+	sentinel := errors.New("connection refused")
+	const provider = "akash1providerfulladdress"
+	err := GatewayErrorForProvider("query provider status", provider, sentinel)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("fallback error lost cause: %v", err)
+	}
+	want := "`akt query provider " + provider + "`"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("fallback error = %q, want %q", err, want)
+	}
+}

--- a/internal/transport/deposit.go
+++ b/internal/transport/deposit.go
@@ -55,7 +55,9 @@ type Deposit struct {
 //
 //	""/"auto"               -> rail default (chain: chain-minimum deposit;
 //	                           console: error, explicit USD required)
-//	"5usd", "$5", "5.50usd" -> USD amount (console rail only)
+//	"5usd", "$5", "5.50usd" -> USD amount (console rail only; plain
+//	                              decimal notation with at most two
+//	                              fractional digits)
 //	"5000000uakt", "5akt"   -> coin amount (chain rail only)
 //	"5", "5.50"             -> bare number: USD on the console rail;
 //	                           rejected on the chain rail (coins need a
@@ -91,9 +93,12 @@ func ParseDeposit(s string) (Deposit, error) {
 		return Deposit{Raw: t, IsUSD: true, USD: usd}, nil
 	}
 
-	// Bare number: valid syntax on both rails, interpreted per rail.
-	if usd, err := strconv.ParseFloat(t, 64); err == nil {
-		if err := validUSDAmount(usd); err != nil {
+	// Bare number: valid syntax on both rails, interpreted per rail. Values
+	// that look numeric stay on the USD parsing path so syntax such as an
+	// exponent or a Go numeric separator cannot fall through to coin parsing.
+	if looksLikeBareUSD(t) {
+		usd, err := parseUSDAmount(t)
+		if err != nil {
 			return Deposit{}, fmt.Errorf("invalid deposit %q: %w", s, err)
 		}
 
@@ -157,6 +162,17 @@ func parseUSDAmount(s string) (float64, error) {
 	if s == "" {
 		return 0, fmt.Errorf("missing USD amount")
 	}
+	if strings.HasPrefix(s, "-") {
+		return 0, fmt.Errorf("USD amount must not be negative")
+	}
+
+	integer, fraction, hasPoint := strings.Cut(s, ".")
+	if integer == "" || !decimalDigits(integer) || (hasPoint && (fraction == "" || !decimalDigits(fraction))) {
+		return 0, fmt.Errorf("invalid USD amount %q: use plain decimal notation", s)
+	}
+	if hasPoint && len(fraction) > 2 {
+		return 0, fmt.Errorf("USD amount must have at most two fractional digits")
+	}
 
 	v, err := strconv.ParseFloat(s, 64)
 	if err != nil {
@@ -168,6 +184,29 @@ func parseUSDAmount(s string) (float64, error) {
 	}
 
 	return v, nil
+}
+
+func decimalDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return s != ""
+}
+
+func looksLikeBareUSD(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r == '.', r == '+', r == '-', r == 'e', r == 'E', r == '_':
+		default:
+			return false
+		}
+	}
+
+	return s != ""
 }
 
 // validUSDAmount rejects negative and non-finite USD amounts. Zero is left

--- a/internal/transport/deposit_test.go
+++ b/internal/transport/deposit_test.go
@@ -52,20 +52,44 @@ func TestParseDeposit(t *testing.T) {
 
 func TestParseDepositErrors(t *testing.T) {
 	for _, in := range []string{
-		"abc",     // not a USD, bare, or coin form
-		"$",       // missing USD amount
-		"$abc",    // non-numeric USD amount
-		"$-5",     // negative USD
-		"-5usd",   // negative USD
-		"usd",     // missing USD amount
-		"-5",      // negative bare amount
-		"$5usd",   // mixed USD forms
-		"AUTO",    // auto is lowercase only (historical chain behavior)
-		"-5uakt",  // negative coin
-		"5milusd", // usd suffix always wins; "5mil" is not a USD amount
+		"abc",      // not a USD, bare, or coin form
+		"$",        // missing USD amount
+		"$abc",     // non-numeric USD amount
+		"$-5",      // negative USD
+		"-5usd",    // negative USD
+		"usd",      // missing USD amount
+		"-5",       // negative bare amount
+		"0.005",    // sub-cent bare amount
+		"0.505usd", // sub-cent USD amount
+		"$1.001",   // sub-cent dollar form
+		"1e0",      // scientific notation is not plain decimal syntax
+		"1E2usd",   // scientific notation with a USD suffix
+		"1_000",    // Go numeric separators are not CLI currency syntax
+		"$5usd",    // mixed USD forms
+		"AUTO",     // auto is lowercase only (historical chain behavior)
+		"-5uakt",   // negative coin
+		"5milusd",  // usd suffix always wins; "5mil" is not a USD amount
 	} {
 		if _, err := ParseDeposit(in); err == nil {
 			t.Errorf("ParseDeposit(%q): expected error, got nil", in)
+		}
+	}
+}
+
+func TestParseDepositUSDGrammarErrorsAreSpecific(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "-1", want: "must not be negative"},
+		{in: "0.005", want: "at most two fractional digits"},
+		{in: "1e0", want: "plain decimal notation"},
+	}
+
+	for _, tt := range tests {
+		_, err := ParseDeposit(tt.in)
+		if err == nil || !strings.Contains(err.Error(), tt.want) {
+			t.Errorf("ParseDeposit(%q) error = %v, want %q", tt.in, err, tt.want)
 		}
 	}
 }

--- a/internal/workflow/adapters/chain.go
+++ b/internal/workflow/adapters/chain.go
@@ -296,28 +296,33 @@ func (c *chainClient) deriveDSeq(ctx context.Context, params map[string]string) 
 // "auto" (or empty) queries the chain minimum deployment deposit, mirroring
 // DetectDeploymentDeposit used by `akt tx deployment create`.
 func (c *chainClient) resolveDeposit(ctx context.Context, depositStr string) (depositv1.Deposit, error) {
-	if depositStr == "" || depositStr == depositAuto {
-		resp, err := c.cl.Query().Deployment().Params(ctx, &dv1beta.QueryParamsRequest{})
-		if err != nil {
-			return depositv1.Deposit{}, err
-		}
+	resolved, err := ResolveChainDepositValue(ctx, c.cl, depositStr)
+	if err != nil {
+		return depositv1.Deposit{}, err
+	}
 
-		depositStr = ""
+	return depositFromString(resolved)
+}
 
-		// always default to ACT
-		for _, sCoin := range resp.Params.MinDeposits {
-			if sCoin.Denom == "uact" {
-				depositStr = fmt.Sprintf("%s%s", sCoin.Amount, sCoin.Denom)
-				break
-			}
-		}
+// ResolveChainDepositValue returns the exact coin the chain adapter will put
+// on a deployment message. Planning and execution share this function so an
+// auto dry-run cannot advertise a value different from the broadcast path.
+func ResolveChainDepositValue(ctx context.Context, cl aclient.LightClient, depositStr string) (string, error) {
+	if depositStr != "" && depositStr != depositAuto {
+		return depositStr, nil
+	}
 
-		if depositStr == "" {
-			return depositv1.Deposit{}, fmt.Errorf("couldn't query default deposit amount for uAKT")
+	resp, err := cl.Query().Deployment().Params(ctx, &dv1beta.QueryParamsRequest{})
+	if err != nil {
+		return "", err
+	}
+	for _, coin := range resp.Params.MinDeposits {
+		if coin.Denom == "uact" {
+			return fmt.Sprintf("%s%s", coin.Amount, coin.Denom), nil
 		}
 	}
 
-	return depositFromString(depositStr)
+	return "", fmt.Errorf("chain deployment parameters contain no uact minimum deposit")
 }
 
 // verifyGroupsUnchanged replicates the safety check performed by

--- a/internal/workflow/adapters/chain_test.go
+++ b/internal/workflow/adapters/chain_test.go
@@ -583,8 +583,8 @@ func TestResolveDepositDistinguishesExplicitAndChainDefault(t *testing.T) {
 		c := newFakeWorkflowBoundaryClient(nil, deployment)
 
 		_, err := c.resolveDeposit(context.Background(), depositAuto)
-		if err == nil || !strings.Contains(err.Error(), "default deposit") {
-			t.Fatalf("resolve auto error = %v, want missing default deposit", err)
+		if err == nil || !strings.Contains(err.Error(), "no uact minimum deposit") {
+			t.Fatalf("resolve auto error = %v, want missing uact minimum", err)
 		}
 	})
 }

--- a/internal/workflow/adapters/console.go
+++ b/internal/workflow/adapters/console.go
@@ -3,7 +3,6 @@ package adapters
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -155,15 +154,14 @@ func (c *consoleChainClient) updateDeployment(ctx context.Context, params map[st
 }
 
 // closeDeployment maps deployment.MsgCloseDeployment to
-// DELETE /v1/deployments/{dseq}. An already-closed deployment is treated as
-// success for idempotent behavior.
+// DELETE /v1/deployments/{dseq}.
 func (c *consoleChainClient) closeDeployment(ctx context.Context, params map[string]string) (*steps.TxResult, error) {
 	dseq, err := requiredDSeqParam(params, msgCloseDeployment)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := c.cc.CloseDeployment(ctx, dseq); err != nil && !errors.Is(err, console.ErrAlreadyClosed) {
+	if err := c.cc.CloseDeployment(ctx, dseq); err != nil {
 		return nil, err
 	}
 

--- a/internal/workflow/adapters/console_test.go
+++ b/internal/workflow/adapters/console_test.go
@@ -306,6 +306,10 @@ func TestConsoleUpdateDeployment(t *testing.T) {
 
 	c, _ := newConsoleClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod, gotPath = r.Method, r.URL.Path
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"owner":"akash1x","dseq":"777"},"state":"active"},"leases":[]}}`))
+			return
+		}
 		gotData = decodeEnvelope(t, r)
 		_, _ = w.Write([]byte(`{"data":{"deployment":{"id":{"owner":"akash1x","dseq":"777"},"state":"active","hash":"` + expectedHash + `"},"leases":[]}}`))
 	})

--- a/internal/workflow/adapters/console_test.go
+++ b/internal/workflow/adapters/console_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -366,14 +367,11 @@ func TestConsoleCloseDeploymentAlreadyClosed(t *testing.T) {
 	})
 
 	res, err := c.BroadcastTx(context.Background(), msgCloseDeployment, map[string]string{"dseq": "999"})
-	if err != nil {
-		t.Fatalf("already-closed must be treated as success, got: %v", err)
+	if !errors.Is(err, console.ErrAlreadyClosed) {
+		t.Fatalf("already-closed error = %v, want ErrAlreadyClosed", err)
 	}
-
-	var data map[string]string
-	_ = json.Unmarshal(res.Data, &data)
-	if data["dseq"] != "999" {
-		t.Errorf("data dseq = %q, want \"999\"", data["dseq"])
+	if res != nil {
+		t.Fatalf("already-closed result = %+v, want no completed transaction", res)
 	}
 }
 

--- a/internal/workflow/builtin/deploy.yaml
+++ b/internal/workflow/builtin/deploy.yaml
@@ -37,6 +37,14 @@ params:
     type: duration
     default: "5m"
     description: Maximum time to wait for bids
+  ready-timeout:
+    type: duration
+    default: "2m"
+    description: Maximum time to wait for deployed services to become ready
+  no-wait-active:
+    type: bool
+    default: "false"
+    description: Return after manifest submission without polling service readiness
   bid-select:
     type: bid-selection
     default: "interactive"
@@ -95,9 +103,5 @@ steps:
   - name: display-result
     type: output
     template: |
-      Deployment active!
+      Deployment created!
         DSEQ: {{ (index .Steps "create-deployment").dseq }}
-      {{ if eq (index (index .Steps "create-deployment") "rail") "console" }}
-        Auto top-up: enabled ({{ (index .Steps "create-deployment").auto_top_up }})
-        Disable with: akt console deployment settings {{ (index .Steps "create-deployment").dseq }} false
-      {{ end }}

--- a/internal/workflow/template_extract_test.go
+++ b/internal/workflow/template_extract_test.go
@@ -291,7 +291,7 @@ func builtinStepTemplate(t *testing.T, workflow, step string) string {
 	return ""
 }
 
-func TestBuiltinDeployResultReportsConsoleAutoTopUp(t *testing.T) {
+func TestBuiltinDeployResultDefersConsoleCompletionDetails(t *testing.T) {
 	tmpl := builtinStepTemplate(t, "deploy", "display-result")
 	state := wf.NewRunState("wf-1", "deploy", "akash1owner", nil)
 	state.SetStepResult("create-deployment", &wf.StepResult{
@@ -309,17 +309,17 @@ func TestBuiltinDeployResultReportsConsoleAutoTopUp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveTemplate: %v", err)
 	}
-	for _, want := range []string{
-		"Auto top-up: enabled (daily)",
-		"akt console deployment settings 9911 false",
-	} {
-		if !strings.Contains(rendered, want) {
-			t.Errorf("Console result does not contain %q:\n%s", want, rendered)
+	if !strings.Contains(rendered, "Deployment created!") {
+		t.Errorf("Console result does not report creation:\n%s", rendered)
+	}
+	for _, premature := range []string{"Deployment active!", "Auto top-up", "console deployment settings"} {
+		if strings.Contains(rendered, premature) {
+			t.Errorf("pre-readiness result contains %q:\n%s", premature, rendered)
 		}
 	}
 }
 
-func TestBuiltinDeployResultOmitsConsoleSettingOnChain(t *testing.T) {
+func TestBuiltinDeployResultDefersChainCompletionDetails(t *testing.T) {
 	tmpl := builtinStepTemplate(t, "deploy", "display-result")
 	state := wf.NewRunState("wf-1", "deploy", "akash1owner", nil)
 	state.SetStepResult("create-deployment", &wf.StepResult{
@@ -333,8 +333,13 @@ func TestBuiltinDeployResultOmitsConsoleSettingOnChain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveTemplate: %v", err)
 	}
-	if strings.Contains(rendered, "Auto top-up") || strings.Contains(rendered, "console deployment settings") {
-		t.Errorf("chain result contains a Console-only setting:\n%s", rendered)
+	if !strings.Contains(rendered, "Deployment created!") {
+		t.Errorf("chain result does not report creation:\n%s", rendered)
+	}
+	for _, premature := range []string{"Deployment active!", "Auto top-up", "console deployment settings"} {
+		if strings.Contains(rendered, premature) {
+			t.Errorf("pre-readiness result contains %q:\n%s", premature, rendered)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve workflow step outputs in JSONL and report deployment identity, provider, price, live URIs, readiness, Console deep links, auto-top-up state, and actionable follow-up commands
- resolve dry-run deposits and signers through the same transport boundaries used by execution, including the live chain minimum with no hardcoded fallback
- enforce Console request validation for deposits, DSEQs, pagination, UUIDs, names, JWT lifetimes, and closed-deployment mutations before network work
- complete the six formerly partial contracts: Console next-step guidance (#66), keys add --yes compatibility (#71), provider status request deadlines (#73), truthful repeated-close failures (#75), truthful API-key deletion (#79), and fixed-point USD deposit syntax (#82)
- improve Console pretty money rendering, shell and screen UX, deployment filters, context and key guidance, provider failures, and empty-state output
- keep MCP query tools available when an optional signing client cannot initialize and resolve Console identities for chain-style read commands
- update DESIGN.md, SPEC.md, README.md, and AICHANGELOG.md before and alongside the implementation

Issue #74 was already satisfied on the current main branch; this sweep verified that behavior while addressing the surrounding default-account resolution gap in #67.

## Verification

- `GOWORK=off make akt`
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off make test-coverage-unit`
- active patch coverage: 100% (local changed-line gate, 0 reviewed exceptions)
- `git diff --check`
- signed commit `7173f9aedc84a15c06d2d0bc4fabb161b2d928e8`

## Issue coverage

Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #65
Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #71
Closes #72
Closes #73
Closes #74
Closes #75
Closes #76
Closes #77
Closes #78
Closes #79
Closes #80
Closes #81
Closes #82