### PR TITLE
fix(console): unify deposit validation and conversion

### DIFF
--- a/AICHANGELOG.md
+++ b/AICHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Fixed
 
+- **Release-range coverage no longer fails on an impossible Console deposit
+  branch**: Console USD validation now returns the exact micro-ACT value used
+  for escrow reconciliation. Deployment creation and deposit mutations share
+  that single boundary instead of validating first and then retaining a second
+  conversion error path that valid input could never reach. Exact conversion
+  tests cover whole-dollar, one-decimal, and two-decimal deposits while the
+  existing request-boundary tests continue to reject invalid amounts before
+  HTTP work.
+
 - **Six partially addressed backlog issues now have complete boundary
   contracts**: every successful Console leaf prints an action-specific `Next:`
   hint on stderr without contaminating structured stdout, while quiet mode

--- a/SPEC.md
+++ b/SPEC.md
@@ -541,7 +541,10 @@ error without sending DELETE; key creation rejects a blank name, and local key
 creation rejects a name that is blank after trimming. USD deposit inputs use
 plain fixed-point decimal syntax with at most two fractional digits; exponent
 notation, non-finite values, and sub-cent precision are rejected before any
-request.
+request. The Console boundary validates the USD value and derives the exact
+whole-micro-ACT reconciliation delta in one operation. Mutation code consumes
+that normalized result directly; it does not perform a second fallible
+conversion after validation has succeeded.
 Commands that require a terminal session, including an interactive Console
 shell with no explicit command, reject non-terminal stdin before any identity
 or network lookup can block.

--- a/internal/console/deployments.go
+++ b/internal/console/deployments.go
@@ -24,7 +24,7 @@ import (
 //
 // Wire: POST /v1/deployments, body {"data":{"sdl":..., "deposit":...}}.
 func (c *Client) CreateDeployment(ctx context.Context, sdl string, depositUSD float64) (*CreateDeploymentResult, error) {
-	if err := validateDepositUSD(depositUSD); err != nil {
+	if _, err := normalizeDepositUSD(depositUSD); err != nil {
 		c.record("create-deployment", "", err)
 		return nil, err
 	}
@@ -520,16 +520,10 @@ func (c *Client) Deposit(ctx context.Context, dseq string, amountUSD float64) er
 		c.record("deposit", dseq, err)
 		return err
 	}
-	if err := validateDepositUSD(amountUSD); err != nil {
+	expectedMicros, err := normalizeDepositUSD(amountUSD)
+	if err != nil {
 		c.record("deposit", dseq, err)
 		return err
-	}
-
-	expectedMicros, err := consoleDepositMicros(amountUSD)
-	if err != nil {
-		wrapped := fmt.Errorf("prepare deployment deposit: %w", err)
-		c.record("deposit", dseq, wrapped)
-		return wrapped
 	}
 
 	before, err := c.GetDeployment(ctx, dseq)
@@ -592,37 +586,33 @@ func (c *Client) Deposit(ctx context.Context, dseq string, amountUSD float64) er
 	return unknown
 }
 
-func consoleDepositMicros(amountUSD float64) (*big.Int, error) {
-	amount, ok := new(big.Rat).SetString(strconv.FormatFloat(amountUSD, 'f', -1, 64))
-	if !ok || amount.Sign() <= 0 {
-		return nil, fmt.Errorf("deposit must be a positive finite USD amount, got %v", amountUSD)
-	}
-
-	amount.Mul(amount, big.NewRat(1_000_000, 1))
-	if !amount.IsInt() {
-		return nil, fmt.Errorf("deposit %v USD has precision below one micro-ACT", amountUSD)
-	}
-
-	return new(big.Int).Set(amount.Num()), nil
-}
-
-func validateDepositUSD(amountUSD float64) error {
+func normalizeDepositUSD(amountUSD float64) (*big.Int, error) {
 	if math.IsNaN(amountUSD) || math.IsInf(amountUSD, 0) {
-		return fmt.Errorf("console: deployment deposit must be a finite USD amount")
+		return nil, fmt.Errorf("console: deployment deposit must be a finite USD amount")
 	}
 	if amountUSD < 0 {
-		return fmt.Errorf("console: deployment deposit must not be negative")
+		return nil, fmt.Errorf("console: deployment deposit must not be negative")
 	}
 
 	text := strconv.FormatFloat(amountUSD, 'f', -1, 64)
-	if _, fraction, ok := strings.Cut(text, "."); ok && len(fraction) > 2 {
-		return fmt.Errorf("console: deployment deposit must have at most two fractional digits")
+	whole, fraction, _ := strings.Cut(text, ".")
+	if len(fraction) > 2 {
+		return nil, fmt.Errorf("console: deployment deposit must have at most two fractional digits")
 	}
 	if amountUSD < MinDepositUSD {
-		return fmt.Errorf("console: deployment deposit must be at least $%.2f, got %v", MinDepositUSD, amountUSD)
+		return nil, fmt.Errorf("console: deployment deposit must be at least $%.2f, got %v", MinDepositUSD, amountUSD)
 	}
 
-	return nil
+	microDigits := whole + fraction + strings.Repeat("0", 6-len(fraction))
+	micros := new(big.Int)
+	ten := big.NewInt(10)
+	digitValue := new(big.Int)
+	for _, digit := range microDigits {
+		micros.Mul(micros, ten)
+		micros.Add(micros, digitValue.SetInt64(int64(digit-'0')))
+	}
+
+	return micros, nil
 }
 
 func deploymentEscrowTotals(detail *DeploymentDetail) (map[string]*big.Rat, error) {

--- a/internal/console/mutation_contract_test.go
+++ b/internal/console/mutation_contract_test.go
@@ -98,13 +98,20 @@ func TestValidateDeploymentUpdateResultRejectsHashMismatch(t *testing.T) {
 }
 
 func TestDepositContractHelpers(t *testing.T) {
-	micros, err := consoleDepositMicros(1.25)
-	if err != nil || micros.Cmp(big.NewInt(1_250_000)) != 0 {
-		t.Fatalf("consoleDepositMicros(1.25) = %v, %v", micros, err)
+	for amount, want := range map[float64]int64{
+		0.5:  500_000,
+		1:    1_000_000,
+		1.25: 1_250_000,
+		12.5: 12_500_000,
+	} {
+		micros, err := normalizeDepositUSD(amount)
+		if err != nil || micros.Cmp(big.NewInt(want)) != 0 {
+			t.Errorf("normalizeDepositUSD(%v) = %v, %v, want %d", amount, micros, err, want)
+		}
 	}
 	for _, amount := range []float64{0, -1, 0.0000001} {
-		if _, err := consoleDepositMicros(amount); err == nil {
-			t.Errorf("consoleDepositMicros(%v) unexpectedly succeeded", amount)
+		if _, err := normalizeDepositUSD(amount); err == nil {
+			t.Errorf("normalizeDepositUSD(%v) unexpectedly succeeded", amount)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- validate Console USD deposits and derive their exact micro-ACT reconciliation value in one boundary
- remove the unreachable second conversion-error branch that blocked release-range patch coverage
- document the invariant in SPEC.md and record the fix in AICHANGELOG.md

## Release recovery

The signed v0.1.0 tag remains immutable. Its release workflow stopped before publication because the v0.0.5..v0.1.0 changed-line gate found the now-impossible branch. After this PR merges, the recovery release will use v0.1.1.

## Validation

- GOWORK=off go test ./internal/console -count=1
- GOWORK=off go test ./...
- GOWORK=off go vet ./...
- GOWORK=off golangci-lint run --timeout=10m
- GOWORK=off make akt
- GOWORK=off make test-race-active
- clean unit, offline E2E, and localnet coverage shards
- v0.0.5..WORKTREE active patch coverage: 100% (6107 executable lines, 0 reviewed exceptions)